### PR TITLE
Set ErrorsMap to nil in Validation.Clear function

### DIFF
--- a/validation/validation.go
+++ b/validation/validation.go
@@ -107,6 +107,7 @@ type Validation struct {
 // Clean all ValidationError.
 func (v *Validation) Clear() {
 	v.Errors = []*ValidationError{}
+ 	v.ErrorsMap = nil
 }
 
 // Has ValidationError nor not.


### PR DESCRIPTION
A bit misleading that the errors map still hangs around after Validation.Clear