### PR TITLE
Fix #1269 extract godoc to own file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![Build Status](https://drone.io/github.com/astaxie/beego/status.png)](https://drone.io/github.com/astaxie/beego/latest)
 [![GoDoc](http://godoc.org/github.com/astaxie/beego?status.svg)](http://godoc.org/github.com/astaxie/beego)
 
-beego is an open-source, high-performance, modular, full-stack web framework.
+beego is used for rapid development of RESTful APIs, web apps and backend services in Go.
+It is inspired by Tornado, Sinatra and Flask. beego has some Go-specific features such as interfaces and struct embedding.
 
 More info [beego.me](http://beego.me)
 

--- a/beego.go
+++ b/beego.go
@@ -12,17 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// beego is an open-source, high-performance, modular, full-stack web framework
-//
-// 		package main
-//
-// 		import "github.com/astaxie/beego"
-//
-// 		func main() {
-//  			beego.Run()
-// 		}
-//
-// more infomation: http://beego.me
 package beego
 
 import (

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,17 @@
+/*
+beego: an open-source, high-performance, modular, full-stack web framework
+
+It is used for rapid development of RESTful APIs, web apps and backend services in Go.
+beego is inspired by Tornado, Sinatra and Flask with the added benefit of some Go-specific features such as interfaces and struct embedding.
+
+	package main
+	import "github.com/astaxie/beego"
+
+	func main() {
+	 beego.Run()
+	}
+
+more infomation: http://beego.me
+*/
+package beego
+


### PR DESCRIPTION
Fix #1269 extract docs from `beego.go` to `doc.go`
Fix #1271 Add description from docs on beego.me to README
and  `doc.go`