### PR TITLE
给 BeegoOutput 添加 Content 变量

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,6 +33,7 @@ type BeegoConfig struct {
 	RecoverPanic        bool
 	CopyRequestBody     bool
 	EnableGzip          bool
+	EnableStoreContent  bool
 	MaxMemory           int64
 	EnableErrorsShow    bool
 	Listen              Listen
@@ -117,6 +118,7 @@ func init() {
 		RecoverPanic:        true,
 		CopyRequestBody:     false,
 		EnableGzip:          false,
+		EnableStoreContent:  false,
 		MaxMemory:           1 << 26, //64MB
 		EnableErrorsShow:    true,
 		Listen: Listen{
@@ -197,6 +199,7 @@ func ParseConfig() (err error) {
 	BConfig.RouterCaseSensitive = AppConfig.DefaultBool("RouterCaseSensitive", BConfig.RouterCaseSensitive)
 	BConfig.ServerName = AppConfig.DefaultString("BeegoServerName", BConfig.ServerName)
 	BConfig.EnableGzip = AppConfig.DefaultBool("EnableGzip", BConfig.EnableGzip)
+	BConfig.EnableStoreContent = AppConfig.DefaultBool("EnableStoreContent", BConfig.EnableStoreContent)
 	BConfig.EnableErrorsShow = AppConfig.DefaultBool("EnableErrorsShow", BConfig.EnableErrorsShow)
 	BConfig.CopyRequestBody = AppConfig.DefaultBool("CopyRequestBody", BConfig.CopyRequestBody)
 	BConfig.MaxMemory = AppConfig.DefaultInt64("MaxMemory", BConfig.MaxMemory)

--- a/context/output.go
+++ b/context/output.go
@@ -32,6 +32,7 @@ import (
 
 // BeegoOutput does work for sending response header.
 type BeegoOutput struct {
+	Content []byte
 	Context    *Context
 	Status     int
 	EnableGzip bool
@@ -58,6 +59,7 @@ func (output *BeegoOutput) Header(key, val string) {
 // if EnableGzip, compress content string.
 // it sends out response body directly.
 func (output *BeegoOutput) Body(content []byte) {
+	output.Content = content
 	var encoding string
 	var buf = &bytes.Buffer{}
 	if output.EnableGzip {

--- a/context/output.go
+++ b/context/output.go
@@ -32,10 +32,11 @@ import (
 
 // BeegoOutput does work for sending response header.
 type BeegoOutput struct {
-	Content []byte
-	Context    *Context
-	Status     int
-	EnableGzip bool
+	Content            []byte
+	Context            *Context
+	Status             int
+	EnableGzip         bool
+	EnableStoreContent bool
 }
 
 // NewOutput returns new BeegoOutput.
@@ -57,9 +58,12 @@ func (output *BeegoOutput) Header(key, val string) {
 
 // Body sets response body content.
 // if EnableGzip, compress content string.
+// if EnableStoreContent, store content for middleware use.
 // it sends out response body directly.
 func (output *BeegoOutput) Body(content []byte) {
-	output.Content = content
+	if output.EnableStoreContent == true {
+		output.Content = content
+	}
 	var encoding string
 	var buf = &bytes.Buffer{}
 	if output.EnableGzip {


### PR DESCRIPTION
在 AfterExec 中需要对之前的 ResponseWriter 的 body 内容进行读取并加工时，原来没有变量存储用户输入的body内容，无法读取，添加content变量方便后续的中间件进行判断处理。