### PR TITLE
XsrfFormHtml should also generate XSRF token

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -640,8 +640,8 @@ func (c *Controller) CheckXsrfCookie() bool {
 
 // XsrfFormHtml writes an input field contains xsrf token value.
 func (c *Controller) XsrfFormHtml() string {
-	return "<input type=\"hidden\" name=\"_xsrf\" value=\"" +
-		c._xsrf_token + "\"/>"
+	return `<input type="hidden" name="_xsrf" value="` +
+		c.XsrfToken() + `" />`
 }
 
 // GetControllerAndAction gets the executing controller name and action name.


### PR DESCRIPTION
I did not receive any comment on [my issue](/astaxie/beego/issues/1397), so I decided to make a pull request instead. It is very, very strange that you have to initialize `_xsrf_token` field by calling `XsrfToken()` function before calling `XsrfFormHtml()`.