### PR TITLE
form required validate for bool field bugfix

### DIFF
--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -26,6 +26,12 @@ func TestRequired(t *testing.T) {
 	if valid.Required(nil, "nil").Ok {
 		t.Error("nil object should be false")
 	}
+	if !valid.Required(true, "bool").Ok {
+		t.Error("Bool value should always return true")
+	}
+	if !valid.Required(false, "bool").Ok {
+		t.Error("Bool value should always return true")
+	}
 	if valid.Required("", "string").Ok {
 		t.Error("\"'\" string should be false")
 	}

--- a/validation/validators.go
+++ b/validation/validators.go
@@ -64,8 +64,8 @@ func (r Required) IsSatisfied(obj interface{}) bool {
 	if str, ok := obj.(string); ok {
 		return len(str) > 0
 	}
-	if b, ok := obj.(bool); ok {
-		return b
+	if _, ok := obj.(bool); ok {
+		return true
 	}
 	if i, ok := obj.(int); ok {
 		return i != 0


### PR DESCRIPTION
if a form field type is bool, valid Required should always return true instead of return it's field value.

for example:

```
type UserForm struct {
     IsAdmin bool   `form:"is_admin" valid:"Required"`
     ...
}
```
in this case if the frontend guy passes false value to our form. the validation for Required can not passed.