### PR TITLE
Update parser.go

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -57,7 +57,7 @@ func parserPkg(pkgRealpath, pkgpath string) error {
 	rep := strings.NewReplacer("/", "_", ".", "_")
 	commentFilename = COMMENTFL + rep.Replace(pkgpath) + ".go"
 	if !compareFile(pkgRealpath) {
-		Info(pkgRealpath + " don't has updated")
+		Info(pkgRealpath + " has no updates")
 		return nil
 	}
 	genInfoList = make(map[string][]ControllerComments)


### PR DESCRIPTION
Log message grammar for un-updated packages  is now correct. Another option would be "has not been updated", but that may confuse some people into thinking the command should have updated something but failed to do so. 