### PR TITLE
add miss error

### DIFF
--- a/session/mysql/sess_mysql.go
+++ b/session/mysql/sess_mysql.go
@@ -147,6 +147,8 @@ func (mp *MysqlProvider) SessionRead(sid string) (session.SessionStore, error) {
 	if err == sql.ErrNoRows {
 		c.Exec("insert into session(`session_key`,`session_data`,`session_expiry`) values(?,?,?)",
 			sid, "", time.Now().Unix())
+	} else if err != nil {
+		return nil, err
 	}
 	var kv map[interface{}]interface{}
 	if len(sessiondata) == 0 {


### PR DESCRIPTION
当配置链接出现错误时，连接MySQL出错时，应该向外提高错误信息，而不是丢弃