### PR TITLE
为ORM中的querySeter增加group by操作

### DIFF
--- a/orm/db.go
+++ b/orm/db.go
@@ -802,6 +802,7 @@ func (d *dbBase) ReadBatch(q dbQuerier, qs *querySet, mi *modelInfo, cond *Condi
 	tables.parseRelated(qs.related, qs.relDepth)
 
 	where, args := tables.getCondSql(cond, false, tz)
+	groupBy := tables.getGroupSql(qs.groups)
 	orderBy := tables.getOrderSql(qs.orders)
 	limit := tables.getLimitSql(mi, offset, rlimit)
 	join := tables.getJoinSql()
@@ -814,7 +815,7 @@ func (d *dbBase) ReadBatch(q dbQuerier, qs *querySet, mi *modelInfo, cond *Condi
 		}
 	}
 
-	query := fmt.Sprintf("SELECT %s FROM %s%s%s T0 %s%s%s%s", sels, Q, mi.table, Q, join, where, orderBy, limit)
+	query := fmt.Sprintf("SELECT %s FROM %s%s%s T0 %s%s%s%s%s", sels, Q, mi.table, Q, join, where, groupBy, orderBy, limit)
 
 	d.ins.ReplaceMarks(&query)
 
@@ -1444,13 +1445,14 @@ func (d *dbBase) ReadValues(q dbQuerier, qs *querySet, mi *modelInfo, cond *Cond
 	}
 
 	where, args := tables.getCondSql(cond, false, tz)
+	groupBy := tables.getGroupSql(qs.groups)
 	orderBy := tables.getOrderSql(qs.orders)
 	limit := tables.getLimitSql(mi, qs.offset, qs.limit)
 	join := tables.getJoinSql()
 
 	sels := strings.Join(cols, ", ")
 
-	query := fmt.Sprintf("SELECT %s FROM %s%s%s T0 %s%s%s%s", sels, Q, mi.table, Q, join, where, orderBy, limit)
+	query := fmt.Sprintf("SELECT %s FROM %s%s%s T0 %s%s%s%s", sels, Q, mi.table, Q, join, where, groupBy, orderBy, limit)
 
 	d.ins.ReplaceMarks(&query)
 

--- a/orm/db_tables.go
+++ b/orm/db_tables.go
@@ -390,6 +390,30 @@ func (t *dbTables) getCondSql(cond *Condition, sub bool, tz *time.Location) (whe
 	return
 }
 
+// generate group sql.
+func (t *dbTables) getGroupSql(groups []string) (groupSql string) {
+	if len(groups)  == 0 {
+		return
+	}
+
+	Q := t.base.TableQuote()
+
+	groupSqls := make([]string, 0, len(groups))
+	for _, group := range groups {
+		exprs := strings.Split(group, ExprSep)
+
+		index, _, fi, suc := t.parseExprs(t.mi, exprs)
+		if suc == false {
+			panic(fmt.Errorf("unknown field/column name `%s`", strings.Join(exprs, ExprSep)))
+		}
+
+		groupSqls = append(groupSqls, fmt.Sprintf("%s.%s%s%s", index, Q, fi.column, Q))
+	}
+
+	groupSql = fmt.Sprintf("GROUP BY %s ", strings.Join(groupSqls, ", "))
+	return
+}
+
 // generate order sql.
 func (t *dbTables) getOrderSql(orders []string) (orderSql string) {
 	if len(orders) == 0 {

--- a/orm/orm_queryset.go
+++ b/orm/orm_queryset.go
@@ -61,6 +61,7 @@ type querySet struct {
 	limit    int64
 	offset   int64
 	orders   []string
+	groups   []string
 	orm      *orm
 }
 
@@ -109,6 +110,12 @@ func (o querySet) Offset(offset interface{}) QuerySeter {
 // "column" means ASC, "-column" means DESC.
 func (o querySet) OrderBy(exprs ...string) QuerySeter {
 	o.orders = exprs
+	return &o
+}
+
+// add GROUP expression
+func (o querySet) GroupBy(exprs ...string) QuerySeter {
+	o.groups = exprs
 	return &o
 }
 

--- a/orm/types.go
+++ b/orm/types.go
@@ -66,6 +66,7 @@ type QuerySeter interface {
 	SetCond(*Condition) QuerySeter
 	Limit(interface{}, ...interface{}) QuerySeter
 	Offset(interface{}) QuerySeter
+	GroupBy(...string) QuerySeter
 	OrderBy(...string) QuerySeter
 	RelatedSel(...interface{}) QuerySeter
 	Count() (int64, error)


### PR DESCRIPTION
orm中的querySerter缺少常用的group by操作的封装，因此添加了GroupBy方法