### PR TITLE
Update error.go

### DIFF
--- a/error.go
+++ b/error.go
@@ -453,7 +453,6 @@ func exception(errcode string, ctx *context.Context) {
 
 func executeError(err *errorInfo, ctx *context.Context, code int) {
 	if err.errorType == errorTypeHandler {
-		ctx.ResponseWriter.WriteHeader(code)
 		err.handler(ctx.ResponseWriter, ctx.Request)
 		return
 	}


### PR DESCRIPTION
this caused `http: multiple response.WriteHeader calls` when using method `CustomAbort` or `Abort` when status is already in errMap like 404.(and in method CustomAbort, it already have  c.Ctx.ResponseWriter.WriteHeader(status))