### PR TITLE
验证码reload问题

### DIFF
--- a/utils/captcha/captcha.go
+++ b/utils/captcha/captcha.go
@@ -132,21 +132,20 @@ func (c *Captcha) Handler(ctx *context.Context) {
 
 	key := c.key(id)
 
-	if v, ok := c.store.Get(key).([]byte); ok {
-		chars = v
-	} else {
-		ctx.Output.SetStatus(404)
-		ctx.WriteString("captcha not found")
-		return
-	}
-
-	// reload captcha
 	if len(ctx.Input.Query("reload")) > 0 {
 		chars = c.genRandChars()
 		if err := c.store.Put(key, chars, c.Expiration); err != nil {
 			ctx.Output.SetStatus(500)
 			ctx.WriteString("captcha reload error")
 			beego.Error("Reload Create Captcha Error:", err)
+			return
+		}
+	} else {
+		if v, ok := c.store.Get(key).([]byte); ok {
+			chars = v
+		} else {
+			ctx.Output.SetStatus(404)
+			ctx.WriteString("captcha not found")
 			return
 		}
 	}


### PR DESCRIPTION
当页面放置一段时间，验证码将从缓存中失效。当用户再来刷新验证码将出现验证码404。对于reload操作应该直接生成验证码。