### PR TITLE
orm: Fix handling of rel(fk) to model with string pk

### DIFF
--- a/orm/cmd_utils.go
+++ b/orm/cmd_utils.go
@@ -45,13 +45,14 @@ func getDbDropSQL(al *alias) (sqls []string) {
 func getColumnTyp(al *alias, fi *fieldInfo) (col string) {
 	T := al.DbBaser.DbTypes()
 	fieldType := fi.fieldType
+	fieldSize := fi.size
 
 checkColumn:
 	switch fieldType {
 	case TypeBooleanField:
 		col = T["bool"]
 	case TypeCharField:
-		col = fmt.Sprintf(T["string"], fi.size)
+		col = fmt.Sprintf(T["string"], fieldSize)
 	case TypeTextField:
 		col = T["string-text"]
 	case TypeDateField:
@@ -89,6 +90,7 @@ checkColumn:
 		}
 	case RelForeignKey, RelOneToOne:
 		fieldType = fi.relModelInfo.fields.pk.fieldType
+		fieldSize = fi.relModelInfo.fields.pk.size
 		goto checkColumn
 	}
 


### PR DESCRIPTION
When using e.g. rel(fk) to a model with a pk of type string(32), it would result in trying to genereate field as varchar(0) in db, which obviously wouldn't work.

This PR fixes the issue by also taking the size of the modelinfo of the related models pk into account.