### PR TITLE
Added MaxMemory limit to CopyBody()

### DIFF
--- a/context/input.go
+++ b/context/input.go
@@ -17,6 +17,7 @@ package context
 import (
 	"bytes"
 	"errors"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -291,8 +292,9 @@ func (input *BeegoInput) Session(key interface{}) interface{} {
 }
 
 // CopyBody returns the raw request body data as bytes.
-func (input *BeegoInput) CopyBody() []byte {
-	requestbody, _ := ioutil.ReadAll(input.Request.Body)
+func (input *BeegoInput) CopyBody(MaxMemory int64) []byte {
+	safe := &io.LimitedReader{R: input.Request.Body, N: MaxMemory}
+	requestbody, _ := ioutil.ReadAll(safe)
 	input.Request.Body.Close()
 	bf := bytes.NewBuffer(requestbody)
 	input.Request.Body = ioutil.NopCloser(bf)

--- a/router.go
+++ b/router.go
@@ -617,7 +617,7 @@ func (p *ControllerRegistor) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 					if ok, params := filterR.ValidRouter(urlPath); ok {
 						for k, v := range params {
 							if context.Input.Params == nil {
-								context.Input.Params = make(map[string]string)	
+								context.Input.Params = make(map[string]string)
 							}
 							context.Input.Params[k] = v
 						}
@@ -665,7 +665,7 @@ func (p *ControllerRegistor) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 
 	if r.Method != "GET" && r.Method != "HEAD" {
 		if CopyRequestBody && !context.Input.IsUpload() {
-			context.Input.CopyBody()
+			context.Input.CopyBody(MaxMemory)
 		}
 		context.Input.ParseFormOrMulitForm(MaxMemory)
 	}


### PR DESCRIPTION
Beego only uses the MaxMemory flag when using go's built in functions
for parsing forms. However the CopyBody() function have no limit an will
coppy anny amount of data into memory using ioutil.ReedAll() on the
request body whitout anny size validation or limit.

This fix wrapps input.Requst.Body in a LimitedReader using the same
memory limit as ParseFormOrMulitForm()