### PR TITLE
Added support for the JSONAPI header

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -321,6 +321,21 @@ func (c *Controller) ServeJson(encoding ...bool) {
 	c.Ctx.Output.Json(c.Data["json"], hasIndent, hasencoding)
 }
 
+// ServeJsonAPI sends a JSONAPI response with custom encoding charset.
+func (c *Controller) ServeJsonApi(charset string, extensions []string, encoding ...bool) {
+	var hasIndent bool
+	var hasencoding bool
+	if RunMode == "prod" {
+		hasIndent = false
+	} else {
+		hasIndent = true
+	}
+	if len(encoding) > 0 && encoding[0] == true {
+		hasencoding = true
+	}
+	c.Ctx.Output.JsonApi(c.Data["json"], hasIndent, hasencoding, charset, extensions)
+}
+
 // ServeJsonp sends a jsonp response.
 func (c *Controller) ServeJsonp() {
 	var hasIndent bool


### PR DESCRIPTION
The format also supports its own official [extensions](http://jsonapi.org/extensions/#official-extensions) and [custom extensions](http://jsonapi.org/extensions/#custom-extensions)

Created to close the [issue 1040](https://github.com/astaxie/beego/issues/1040) and to support those creating APIs following this [format](http://jsonapi.org)