### PR TITLE
Log config parsing errors

### DIFF
--- a/config.go
+++ b/config.go
@@ -354,10 +354,12 @@ func init() {
 	SetLogFuncCall(true)
 
 	err = ParseConfig()
-	if err != nil && os.IsNotExist(err) {
-		// for init if doesn't have app.conf will not panic
-		ac := config.NewFakeConfig()
-		AppConfig = &beegoAppConfig{ac}
+	if err != nil {
+		if os.IsNotExist(err) {
+			// for init if doesn't have app.conf will not panic
+			ac := config.NewFakeConfig()
+			AppConfig = &beegoAppConfig{ac}
+		}
 		Warning(err)
 	}
 }


### PR DESCRIPTION
Beego currently handles the case of "conf/app.conf"
not existing, but all other errors are not logged.
This fixes that.

I ran into an issue where beego was not listening on the
correct port, and it turned out that the conf/app.conf file
had a colon ":" instead of an equal sign "=" (confusion of
INI vs YAML formats).  When there was a parsing error, beego
would give up on parsing app.conf and not log anything to the
console.