### PR TITLE
*bugfix) config的default系列方法没有考虑runmode。

### DIFF
--- a/config.go
+++ b/config.go
@@ -150,27 +150,27 @@ func (b *beegoAppConfig) Float(key string) (float64, error) {
 }
 
 func (b *beegoAppConfig) DefaultString(key string, defaultval string) string {
-	return b.innerConfig.DefaultString(key, defaultval)
+	return b.innerConfig.DefaultString(RunMode+"::"+key, defaultval)
 }
 
 func (b *beegoAppConfig) DefaultStrings(key string, defaultval []string) []string {
-	return b.innerConfig.DefaultStrings(key, defaultval)
+	return b.innerConfig.DefaultStrings(RunMode+"::"+key, defaultval)
 }
 
 func (b *beegoAppConfig) DefaultInt(key string, defaultval int) int {
-	return b.innerConfig.DefaultInt(key, defaultval)
+	return b.innerConfig.DefaultInt(RunMode+"::"+key, defaultval)
 }
 
 func (b *beegoAppConfig) DefaultInt64(key string, defaultval int64) int64 {
-	return b.innerConfig.DefaultInt64(key, defaultval)
+	return b.innerConfig.DefaultInt64(RunMode+"::"+key, defaultval)
 }
 
 func (b *beegoAppConfig) DefaultBool(key string, defaultval bool) bool {
-	return b.innerConfig.DefaultBool(key, defaultval)
+	return b.innerConfig.DefaultBool(RunMode+"::"+key, defaultval)
 }
 
 func (b *beegoAppConfig) DefaultFloat(key string, defaultval float64) float64 {
-	return b.innerConfig.DefaultFloat(key, defaultval)
+	return b.innerConfig.DefaultFloat(RunMode+"::"+key, defaultval)
 }
 
 func (b *beegoAppConfig) DIY(key string) (interface{}, error) {


### PR DESCRIPTION
考虑一致性，应该两个接口都加入对runmode的判断。

找了半天bug原来是beego这里。很容易迷惑难查的bug。
