### PR TITLE
always use server's locale to parse date

### DIFF
--- a/templatefunc.go
+++ b/templatefunc.go
@@ -352,7 +352,7 @@ func ParseForm(form url.Values, obj interface{}) error {
 				if len(tags) > 1 {
 					format = tags[1]
 				}
-				t, err := time.Parse(format, value)
+				t, err := time.ParseInLocation(format, value, time.Local)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
When parsing the date without time, it's always using UTC date, which is
unexpected. suppose we get '2015-09-02' from page, it's always parsed as '2015-09-02 00:00:00 UTC' but by default, what we expect is '2015-09-02 00:00:00' at local time zone.

And If we want to use UTC date throughout the system, it's recommend to set all
server's timezone as UTC including DB.