### PR TITLE
Remove Unnecessary c.Ctx.ResponseWriter.WriteHeader(status)

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -278,7 +278,6 @@ func (c *Controller) Abort(code string) {
 
 // CustomAbort stops controller handler and show the error data, it's similar Aborts, but support status code and body.
 func (c *Controller) CustomAbort(status int, body string) {
-	c.Ctx.ResponseWriter.WriteHeader(status)
 	// first panic from ErrorMaps, is is user defined error functions.
 	if _, ok := ErrorMaps[body]; ok {
 		panic(body)


### PR DESCRIPTION
The following error is thrown with this line in place: 

`http: multiple response.WriteHeader calls`