### PR TITLE
修复Context的ResponseWriter属性初始化的错误

### DIFF
--- a/router.go
+++ b/router.go
@@ -592,7 +592,7 @@ func (p *ControllerRegistor) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 
 	// init context
 	context := &beecontext.Context{
-		ResponseWriter: w,
+		ResponseWriter: rw,
 		Request:        r,
 		Input:          beecontext.NewInput(r),
 		Output:         beecontext.NewOutput(),


### PR DESCRIPTION
这个属性应该是从ServeHTTP里的rw参数直接获取的http.ResponseWriter类型，而不是私有的reponseWriter强制转换来的。