### PR TITLE
remove space after int()& add sort for commentsRouter file

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"sort"
 	"strings"
 
 	"github.com/astaxie/beego/utils"
@@ -36,7 +37,7 @@ import (
 )
 
 func init() {
-	{{.globalinfo}}
+{{.globalinfo}}
 }
 `
 
@@ -129,7 +130,13 @@ func genRouterCode() {
 	os.Mkdir(path.Join(workPath, "routers"), 0755)
 	Info("generate router from comments")
 	var globalinfo string
-	for k, cList := range genInfoList {
+	sortKey := make([]string, 0)
+	for k, _ := range genInfoList {
+		sortKey = append(sortKey, k)
+	}
+	sort.Strings(sortKey)
+	for _, k := range sortKey {
+		cList := genInfoList[k]
 		for _, c := range cList {
 			allmethod := "nil"
 			if len(c.AllowHTTPMethods) > 0 {


### PR DESCRIPTION
when the commentsRouter file auto generated, the go file fmt is not right and the GlobalControllerRouter sequence is random
so i remove the tab after int() { and sort genInfoList key before create file.