### PR TITLE
Add buffered output and flush into output context

### DIFF
--- a/context/output.go
+++ b/context/output.go
@@ -49,6 +49,22 @@ func (output *BeegoOutput) Header(key, val string) {
 	output.Context.ResponseWriter.Header().Set(key, val)
 }
 
+// Flush current output buffer to the client
+func (output *BeegoOutput) Flush() {
+	flusher,ok := output.Context.ResponseWriter.(http.Flusher)
+	if ok {
+		flusher.Flush()
+	}
+}
+
+// Write response content into the buffer directly
+func (output *BeegoOutput) Write(content []byte) {
+	output_writer,ok := output.Context.ResponseWriter.(io.Writer)
+	if ok {
+		output_writer.Write(content)
+	}
+}
+
 // Body sets response body content.
 // if EnableGzip, compress content string.
 // it sends out response body directly.


### PR DESCRIPTION
Add buffered output and flush support.
So you can flush content to the client while the application is running.
Like this:
```GO
func (this *MyController) Get() {
	this.Ctx.Output.Header("Content-Type", "text/html; charset=utf-8")

	for i := 1024; i>0; i-- {
		this.Ctx.Output.Write([]byte(" "))
	}

	this.Ctx.Output.Flush()

	for i := 10; i>0; i-- {
		this.Ctx.Output.Write([]byte(fmt.Sprintf("%03d...<br/>\n",i)))
		this.Ctx.Output.Flush()
		time.Sleep(1000*time.Millisecond)
	}
	this.StopRun()
}
```