### PR TITLE
Retrieve session identifier from cookie and query parameters

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -133,63 +133,65 @@ func NewManager(provideName, config string) (*Manager, error) {
 	}, nil
 }
 
+// getSid retrieves session identifier from HTTP Request.
+// First try to retrieve id by reading from cookie, session cookie name is configurable,
+// if not exist, then retrieve id from querying parameters.
+//
+// error is not nil when there is anything wrong.
+// sid is empty when need to generate a new session id
+// otherwise return an valid session id.
+func (manager *Manager) getSid(r *http.Request) (string, error) {
+	cookie, errs := r.Cookie(manager.config.CookieName)
+	if errs != nil || cookie.Value == "" {
+		errs := r.ParseForm()
+		if errs != nil {
+			return "", errs
+		}
+
+		sid := r.FormValue(manager.config.CookieName)
+		return sid, nil
+	}
+
+	// HTTP Request contains cookie for sessionid info.
+	return url.QueryUnescape(cookie.Value)
+}
+
 // Start session. generate or read the session id from http request.
 // if session id exists, return SessionStore with this id.
 func (manager *Manager) SessionStart(w http.ResponseWriter, r *http.Request) (session SessionStore, err error) {
-	cookie, errs := r.Cookie(manager.config.CookieName)
-	if errs != nil || cookie.Value == "" {
-		sid, errs := manager.sessionId(r)
-		if errs != nil {
-			return nil, errs
-		}
-		session, err = manager.provider.SessionRead(sid)
-		cookie = &http.Cookie{
-			Name:     manager.config.CookieName,
-			Value:    url.QueryEscape(sid),
-			Path:     "/",
-			HttpOnly: true,
-			Secure:   manager.isSecure(r),
-			Domain:   manager.config.Domain,
-		}
-		if manager.config.CookieLifeTime > 0 {
-			cookie.MaxAge = manager.config.CookieLifeTime
-			cookie.Expires = time.Now().Add(time.Duration(manager.config.CookieLifeTime) * time.Second)
-		}
-		if manager.config.EnableSetCookie {
-			http.SetCookie(w, cookie)
-		}
-		r.AddCookie(cookie)
-	} else {
-		sid, errs := url.QueryUnescape(cookie.Value)
-		if errs != nil {
-			return nil, errs
-		}
-		if manager.provider.SessionExist(sid) {
-			session, err = manager.provider.SessionRead(sid)
-		} else {
-			sid, err = manager.sessionId(r)
-			if err != nil {
-				return nil, err
-			}
-			session, err = manager.provider.SessionRead(sid)
-			cookie = &http.Cookie{
-				Name:     manager.config.CookieName,
-				Value:    url.QueryEscape(sid),
-				Path:     "/",
-				HttpOnly: true,
-				Secure:   manager.isSecure(r),
-				Domain:   manager.config.Domain,
-			}
-			if manager.config.CookieLifeTime > 0 {
-				cookie.MaxAge = manager.config.CookieLifeTime
-				cookie.Expires = time.Now().Add(time.Duration(manager.config.CookieLifeTime) * time.Second)
-			}
-			if manager.config.EnableSetCookie {
-				http.SetCookie(w, cookie)
-			}
-			r.AddCookie(cookie)
-		}
+	sid, errs := manager.getSid(r)
+	if errs != nil {
+		return nil, errs
 	}
+
+	if sid != "" && manager.provider.SessionExist(sid) {
+		return manager.provider.SessionRead(sid)
+	}
+
+	// Generate a new session
+	sid, errs = manager.sessionId(r)
+	if errs != nil {
+		return nil, errs
+	}
+
+	session, err = manager.provider.SessionRead(sid)
+	cookie := &http.Cookie{
+		Name:     manager.config.CookieName,
+		Value:    url.QueryEscape(sid),
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   manager.isSecure(r),
+		Domain:   manager.config.Domain,
+	}
+	if manager.config.CookieLifeTime > 0 {
+		cookie.MaxAge = manager.config.CookieLifeTime
+		cookie.Expires = time.Now().Add(time.Duration(manager.config.CookieLifeTime) * time.Second)
+	}
+	if manager.config.EnableSetCookie {
+		http.SetCookie(w, cookie)
+	}
+	r.AddCookie(cookie)
+
 	return
 }
 


### PR DESCRIPTION
Currently beego only retrieve session identifier from cookie in HTTP request.

This pull request try to retrieve session identifier from URL query parameters if could not find from cookie.

Thus following request will works:

CURL -X GET http://example.com/api/resource?gosessionid=<SESSIONID>

Session identifier is configurable.