### PR TITLE
Fix dbBase.Update not returning error on failure

### DIFF
--- a/orm/db.go
+++ b/orm/db.go
@@ -488,7 +488,8 @@ func (d *dbBase) Update(q dbQuerier, mi *modelInfo, ind reflect.Value, tz *time.
 
 	d.ins.ReplaceMarks(&query)
 
-	if res, err := q.Exec(query, setValues...); err == nil {
+	res, err := q.Exec(query, setValues...)
+	if err == nil {
 		return res.RowsAffected()
 	}
 	return 0, err


### PR DESCRIPTION
I discovered that when doing an update that failed (in my case a unique constraint failing), the Update method would return (0, nil) instead of (0, actualErrorInstance).

This PR fixes this.

The issue was that the err was captured in a scoped err variable inside the if, and thus when getting to the point of returning from the function it would use the outer err var which was nil.