### PR TITLE
beego HTTPS tls config support

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -104,8 +104,12 @@ func listConf(rw http.ResponseWriter, r *http.Request) {
 			m["HttpAddr"] = HttpAddr
 			m["HttpPort"] = HttpPort
 			m["HttpTLS"] = EnableHttpTLS
-			m["HttpCertFile"] = HttpCertFile
-			m["HttpKeyFile"] = HttpKeyFile
+			m["HttpsCertFile"] = HttpsCertFile
+			m["HttpsKeyFile"] = HttpsKeyFile
+			m["TLSMinVersion"] = TLSMinVersion
+			m["TLSMaxVersion"] = TLSMaxVersion
+			m["TLSPreferServerCipher"] = TLSPreferServerCipher
+			m["TLSCiphers"] = TLSCiphers
 			m["RecoverPanic"] = RecoverPanic
 			m["AutoRender"] = AutoRender
 			m["ViewsPath"] = ViewsPath

--- a/config.go
+++ b/config.go
@@ -468,11 +468,11 @@ func ParseConfig() (err error) {
 		TLSMaxVersion = maxversion
 	}
 
-	if preferservercipher, err := AppConfig.Bool("TLSMaxVersion"); err == nil {
+	if preferservercipher, err := AppConfig.Bool("TLSPreferServerCipher"); err == nil {
 		TLSPreferServerCipher = preferservercipher
 	}
 
-	if ciphers := AppConfig.Strings("TLSCiphers"); len(ciphers) > 0 {
+	if ciphers := AppConfig.Strings("TLSCiphers"); len(ciphers) > 0 && ciphers[0] != "" {
 		TLSCiphers = ciphers
 	}
 

--- a/config.go
+++ b/config.go
@@ -43,10 +43,14 @@ var (
 	ListenTCP4             bool
 	EnableHttpTLS          bool
 	HttpsPort              int
-	HttpCertFile           string
-	HttpKeyFile            string
-	RecoverPanic           bool // flag of auto recover panic
-	AutoRender             bool // flag of render template automatically
+	HttpsCertFile          string
+	HttpsKeyFile           string
+	TLSMinVersion          string
+	TLSMaxVersion          string
+	TLSPreferServerCipher  bool
+	TLSCiphers             []string //server supported Ciphers
+	RecoverPanic           bool     // flag of auto recover panic
+	AutoRender             bool     // flag of render template automatically
 	ViewsPath              string
 	AppConfig              *beegoAppConfig
 	RunMode                string           // run mode, "dev" or "prod"
@@ -250,6 +254,14 @@ func init() {
 
 	HttpsPort = 10443
 
+	TLSMinVersion = "tls1.0"
+
+	TLSMaxVersion = "tls1.2"
+
+	TLSPreferServerCipher = true
+
+	TLSCiphers = []string{"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-ECDSA-AES128-GCM-SHA256", "ECDHE-RSA-AES128-CBC-SHA", "ECDHE-RSA-AES256-CBC-SHA", "ECDHE-ECDSA-AES256-CBC-SHA", "ECDHE-ECDSA-AES128-CBC-SHA", "RSA-AES128-CBC-SHA", "RSA-AES256-CBC-SHA", "ECDHE-RSA-3DES-EDE-CBC-SHA", "RSA-3DES-EDE-CBC-SHA"}
+
 	AppName = "beego"
 
 	RunMode = "dev" //default runmod
@@ -440,12 +452,28 @@ func ParseConfig() (err error) {
 		HttpsPort = httpsport
 	}
 
-	if certfile := AppConfig.String("HttpCertFile"); certfile != "" {
-		HttpCertFile = certfile
+	if certfile := AppConfig.String("HttpsCertFile"); certfile != "" {
+		HttpsCertFile = certfile
 	}
 
-	if keyfile := AppConfig.String("HttpKeyFile"); keyfile != "" {
-		HttpKeyFile = keyfile
+	if keyfile := AppConfig.String("HttpsKeyFile"); keyfile != "" {
+		HttpsKeyFile = keyfile
+	}
+
+	if minversion := AppConfig.String("TLSMinVersion"); defaultsupportedProtocols[minversion] != 0 {
+		TLSMinVersion = minversion
+	}
+
+	if maxversion := AppConfig.String("TLSMaxVersion"); defaultsupportedProtocols[maxversion] != 0 {
+		TLSMaxVersion = maxversion
+	}
+
+	if preferservercipher, err := AppConfig.Bool("TLSMaxVersion"); err == nil {
+		TLSPreferServerCipher = preferservercipher
+	}
+
+	if ciphers := AppConfig.Strings("TLSCiphers"); len(ciphers) > 0 {
+		TLSCiphers = ciphers
 	}
 
 	if serverName := AppConfig.String("BeegoServerName"); serverName != "" {

--- a/grace/grace.go
+++ b/grace/grace.go
@@ -42,6 +42,7 @@
 package grace
 
 import (
+	"crypto/tls"
 	"flag"
 	"net/http"
 	"os"
@@ -146,5 +147,14 @@ func ListenAndServe(addr string, handler http.Handler) error {
 // refer http.ListenAndServeTLS
 func ListenAndServeTLS(addr string, certFile string, keyFile string, handler http.Handler) error {
 	server := NewServer(addr, handler)
-	return server.ListenAndServeTLS(certFile, keyFile)
+	if server.TLSConfig == nil {
+		server.TLSConfig = &tls.Config{}
+	}
+	var err error
+	server.TLSConfig.Certificates = make([]tls.Certificate, 1)
+	server.TLSConfig.Certificates[0], err = tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return err
+	}
+	return server.ListenAndServeTLS()
 }

--- a/grace/server.go
+++ b/grace/server.go
@@ -83,24 +83,23 @@ func (srv *graceServer) ListenAndServe() (err error) {
 // CA's certificate.
 //
 // If srv.Addr is blank, ":https" is used.
-func (srv *graceServer) ListenAndServeTLS(certFile, keyFile string) (err error) {
+func (srv *graceServer) ListenAndServeTLS() (err error) {
 	addr := srv.Addr
 	if addr == "" {
 		addr = ":https"
 	}
 
 	config := &tls.Config{}
-	if srv.TLSConfig != nil {
-		*config = *srv.TLSConfig
+	if srv.TLSConfig == nil {
+		return fmt.Errorf("Not Configured TLSConfig")
 	}
+	if len(srv.TLSConfig.Certificates) < 1 {
+
+		return fmt.Errorf("SSL certificate information is not configured")
+	}
+	*config = *srv.TLSConfig
 	if config.NextProtos == nil {
 		config.NextProtos = []string{"http/1.1"}
-	}
-
-	config.Certificates = make([]tls.Certificate, 1)
-	config.Certificates[0], err = tls.LoadX509KeyPair(certFile, keyFile)
-	if err != nil {
-		return
 	}
 
 	go srv.handleSignals()

--- a/tls.go
+++ b/tls.go
@@ -1,0 +1,173 @@
+// Copyright 2014 beego Author. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package beego
+
+import (
+	"crypto/tls"
+	"errors"
+	"net"
+	"net/http"
+	"time"
+)
+
+type TLSServer struct {
+	*http.Server
+	Certificate                 tls.Certificate
+	TLSMinVersion               uint16
+	TLSMaxVersion               uint16
+	TLSPreferServerCipherSuites bool
+	TLSCiphers                  []uint16
+}
+
+//Creating TLS configuration information
+func (srv *TLSServer) TLSConfigServer() (err error) {
+	srv.TLSPreferServerCipherSuites = TLSPreferServerCipher
+	srv.TLSMinVersion = defaultsupportedProtocols[TLSMinVersion]
+	srv.TLSMaxVersion = defaultsupportedProtocols[TLSMaxVersion]
+
+	for _, value := range TLSCiphers {
+		srv.TLSCiphers = append(srv.TLSCiphers, supportedCiphersMap[value])
+	}
+	if len(srv.TLSCiphers) < 1 {
+		srv.TLSCiphers = defaultsupportedCiphers
+	}
+
+	if HttpsCertFile != "" && HttpsKeyFile != "" {
+		var err error
+		srv.Certificate, err = tls.LoadX509KeyPair(HttpsCertFile, HttpsKeyFile)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	HttpsCertContent, HttpsKeyContent := AppConfig.String("HttpsCertContent"), AppConfig.String("HttpsKeyContent")
+	srv.Certificate, err = tls.X509KeyPair([]byte(HttpsCertContent), []byte(HttpsKeyContent))
+	if err != nil {
+		return err
+	}
+	srv.TLSConfig = &tls.Config{
+		CipherSuites:             srv.TLSCiphers,
+		PreferServerCipherSuites: srv.TLSPreferServerCipherSuites,
+		MinVersion:               srv.TLSMinVersion,
+		MaxVersion:               srv.TLSMaxVersion,
+	}
+	srv.TLSConfig.Certificates = make([]tls.Certificate, 1)
+	srv.TLSConfig.Certificates[0] = srv.Certificate
+	return nil
+}
+
+// ListenAndServeTLS listens on the TCP network address srv.Addr and
+// then calls Serve to handle requests on incoming TLS connections.
+//
+// Filenames containing a certificate and matching private key for
+// the server must be provided. If the certificate is signed by a
+// certificate authority, the certFile should be the concatenation
+// of the server's certificate followed by the CA's certificate.
+//
+// If srv.Addr is blank, ":https" is used.
+func (srv *TLSServer) ListenAndServeTLS() error {
+	addr := srv.Addr
+	if addr == "" {
+		addr = ":https"
+	}
+
+	config := &tls.Config{}
+	if srv.TLSConfig == nil {
+		return errors.New("Not Configured TLSConfig")
+	}
+	if len(srv.TLSConfig.Certificates) < 1 {
+		return errors.New("SSL certificate information is not configured")
+	}
+	*config = *srv.TLSConfig
+	if config.NextProtos == nil {
+		config.NextProtos = []string{"http/1.1"}
+	}
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+
+	tlsListener := tls.NewListener(tcpKeepAliveListener{ln.(*net.TCPListener)}, config)
+	return srv.Serve(tlsListener)
+}
+
+// tcpKeepAliveListener sets TCP keep-alive timeouts on accepted
+// connections. It's used by ListenAndServe and ListenAndServeTLS so
+// dead TCP connections (e.g. closing laptop mid-download) eventually
+// go away.
+type tcpKeepAliveListener struct {
+	*net.TCPListener
+}
+
+func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
+	tc, err := ln.AcceptTCP()
+	if err != nil {
+		return
+	}
+	tc.SetKeepAlive(true)
+	tc.SetKeepAlivePeriod(3 * time.Minute)
+	return tc, nil
+}
+
+// List of supported cipher suites in descending order of preference.
+// Ordering is very important! Getting the wrong order will break
+// Note that TLS_FALLBACK_SCSV is not in this list since it is always
+// added manually.
+var defaultsupportedCiphers = []uint16{
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+	tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+	tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+	tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+	tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+}
+
+// Map of supported ciphers, used only for parsing config.
+//
+// Note that, at time of writing, HTTP/2 blacklists 276 cipher suites,
+// including all but two of the suites below (the two GCM suites).
+// See https://http2.github.io/http2-spec/#BadCipherSuites
+//
+// TLS_FALLBACK_SCSV is not in this list because we manually ensure
+// it is always added (even though it is not technically a cipher suite).
+//
+// This map, like any map, is NOT ORDERED. Do not range over this map.
+var supportedCiphersMap = map[string]uint16{
+	"ECDHE-RSA-AES128-GCM-SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	"ECDHE-ECDSA-AES128-GCM-SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	"ECDHE-RSA-AES128-CBC-SHA":      tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+	"ECDHE-RSA-AES256-CBC-SHA":      tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+	"ECDHE-ECDSA-AES256-CBC-SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+	"ECDHE-ECDSA-AES128-CBC-SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+	"RSA-AES128-CBC-SHA":            tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+	"RSA-AES256-CBC-SHA":            tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+	"ECDHE-RSA-3DES-EDE-CBC-SHA":    tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+	"RSA-3DES-EDE-CBC-SHA":          tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+}
+
+// Map of supported protocols
+// SSLv3 will be not supported in future release
+// HTTP/2 only supports TLS 1.2 and higher
+var defaultsupportedProtocols = map[string]uint16{
+	"ssl3.0": tls.VersionSSL30,
+	"tls1.0": tls.VersionTLS10,
+	"tls1.1": tls.VersionTLS11,
+	"tls1.2": tls.VersionTLS12,
+}

--- a/tls.go
+++ b/tls.go
@@ -36,26 +36,25 @@ func (srv *TLSServer) TLSConfigServer() (err error) {
 	srv.TLSPreferServerCipherSuites = TLSPreferServerCipher
 	srv.TLSMinVersion = defaultsupportedProtocols[TLSMinVersion]
 	srv.TLSMaxVersion = defaultsupportedProtocols[TLSMaxVersion]
-
 	for _, value := range TLSCiphers {
 		srv.TLSCiphers = append(srv.TLSCiphers, supportedCiphersMap[value])
 	}
+
 	if len(srv.TLSCiphers) < 1 {
 		srv.TLSCiphers = defaultsupportedCiphers
 	}
 
 	if HttpsCertFile != "" && HttpsKeyFile != "" {
-		var err error
 		srv.Certificate, err = tls.LoadX509KeyPair(HttpsCertFile, HttpsKeyFile)
 		if err != nil {
 			return err
 		}
-		return nil
-	}
-	HttpsCertContent, HttpsKeyContent := AppConfig.String("HttpsCertContent"), AppConfig.String("HttpsKeyContent")
-	srv.Certificate, err = tls.X509KeyPair([]byte(HttpsCertContent), []byte(HttpsKeyContent))
-	if err != nil {
-		return err
+	} else {
+		HttpsCertContent, HttpsKeyContent := AppConfig.String("HttpsCertContent"), AppConfig.String("HttpsKeyContent")
+		srv.Certificate, err = tls.X509KeyPair([]byte(HttpsCertContent), []byte(HttpsKeyContent))
+		if err != nil {
+			return err
+		}
 	}
 	srv.TLSConfig = &tls.Config{
 		CipherSuites:             srv.TLSCiphers,
@@ -83,13 +82,13 @@ func (srv *TLSServer) ListenAndServeTLS() error {
 		addr = ":https"
 	}
 
-	config := &tls.Config{}
 	if srv.TLSConfig == nil {
 		return errors.New("Not Configured TLSConfig")
 	}
 	if len(srv.TLSConfig.Certificates) < 1 {
 		return errors.New("SSL certificate information is not configured")
 	}
+	config := &tls.Config{}
 	*config = *srv.TLSConfig
 	if config.NextProtos == nil {
 		config.NextProtos = []string{"http/1.1"}

--- a/tls_test.go
+++ b/tls_test.go
@@ -1,0 +1,121 @@
+// Copyright 2014 beego Author. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package beego
+
+import (
+	"testing"
+
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+)
+
+var TestTLSServer = &TLSServer{Server: &http.Server{}}
+
+var rsaCertPEM = `-----BEGIN CERTIFICATE-----
+MIIB0zCCAX2gAwIBAgIJAI/M7BYjwB+uMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV
+BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
+aWRnaXRzIFB0eSBMdGQwHhcNMTIwOTEyMjE1MjAyWhcNMTUwOTEyMjE1MjAyWjBF
+MQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50
+ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANLJ
+hPHhITqQbPklG3ibCVxwGMRfp/v4XqhfdQHdcVfHap6NQ5Wok/4xIA+ui35/MmNa
+rtNuC+BdZ1tMuVCPFZcCAwEAAaNQME4wHQYDVR0OBBYEFJvKs8RfJaXTH08W+SGv
+zQyKn0H8MB8GA1UdIwQYMBaAFJvKs8RfJaXTH08W+SGvzQyKn0H8MAwGA1UdEwQF
+MAMBAf8wDQYJKoZIhvcNAQEFBQADQQBJlffJHybjDGxRMqaRmDhX0+6v02TUKZsW
+r5QuVbpQhH6u+0UgcW0jp9QwpxoPTLTWGXEWBBBurxFwiCBhkQ+V
+-----END CERTIFICATE-----
+`
+
+var rsaKeyPEM = `-----BEGIN RSA PRIVATE KEY-----
+MIIBOwIBAAJBANLJhPHhITqQbPklG3ibCVxwGMRfp/v4XqhfdQHdcVfHap6NQ5Wo
+k/4xIA+ui35/MmNartNuC+BdZ1tMuVCPFZcCAwEAAQJAEJ2N+zsR0Xn8/Q6twa4G
+6OB1M1WO+k+ztnX/1SvNeWu8D6GImtupLTYgjZcHufykj09jiHmjHx8u8ZZB/o1N
+MQIhAPW+eyZo7ay3lMz1V01WVjNKK9QSn1MJlb06h/LuYv9FAiEA25WPedKgVyCW
+SmUwbPw8fnTcpqDWE3yTO3vKcebqMSsCIBF3UmVue8YU3jybC3NxuXq3wNm34R8T
+xVLHwDXh/6NJAiEAl2oHGGLz64BuAfjKrqwz7qMYr9HCLIe/YsoWq/olzScCIQDi
+D2lWusoe2/nEqfDVVWGWlyJ7yOmqaVm/iNUN9B2N2g==
+-----END RSA PRIVATE KEY-----
+`
+
+func init() {
+	TestTLSServer.TLSMinVersion = defaultsupportedProtocols["ssl3.0"]
+	TestTLSServer.TLSMaxVersion = defaultsupportedProtocols["tls1.2"]
+	TestTLSServer.TLSPreferServerCipherSuites = true
+	TLSCiphers = []string{"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-ECDSA-AES128-GCM-SHA256", "ECDHE-RSA-AES128-CBC-SHA", "ECDHE-RSA-AES256-CBC-SHA", "ECDHE-ECDSA-AES256-CBC-SHA", "ECDHE-ECDSA-AES128-CBC-SHA", "RSA-AES128-CBC-SHA", "RSA-AES256-CBC-SHA", "ECDHE-RSA-3DES-EDE-CBC-SHA", "RSA-3DES-EDE-CBC-SHA"}
+	AppConfig.Set("HttpsCertContent", rsaCertPEM)
+	AppConfig.Set("HttpsKeyContent", rsaKeyPEM)
+}
+
+func TestListenAndServeTLS(t *testing.T) {
+
+	if e := TestTLSServer.TLSConfigServer(); e != nil {
+		t.Errorf("TestListenAndServeTLS Obtain a certificate error")
+	}
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-TLS-Set", "true")
+		if r.TLS.HandshakeComplete {
+			w.Header().Set("X-TLS-HandshakeComplete", "true")
+		}
+	}))
+	ts.TLS = TestTLSServer.Server.TLSConfig
+	ts.StartTLS()
+	defer ts.Close()
+	goTimeout(t, 10*time.Second, func() {
+		if !strings.HasPrefix(ts.URL, "https://") {
+			t.Errorf("expected test TLS server to start with https://, got %q", ts.URL)
+			return
+		}
+		noVerifyTransport := &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		}
+		client := &http.Client{Transport: noVerifyTransport}
+		res, err := client.Get(ts.URL)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if res == nil {
+			t.Errorf("got nil Response")
+			return
+		}
+		defer res.Body.Close()
+		if res.Header.Get("X-TLS-Set") != "true" {
+			t.Errorf("expected X-TLS-Set response header")
+			return
+		}
+		if res.Header.Get("X-TLS-HandshakeComplete") != "true" {
+			t.Errorf("expected X-TLS-HandshakeComplete header")
+		}
+	})
+}
+
+// goTimeout runs f, failing t if f takes more than ns to complete.
+func goTimeout(t *testing.T, d time.Duration, f func()) {
+	ch := make(chan bool, 2)
+	timer := time.AfterFunc(d, func() {
+		t.Errorf("Timeout expired after %v", d)
+		ch <- true
+	})
+	defer timer.Stop()
+	go func() {
+		defer func() { ch <- true }()
+		f()
+	}()
+	<-ch
+}


### PR DESCRIPTION
新增配置选项
1.TLSCiphers 加密组合列表,如果不设置 TLS连接会使用默认的实现支持的密码组合列表
支持 ECDHE-RSA-AES128-GCM-SHA256;ECDHE-ECDSA-AES128-GCM-SHA256;ECDHE-RSA-AES128-CBC-SHA;ECDHE-RSA-AES256-CBC-SHA;ECDHE-ECDSA-AES256-CBC-SHA;ECDHE-ECDSA-AES128-CBC-SHA;RSA-AES128-CBC-SHA;RSA-AES256-CBC-SHA;ECDHE-RSA-3DES-EDE-CBC-SHA;RSA-3DES-EDE-CBC-SHA
2.TLSMinVersion 最底SSL/TLS版本,如果不设置 会将TLS1.0作为最低版本.SSL/TLS支持范围 SSLv3,TLS1.0,TLS1.1,TLS1.2
3.TLSMaxVersion 最高SSL/TLS版本,如果不设置 会将TLS1.2作为最高版本.
4.TLSPreferServerCipher 优先服务端加密组合列表,如果不设置默认为true,服务端是选择客户端最期望的密码组合还是服务端最期望的密码组合

内部调用设置-适用于多webserver,通过传输配置.不需要本地放置key,crt文件
在调用beego.Run()之前设置可以不设置HttpsCertFile,HttpsKeyFile
beego.AppConfig.Set("HttpsCertContent", val)
beego.AppConfig.Set("HttpsKeyContent", val)

修改配置字段
HttpCertFile->HttpsCertFile
HttpKeyFile->HttpsKeyFile

设置例子
HttpsCertFile = /home/domain.crt
HttpsKeyFile = /home/domain.key
设置例子--也是默认参数(小白用户在不进行配置情况下也可获得优化的体验)
TLSCiphers = ECDHE-RSA-AES128-GCM-SHA256;ECDHE-ECDSA-AES128-GCM-SHA256;ECDHE-RSA-AES128-CBC-SHA;ECDHE-RSA-AES256-CBC-SHA;ECDHE-ECDSA-AES256-CBC-SHA;ECDHE-ECDSA-AES128-CBC-SHA;RSA-AES128-CBC-SHA;RSA-AES256-CBC-SHA;ECDHE-RSA-3DES-EDE-CBC-SHA;RSA-3DES-EDE-CBC-SHA
TLSMinVersion = tls1.0
TLSMaxVersion = tls1.2
TLSPreferServerCipher = true

支持思路
遵循beego配置文件理念
先通过读取配置文件.run后通过TLSConfigServer进行TSL配置转换tls.Config{}
App.Server = http.Server
匿名字段修改成TLSServer
复写http.server.ListenAndServeTLS()

修改Graceful ListenAndServeTLS
在ListenAndServeTLS 进行tls.Config{}配置
然后调用 Graceful的srv.ListenAndServeTLS()

在ListenAndServeTLS里不对tls.config{}进行处理  给上层更自由的管理
这样再进行增加tls配置
直接修改上层tls.go即可