### PR TITLE
Fix regression caused by commit ad65479

### DIFF
--- a/plugins/cors/cors.go
+++ b/plugins/cors/cors.go
@@ -36,6 +36,7 @@
 package cors
 
 import (
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -215,6 +216,7 @@ func Allow(opts *Options) beego.FilterFunc {
 			for key, value := range headers {
 				ctx.Output.Header(key, value)
 			}
+			ctx.ResponseWriter.WriteHeader(http.StatusOK)
 			return
 		}
 		headers = opts.Header(origin)


### PR DESCRIPTION
Commit ad6547936e will cause "Method Not Allow" in preflight response
when enable CORS plugin.

The root cause is that CORS plugin didn't generate http output after applied
commit ad6547936e, so the value of `ctx.ResponseWriter.Started` will be keep
`false`, and then later filter chains will be go on to run when CORS filter
finished.

This path will both fix "Method Not Allow" and the original bug
"multiple response.WriteHeader calls".

Signed-off-by: Yunkai Zhang <qiushu.zyk@taobao.com>