### PR TITLE
add Config.Load func

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -88,7 +88,7 @@ func listConf(rw http.ResponseWriter, r *http.Request) {
 
 	data := make(map[interface{}]interface{})
 	switch command {
-	case "conf":
+	case confDir:
 		m := make(map[string]interface{})
 		m["AppConfigPath"] = AppConfigPath
 		m["AppConfigProvider"] = AppConfigProvider

--- a/beego.go
+++ b/beego.go
@@ -101,7 +101,7 @@ func initBeforeHTTPRun() {
 // TestBeegoInit is for test package init
 func TestBeegoInit(ap string) {
 	os.Setenv("BEEGO_RUNMODE", "test")
-	AppConfigPath = filepath.Join(ap, "conf", "app.conf")
+	AppConfigPath = filepath.Join(ap, confDir, "app.conf")
 	os.Chdir(ap)
 	initBeforeHTTPRun()
 }

--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@
 package beego
 
 import (
+	"errors"
 	"html/template"
 	"os"
 	"path/filepath"
@@ -24,6 +25,8 @@ import (
 	"github.com/astaxie/beego/session"
 	"github.com/astaxie/beego/utils"
 )
+
+const confDir = "conf"
 
 // Config is the main struct for BConfig
 type Config struct {
@@ -39,6 +42,37 @@ type Config struct {
 	Listen              Listen
 	WebConfig           WebConfig
 	Log                 LogConfig
+
+	configFileMap map[string]config.Configer
+}
+
+// Load return Configer
+// you can load the specific config file by run mode
+func (c *Config) Load(configFile string) (cf config.Configer, err error) {
+
+	if c, ok := c.configFileMap[configFile]; ok {
+		cf = c
+		return
+	}
+
+	fullPathFile := filepath.Join(confDir, c.RunMode, configFile)
+
+	if !utils.FileExists(fullPathFile) {
+		fullPathFile = filepath.Join(confDir, configFile)
+		if !utils.FileExists(fullPathFile) {
+			err = errors.New(fullPathFile + " not found")
+			return
+		}
+	}
+
+	adapter := filepath.Ext(fullPathFile)
+
+	cf, err = config.NewConfig(adapter, fullPathFile)
+	if err != nil {
+		c.configFileMap[configFile] = cf
+	}
+
+	return
 }
 
 // Listen holds for http and https related config
@@ -189,7 +223,7 @@ func init() {
 func ParseConfig() (err error) {
 	if AppConfigPath == "" {
 		// initialize default configurations
-		AppConfigPath = filepath.Join(AppPath, "conf", "app.conf")
+		AppConfigPath = filepath.Join(AppPath, confDir, "app.conf")
 		if !utils.FileExists(AppConfigPath) {
 			AppConfig = &beegoAppConfig{config.NewFakeConfig()}
 			return

--- a/config.go
+++ b/config.go
@@ -43,20 +43,17 @@ type Config struct {
 	WebConfig           WebConfig
 	Log                 LogConfig
 
-	configFileMap map[string]config.Configer
+	configFiles map[string]config.Configer
 }
 
 // Load return Configer
 // you can load the specific config file by run mode
 func (c *Config) Load(configFile string) (cf config.Configer, err error) {
-
-	if c, ok := c.configFileMap[configFile]; ok {
+	if c, ok := c.configFiles[configFile]; ok {
 		cf = c
 		return
 	}
-
 	fullPathFile := filepath.Join(confDir, c.RunMode, configFile)
-
 	if !utils.FileExists(fullPathFile) {
 		fullPathFile = filepath.Join(confDir, configFile)
 		if !utils.FileExists(fullPathFile) {
@@ -64,14 +61,11 @@ func (c *Config) Load(configFile string) (cf config.Configer, err error) {
 			return
 		}
 	}
-
-	adapter := filepath.Ext(fullPathFile)
-
+	adapter := strings.TrimLeft(filepath.Ext(fullPathFile), ".")
 	cf, err = config.NewConfig(adapter, fullPathFile)
 	if err != nil {
-		c.configFileMap[configFile] = cf
+		c.configFiles[configFile] = cf
 	}
-
 	return
 }
 


### PR DESCRIPTION
Add new feature for beego. 

you can load specific config file by run mode, just as below

cf, err := beego.BConfig.Load("auth.json")

It will load conf/dev/auth.json if you run in dev mode, or load conf/prod/auth.json in prod mode.

If can not find the file in above dir, it will load conf/auth.json.