### PR TITLE
Added MaxMemory limit to CopyBody() Supersedes #1484

### DIFF
--- a/context/input.go
+++ b/context/input.go
@@ -17,6 +17,7 @@ package context
 import (
 	"bytes"
 	"errors"
+	"io"
 	"io/ioutil"
 	"net/url"
 	"reflect"
@@ -296,8 +297,9 @@ func (input *BeegoInput) Session(key interface{}) interface{} {
 }
 
 // CopyBody returns the raw request body data as bytes.
-func (input *BeegoInput) CopyBody() []byte {
-	requestbody, _ := ioutil.ReadAll(input.Context.Request.Body)
+func (input *BeegoInput) CopyBody(MaxMemory int64) []byte {
+	safe := &io.LimitedReader{R:input.Context.Request.Body, N:MaxMemory}
+	requestbody, _ := ioutil.ReadAll(safe)
 	input.Context.Request.Body.Close()
 	bf := bytes.NewBuffer(requestbody)
 	input.Context.Request.Body = ioutil.NopCloser(bf)

--- a/router.go
+++ b/router.go
@@ -659,7 +659,7 @@ func (p *ControllerRegister) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 
 	if r.Method != "GET" && r.Method != "HEAD" {
 		if BConfig.CopyRequestBody && !context.Input.IsUpload() {
-			context.Input.CopyBody()
+			context.Input.CopyBody(BConfig.MaxMemory)
 		}
 		context.Input.ParseFormOrMulitForm(BConfig.MaxMemory)
 	}


### PR DESCRIPTION
Beego only uses the MaxMemory flag when using go's built in functions
for parsing forms. However the CopyBody() function have no limit an will
coppy anny amount of data into memory using ioutil.ReedAll() on the
request body whitout anny size validation or limit.

This fix wrapps input.Requst.Body in a LimitedReader using the same
memory limit as ParseFormOrMulitForm()