### PR TITLE
log file name bug fixed

### DIFF
--- a/logs/console.go
+++ b/logs/console.go
@@ -35,14 +35,14 @@ func newBrush(color string) brush {
 }
 
 var colors = []brush{
-	newBrush("1;37"), // Emergency	white
-	newBrush("1;36"), // Alert			cyan
-	newBrush("1;35"), // Critical   magenta
-	newBrush("1;31"), // Error      red
-	newBrush("1;33"), // Warning    yellow
-	newBrush("1;32"), // Notice			green
+	newBrush("1;37"), // Emergency		white
+	newBrush("1;36"), // Alert		cyan
+	newBrush("1;35"), // Critical   	magenta
+	newBrush("1;31"), // Error      	red
+	newBrush("1;33"), // Warning    	yellow
+	newBrush("1;32"), // Notice		green
 	newBrush("1;34"), // Informational	blue
-	newBrush("1;34"), // Debug      blue
+	newBrush("1;34"), // Debug      	blue
 }
 
 // consoleWriter implements LoggerInterface and writes messages to terminal.
@@ -61,12 +61,12 @@ func NewConsole() Logger {
 }
 
 // Init init console logger.
-// jsonconfig like '{"level":LevelTrace}'.
-func (c *consoleWriter) Init(jsonconfig string) error {
-	if len(jsonconfig) == 0 {
+// jsonConfig like '{"level":LevelTrace}'.
+func (c *consoleWriter) Init(jsonConfig string) error {
+	if len(jsonConfig) == 0 {
 		return nil
 	}
-	return json.Unmarshal([]byte(jsonconfig), c)
+	return json.Unmarshal([]byte(jsonConfig), c)
 }
 
 // WriteMsg write message in console.
@@ -75,7 +75,7 @@ func (c *consoleWriter) WriteMsg(when time.Time, msg string, level int) error {
 		return nil
 	}
 	msg = formatLogTime(when) + msg
-	if goos := runtime.GOOS; goos == "windows" {
+	if runtime.GOOS == "windows" {
 		c.lg.Println(msg)
 		return nil
 	}

--- a/logs/console.go
+++ b/logs/console.go
@@ -35,14 +35,14 @@ func newBrush(color string) brush {
 }
 
 var colors = []brush{
-	newBrush("1;37"), // Emergency		white
-	newBrush("1;36"), // Alert		cyan
-	newBrush("1;35"), // Critical   	magenta
-	newBrush("1;31"), // Error      	red
-	newBrush("1;33"), // Warning    	yellow
-	newBrush("1;32"), // Notice		green
-	newBrush("1;34"), // Informational	blue
-	newBrush("1;34"), // Debug      	blue
+	newBrush("1;37"), // Emergency          white
+	newBrush("1;36"), // Alert              cyan
+	newBrush("1;35"), // Critical           magenta
+	newBrush("1;31"), // Error              red
+	newBrush("1;33"), // Warning            yellow
+	newBrush("1;32"), // Notice             green
+	newBrush("1;34"), // Informational      blue
+	newBrush("1;34"), // Debug              blue
 }
 
 // consoleWriter implements LoggerInterface and writes messages to terminal.

--- a/logs/file.go
+++ b/logs/file.go
@@ -118,19 +118,16 @@ func (w *fileLogWriter) WriteMsg(when time.Time, msg string, level int) error {
 	if level > w.Level {
 		return nil
 	}
-	//2016/01/12 21:34:33
-	// now := time.Now()
-	d := when.Day()
 	msg = formatLogTime(when) + msg + "\n"
 
 	if w.Rotate {
+		d := when.Day()
 		if w.needRotate(len(msg), d) {
 			w.Lock()
 			if w.needRotate(len(msg), d) {
 				if err := w.doRotate(when); err != nil {
 					fmt.Fprintf(os.Stderr, "FileLogWriter(%q): %s\n", w.Filename, err)
 				}
-
 			}
 			w.Unlock()
 		}

--- a/logs/file.go
+++ b/logs/file.go
@@ -127,7 +127,7 @@ func (w *fileLogWriter) WriteMsg(when time.Time, msg string, level int) error {
 		if w.needRotate(len(msg), d) {
 			w.Lock()
 			if w.needRotate(len(msg), d) {
-				if err := w.doRotate(); err != nil {
+				if err := w.doRotate(when); err != nil {
 					fmt.Fprintf(os.Stderr, "FileLogWriter(%q): %s\n", w.Filename, err)
 				}
 
@@ -200,7 +200,7 @@ func (w *fileLogWriter) lines() (int, error) {
 
 // DoRotate means it need to write file in new file.
 // new file name like xx.2013-01-01.2.log
-func (w *fileLogWriter) doRotate() error {
+func (w *fileLogWriter) doRotate(logTime time.Time) error {
 	_, err := os.Lstat(w.Filename)
 	if err != nil {
 		return err
@@ -215,7 +215,7 @@ func (w *fileLogWriter) doRotate() error {
 		suffix = ".log"
 	}
 	for ; err == nil && num <= 999; num++ {
-		fName = filenameOnly + fmt.Sprintf(".%s.%03d%s", time.Now().Format("2006-01-02"), num, suffix)
+		fName = filenameOnly + fmt.Sprintf(".%s.%03d%s", logTime.Format("2006-01-02"), num, suffix)
 		_, err = os.Lstat(fName)
 	}
 	// return error if the last file checked still existed


### PR DESCRIPTION
this bug happens when daily rotate. ex,when it is 2016-01-22 23:59:59 and need a rotate,the file name should named with 2016-01-22 but named with 2016-01-23(next day)
![image](https://cloud.githubusercontent.com/assets/707691/12570079/9682b9ea-c40f-11e5-8bbc-92ebd68088e3.png)
