### PR TITLE
处理bug

### DIFF
--- a/beego.go
+++ b/beego.go
@@ -336,13 +336,13 @@ func initBeforeHttpRun() {
 // this function is for test package init
 func TestBeegoInit(apppath string) {
 	AppPath = apppath
-	RunMode = "test"
 	AppConfigPath = filepath.Join(AppPath, "conf", "app.conf")
 	err := ParseConfig()
 	if err != nil && !os.IsNotExist(err) {
 		// for init if doesn't have app.conf will not panic
 		Info(err)
 	}
+	RunMode = "test"
 	os.Chdir(AppPath)
 	initBeforeHttpRun()
 }

--- a/context/input.go
+++ b/context/input.go
@@ -268,6 +268,9 @@ func (input *BeegoInput) Session(key interface{}) interface{} {
 
 // CopyBody returns the raw request body data as bytes.
 func (input *BeegoInput) CopyBody() []byte {
+	if input.Request.Body == nil {
+		return []byte{}
+	}
 	requestbody, _ := ioutil.ReadAll(input.Request.Body)
 	input.Request.Body.Close()
 	bf := bytes.NewBuffer(requestbody)


### PR DESCRIPTION
1.  #1057 

2. 
这种方式调用 http.NewRequest("DELETE", "/v1/users/123", nil)，会报错，（注意是DELETE请求，body为空时）
原因是 CopyBody() 中 input.Request.Body.Close() 错误 
input.Request.Body为nil

```
        r, _ := http.NewRequest("DELETE", url, nil)    // 这样会报错
        r, _ := http.NewRequest("DELETE", url, bytes.NewBuffer([]byte(``)))  // 得这样写
	r.Header.Set("Content-Type", "application/json")

	w := httptest.NewRecorder()
	beego.BeeApp.Handlers.ServeHTTP(w, r)
```