### PR TITLE
fix example/chat i/o timeout

### DIFF
--- a/example/chat/controllers/ws.go
+++ b/example/chat/controllers/ws.go
@@ -54,14 +54,13 @@ func (c *connection) readPump() {
 	}()
 	c.ws.SetReadLimit(maxMessageSize)
 	c.ws.SetReadDeadline(time.Now().Add(readWait))
+	c.ws.SetPongHandler(func(string) error { c.ws.SetReadDeadline(time.Now().Add(readWait)); return nil })
 	for {
 		op, r, err := c.ws.NextReader()
 		if err != nil {
 			break
 		}
 		switch op {
-		case websocket.PongMessage:
-			c.ws.SetReadDeadline(time.Now().Add(readWait))
 		case websocket.TextMessage:
 			message, err := ioutil.ReadAll(r)
 			if err != nil {


### PR DESCRIPTION
// NextReader returns the next data message received from the peer. The
// returned messageType is either TextMessage or BinaryMessage.
func (c *Conn) NextReader() (messageType int, r io.Reader, err error) 

so, readPump() will 100% cause i/o timeout
