### PR TITLE
cors test benchmark doesn't use b.N

### DIFF
--- a/plugins/cors/cors_test.go
+++ b/plugins/cors/cors_test.go
@@ -225,8 +225,8 @@ func Benchmark_WithoutCORS(b *testing.B) {
 		ctx.Output.SetStatus(500)
 	})
 	b.ResetTimer()
-	for i := 0; i < 100; i++ {
-		r, _ := http.NewRequest("PUT", "/foo", nil)
+	r, _ := http.NewRequest("PUT", "/foo", nil)
+	for i := 0; i < b.N; i++ {
 		handler.ServeHTTP(recorder, r)
 	}
 }
@@ -246,8 +246,8 @@ func Benchmark_WithCORS(b *testing.B) {
 		ctx.Output.SetStatus(500)
 	})
 	b.ResetTimer()
-	for i := 0; i < 100; i++ {
-		r, _ := http.NewRequest("PUT", "/foo", nil)
+	r, _ := http.NewRequest("PUT", "/foo", nil)
+	for i := 0; i < b.N; i++ {
 		handler.ServeHTTP(recorder, r)
 	}
 }


### PR DESCRIPTION
这个函数没有调用b.N,按照我的理解,把NewRequest移出循环似乎更合理一些.
个人建议