### PR TITLE
fix postgres syntax error during migration

### DIFF
--- a/migration/migration.go
+++ b/migration/migration.go
@@ -101,12 +101,10 @@ func (m *Migration) Exec(name, status string) error {
 }
 
 func (m *Migration) addOrUpdateRecord(name, status string) error {
-	var err error
-	var p orm.RawPreparer
 	o := orm.NewOrm()
 	if status == "down" {
 		status = "rollback"
-		p, err = o.Raw("update migrations set status = ?, rollback_statements = ?, created_at = ? where name = ?").Prepare()
+		p, err := o.Raw("update migrations set status = ?, rollback_statements = ?, created_at = ? where name = ?").Prepare()
 		if err != nil {
 			return nil
 		}
@@ -114,7 +112,7 @@ func (m *Migration) addOrUpdateRecord(name, status string) error {
 		return err
 	}
 	status = "update"
-	p, err = o.Raw("insert into migrations(name, created_at, statements, status) values(?,?,?,?)").Prepare()
+	p, err := o.Raw("insert into migrations(name, created_at, statements, status) values(?,?,?,?)").Prepare()
 	if err != nil {
 		return err
 	}

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -106,12 +106,7 @@ func (m *Migration) addOrUpdateRecord(name, status string) error {
 	o := orm.NewOrm()
 	if status == "down" {
 		status = "rollback"
-		switch o.Driver().Type() {
-		case orm.DRPostgres:
-			p, err = o.Raw("update migrations set status = ?, rollback_statements = ?, created_at = ? where name = ?").Prepare()
-		default: // MySQL
-			p, err = o.Raw("update migrations set `status` = ?, `rollback_statements` = ?, `created_at` = ? where name = ?").Prepare()
-		}
+		p, err = o.Raw("update migrations set status = ?, rollback_statements = ?, created_at = ? where name = ?").Prepare()
 		if err != nil {
 			return nil
 		}
@@ -119,12 +114,7 @@ func (m *Migration) addOrUpdateRecord(name, status string) error {
 		return err
 	}
 	status = "update"
-	switch o.Driver().Type() {
-	case orm.DRPostgres:
-		p, err = o.Raw("insert into migrations(name, created_at, statements, status) values(?,?,?,?)").Prepare()
-	default: // MySQL
-		p, err = o.Raw("insert into migrations(`name`, `created_at`, `statements`, `status`) values(?,?,?,?)").Prepare()
-	}
+	p, err = o.Raw("insert into migrations(name, created_at, statements, status) values(?,?,?,?)").Prepare()
 	if err != nil {
 		return err
 	}

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -101,10 +101,17 @@ func (m *Migration) Exec(name, status string) error {
 }
 
 func (m *Migration) addOrUpdateRecord(name, status string) error {
+	var err error
+	var p orm.RawPreparer
 	o := orm.NewOrm()
 	if status == "down" {
 		status = "rollback"
-		p, err := o.Raw("update migrations set `status` = ?, `rollback_statements` = ?, `created_at` = ? where name = ?").Prepare()
+		switch o.Driver().Type() {
+		case orm.DRPostgres:
+			p, err = o.Raw("update migrations set status = ?, rollback_statements = ?, created_at = ? where name = ?").Prepare()
+		default: // MySQL
+			p, err = o.Raw("update migrations set `status` = ?, `rollback_statements` = ?, `created_at` = ? where name = ?").Prepare()
+		}
 		if err != nil {
 			return nil
 		}
@@ -112,7 +119,12 @@ func (m *Migration) addOrUpdateRecord(name, status string) error {
 		return err
 	}
 	status = "update"
-	p, err := o.Raw("insert into migrations(`name`, `created_at`, `statements`, `status`) values(?,?,?,?)").Prepare()
+	switch o.Driver().Type() {
+	case orm.DRPostgres:
+		p, err = o.Raw("insert into migrations(name, created_at, statements, status) values(?,?,?,?)").Prepare()
+	default: // MySQL
+		p, err = o.Raw("insert into migrations(`name`, `created_at`, `statements`, `status`) values(?,?,?,?)").Prepare()
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
when doing migration using bee tool and postgresql as database postgresql return the following error:

```
pq: syntax error at or near "`"
```
This patch fix this error