### PR TITLE
fix multiple filters execute issue

### DIFF
--- a/router.go
+++ b/router.go
@@ -611,9 +611,6 @@ func (p *ControllerRegistor) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 		if p.enableFilter {
 			if l, ok := p.filters[pos]; ok {
 				for _, filterR := range l {
-					if filterR.returnOnOutput && w.started {
-						return true
-					}
 					if ok, params := filterR.ValidRouter(urlPath); ok {
 						for k, v := range params {
 							context.Input.Params[k] = v


### PR DESCRIPTION
The last filterFunc with returnOnOutput=ture won't be executed.

``` golang
	beego.InsertFilter("/*", beego.BeforeExec, FilterLoginCheck1,false)
	beego.InsertFilter("/*", beego.BeforeExec, FilterLoginCheck2)
```
In function  FilterLoginCheck1 , I'll write data via ResponseWriter, and w.started = true
FilterLoginCheck2 won't be executed, it should be.