### PR TITLE
Fix joins for reverse(many) with custom pk

### DIFF
--- a/orm/db_tables.go
+++ b/orm/db_tables.go
@@ -186,7 +186,7 @@ func (t *dbTables) getJoinSQL() (join string) {
 		table = jt.mi.table
 
 		switch {
-		case jt.fi.fieldType == RelManyToMany || jt.fi.reverse && jt.fi.reverseFieldInfo.fieldType == RelManyToMany:
+		case jt.fi.fieldType == RelManyToMany || jt.fi.fieldType == RelReverseMany || jt.fi.reverse && jt.fi.reverseFieldInfo.fieldType == RelManyToMany:
 			c1 = jt.fi.mi.fields.pk.column
 			for _, ffi := range jt.mi.fields.fieldsRel {
 				if jt.fi.mi == ffi.relModelInfo {

--- a/orm/models_test.go
+++ b/orm/models_test.go
@@ -332,6 +332,24 @@ func NewComment() *Comment {
 	return obj
 }
 
+type Group struct {
+	GID         string `orm:"pk;column(gid);size(32);unique"`
+	Name        string
+	Permissions []*Permission `orm:"reverse(many)" json:"-"`
+}
+
+type Permission struct {
+	ID     int `orm:"column(id)"`
+	Name   string
+	Groups []*Group `orm:"rel(m2m);rel_through(github.com/astaxie/beego/orm.GroupPermissions)"`
+}
+
+type GroupPermissions struct {
+	ID         int         `orm:"column(id)"`
+	Group      *Group      `orm:"rel(fk)"`
+	Permission *Permission `orm:"rel(fk)"`
+}
+
 var DBARGS = struct {
 	Driver string
 	Source string


### PR DESCRIPTION
Fix issue for reverse many relations with inner join being made on id column even if model specifies custom pk name.

Also includes test covering this.