### PR TITLE
Update context.go

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -54,7 +54,6 @@ func (ctx *Context) Redirect(status int, localurl string) {
 // Abort stops this request.
 // if beego.ErrorMaps exists, panic body.
 func (ctx *Context) Abort(status int, body string) {
-	ctx.ResponseWriter.WriteHeader(status)
 	panic(body)
 }
 


### PR DESCRIPTION
all error status is handled by error.go, this line will cause multi-resp