### PR TITLE
*feature) add BeeLogger.GetLogFuncCallDepth make simple wrapper log method aviable.

### DIFF
--- a/logs/log.go
+++ b/logs/log.go
@@ -181,6 +181,11 @@ func (bl *BeeLogger) SetLogFuncCallDepth(d int) {
 	bl.loggerFuncCallDepth = d
 }
 
+// get log funcCallDepth for wrapper
+func (bl *BeeLogger) GetLogFuncCallDepth() int {
+	return bl.loggerFuncCallDepth
+}
+
 // enable log funcCallDepth
 func (bl *BeeLogger) EnableFuncCallDepth(b bool) {
 	bl.enableFuncCallDepth = b


### PR DESCRIPTION
我需要封装beego的logger函数，最终目的是将服务的log跟beego解耦，支持方便接入统一的日志系统，这未来应该还得再需要beego有接口或者我就实现自己的log方法就得了。但现在我先得有简单封装做好接口。

最简单就像这样。
 func Alert(v ...interface{}) {
        beego.BeeLogger.SetLogFuncCallDepth(beego.BeeLogger.GetLogFuncCallDepth() + 1)
        beego.Alert(v...)
        beego.BeeLogger.SetLogFuncCallDepth(beego.BeeLogger.GetLogFuncCallDepth() - 1)
 }

希望官方也采纳，增加个读的方法。