### PR TITLE
Config logic

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -90,8 +90,8 @@ func listConf(rw http.ResponseWriter, r *http.Request) {
 	switch command {
 	case "conf":
 		m := make(map[string]interface{})
-		m["AppConfigPath"] = AppConfigPath
-		m["AppConfigProvider"] = AppConfigProvider
+		m["AppConfigPath"] = appConfigPath
+		m["AppConfigProvider"] = appConfigProvider
 		m["BConfig.AppName"] = BConfig.AppName
 		m["BConfig.RunMode"] = BConfig.RunMode
 		m["BConfig.RouterCaseSensitive"] = BConfig.RouterCaseSensitive

--- a/beego.go
+++ b/beego.go
@@ -85,7 +85,7 @@ func initBeforeHTTPRun() {
 // TestBeegoInit is for test package init
 func TestBeegoInit(ap string) {
 	os.Setenv("BEEGO_RUNMODE", "test")
-	AppConfigPath = filepath.Join(ap, "conf", "app.conf")
+	appConfigPath = filepath.Join(ap, "conf", "app.conf")
 	os.Chdir(ap)
 	initBeforeHTTPRun()
 }

--- a/beego.go
+++ b/beego.go
@@ -15,7 +15,6 @@
 package beego
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -76,15 +75,6 @@ func initBeforeHTTPRun() {
 	}
 	*/
 	var err error
-	//init log
-	for adaptor, config := range BConfig.Log.Outputs {
-		err = BeeLogger.SetLogger(adaptor, config)
-		if err != nil {
-			fmt.Printf("%s with the config `%s` got err:%s\n", adaptor, config, err)
-		}
-	}
-
-	SetLogFuncCall(BConfig.Log.FileLineNum)
 
 	//init hooks
 	AddAPPStartHook(registerMime)
@@ -95,7 +85,7 @@ func initBeforeHTTPRun() {
 	AddAPPStartHook(registerAdmin)
 
 	for _, hk := range hooks {
-		if err := hk(); err != nil {
+		if err = hk(); err != nil {
 			panic(err)
 		}
 	}

--- a/beego.go
+++ b/beego.go
@@ -67,15 +67,6 @@ func Run(params ...string) {
 }
 
 func initBeforeHTTPRun() {
-	// if AppConfigPath is setted or conf/app.conf exist
-	/*
-	err := ParseConfig()
-	if err != nil {
-		panic(err)
-	}
-	*/
-	var err error
-
 	//init hooks
 	AddAPPStartHook(registerMime)
 	AddAPPStartHook(registerDefaultErrorHandler)
@@ -85,7 +76,7 @@ func initBeforeHTTPRun() {
 	AddAPPStartHook(registerAdmin)
 
 	for _, hk := range hooks {
-		if err = hk(); err != nil {
+		if err := hk(); err != nil {
 			panic(err)
 		}
 	}

--- a/beego.go
+++ b/beego.go
@@ -69,10 +69,13 @@ func Run(params ...string) {
 
 func initBeforeHTTPRun() {
 	// if AppConfigPath is setted or conf/app.conf exist
+	/*
 	err := ParseConfig()
 	if err != nil {
 		panic(err)
 	}
+	*/
+	var err error
 	//init log
 	for adaptor, config := range BConfig.Log.Outputs {
 		err = BeeLogger.SetLogger(adaptor, config)

--- a/config.go
+++ b/config.go
@@ -124,6 +124,10 @@ func init() {
 	workPath, _ = os.Getwd()
 	workPath, _ = filepath.Abs(workPath)
 
+	if workPath != AppPath {
+		os.Chdir(AppPath)
+	}
+
 	BConfig = &Config{
 		AppName:             "beego",
 		RunMode:             DEV,
@@ -195,10 +199,6 @@ func init() {
 
 // now only support ini, next will support json.
 func parseConfig(appConfigPath string) (err error) {
-	if workPath != AppPath {
-		os.Chdir(AppPath)
-	}
-
 	AppConfig, err = newAppConfig(AppConfigProvider, appConfigPath)
 	if err != nil {
 		return err

--- a/config.go
+++ b/config.go
@@ -312,7 +312,7 @@ func parseConfig(appConfigPath string) (err error) {
 }
 
 // LoadAppConfig allow developer to apply a config file
-func LoadAppConfig(configPath string, adapterName string) error {
+func LoadAppConfig(adapterName string, configPath string) error {
 	absConfigPath, err := filepath.Abs(configPath)
 	if err != nil {
 		return err

--- a/config.go
+++ b/config.go
@@ -106,16 +106,16 @@ var (
 	AppConfig *beegoAppConfig
 	// AppPath is the absolute path to the app
 	AppPath string
-	// AppConfigPath is the path to the config files
-	AppConfigPath string
-	// AppConfigProvider is the provider for the config, default is ini
-	AppConfigProvider = "ini"
 	// TemplateCache stores template caching
 	TemplateCache map[string]*template.Template
 	// GlobalSessions is the instance for the session manager
 	GlobalSessions *session.Manager
 
 	workPath string
+	// appConfigPath is the path to the config files
+	appConfigPath string
+	// appConfigProvider is the provider for the config, default is ini
+	appConfigProvider = "ini"
 )
 
 func init() {
@@ -187,18 +187,18 @@ func init() {
 		},
 	}
 
-	AppConfigPath = filepath.Join(AppPath, "conf", "app.conf")
-	if !utils.FileExists(AppConfigPath) {
+	appConfigPath = filepath.Join(AppPath, "conf", "app.conf")
+	if !utils.FileExists(appConfigPath) {
 		AppConfig = &beegoAppConfig{config.NewFakeConfig()}
 		return
 	}
 
-	parseConfig(AppConfigPath)
+	parseConfig(appConfigPath)
 }
 
 // now only support ini, next will support json.
 func parseConfig(appConfigPath string) (err error) {
-	AppConfig, err = newAppConfig(AppConfigProvider, appConfigPath)
+	AppConfig, err = newAppConfig(appConfigProvider, appConfigPath)
 	if err != nil {
 		return err
 	}
@@ -312,7 +312,7 @@ func parseConfig(appConfigPath string) (err error) {
 }
 
 // LoadAppConfig allow developer to apply a config file
-func LoadAppConfig(adapterName string, configPath string) error {
+func LoadAppConfig(adapterName, configPath string) error {
 	absConfigPath, err := filepath.Abs(configPath)
 	if err != nil {
 		return err
@@ -322,22 +322,22 @@ func LoadAppConfig(adapterName string, configPath string) error {
 		return fmt.Errorf("the target config file: %s don't exist!", configPath)
 	}
 
-	if absConfigPath == AppConfigPath {
+	if absConfigPath == appConfigPath {
 		return nil
 	}
 
-	AppConfigPath = absConfigPath
-	AppConfigProvider = adapterName
+	appConfigPath = absConfigPath
+	appConfigProvider = adapterName
 
-	return parseConfig(AppConfigPath)
+	return parseConfig(appConfigPath)
 }
 
 type beegoAppConfig struct {
 	innerConfig config.Configer
 }
 
-func newAppConfig(AppConfigProvider, AppConfigPath string) (*beegoAppConfig, error) {
-	ac, err := config.NewConfig(AppConfigProvider, AppConfigPath)
+func newAppConfig(appConfigProvider, appConfigPath string) (*beegoAppConfig, error) {
+	ac, err := config.NewConfig(appConfigProvider, appConfigPath)
 	if err != nil {
 		return nil, err
 	}

--- a/config.go
+++ b/config.go
@@ -20,7 +20,6 @@ import (
 	"path/filepath"
 	"strings"
 	"fmt"
-	"errors"
 
 	"github.com/astaxie/beego/config"
 	"github.com/astaxie/beego/session"
@@ -320,7 +319,7 @@ func LoadAppConfig(configPath string, adapterName string) error {
 	}
 
 	if !utils.FileExists(absConfigPath) {
-		return errors.New(fmt.Sprintf("the target config file: %s don't exist!", configPath))
+		return fmt.Errorf("the target config file: %s don't exist!", configPath)
 	}
 
 	if absConfigPath == AppConfigPath {

--- a/config.go
+++ b/config.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"strings"
 	"fmt"
+	"errors"
 
 	"github.com/astaxie/beego/config"
 	"github.com/astaxie/beego/session"
@@ -313,6 +314,11 @@ func LoadAppConfig(configPath string, adapterName string) error {
 	if err != nil {
 		return err
 	}
+
+	if !utils.FileExists(absConfigPath) {
+		return errors.New(fmt.Sprintf("the target config file: %s don't exist!", configPath))
+	}
+
 	if absConfigPath == AppConfigPath {
 		return nil
 	}

--- a/config.go
+++ b/config.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"fmt"
 
 	"github.com/astaxie/beego/config"
 	"github.com/astaxie/beego/session"
@@ -103,14 +104,15 @@ var (
 	BConfig *Config
 	// AppConfig is the instance of Config, store the config information from file
 	AppConfig *beegoAppConfig
-	// AppConfigPath is the path to the config files
-	AppConfigPath string
-	// AppConfigProvider is the provider for the config, default is ini
-	AppConfigProvider = "ini"
 	// TemplateCache stores template caching
 	TemplateCache map[string]*template.Template
 	// GlobalSessions is the instance for the session manager
 	GlobalSessions *session.Manager
+
+	// AppConfigPath is the path to the config files
+	AppConfigPath string
+	// AppConfigProvider is the provider for the config, default is ini
+	AppConfigProvider = "ini"
 )
 
 func init() {
@@ -173,22 +175,26 @@ func init() {
 			Outputs:     map[string]string{"console": ""},
 		},
 	}
-	ParseConfig()
+
+	AppConfigPath = getDefaultAppConfigPath()
+
+	if !utils.FileExists(AppConfigPath) {
+		AppConfig = &beegoAppConfig{config.NewFakeConfig()}
+		return
+	}
+
+	parseConfig(AppConfigPath)
 }
 
-// ParseConfig parsed default config file.
+func getDefaultAppConfigPath() string {
+	// default config path
+	AppPath, _ := filepath.Abs(filepath.Dir(os.Args[0]))
+	return filepath.Join(AppPath, "conf", "app.conf")
+}
+
 // now only support ini, next will support json.
-func ParseConfig() (err error) {
-	if AppConfigPath == "" {
-		// initialize default configurations
-		AppPath, _ := filepath.Abs(filepath.Dir(os.Args[0]))
-		AppConfigPath = filepath.Join(AppPath, "conf", "app.conf")
-		if !utils.FileExists(AppConfigPath) {
-			AppConfig = &beegoAppConfig{config.NewFakeConfig()}
-			return
-		}
-	}
-	AppConfig, err = newAppConfig(AppConfigProvider, AppConfigPath)
+func parseConfig(appConfigPath string) (err error) {
+	AppConfig, err = newAppConfig(AppConfigProvider, appConfigPath)
 	if err != nil {
 		return err
 	}
@@ -242,6 +248,8 @@ func ParseConfig() (err error) {
 	BConfig.WebConfig.Session.SessionCookieLifeTime = AppConfig.DefaultInt("SessionCookieLifeTime", BConfig.WebConfig.Session.SessionCookieLifeTime)
 	BConfig.WebConfig.Session.SessionAutoSetCookie = AppConfig.DefaultBool("SessionAutoSetCookie", BConfig.WebConfig.Session.SessionAutoSetCookie)
 	BConfig.WebConfig.Session.SessionDomain = AppConfig.DefaultString("SessionDomain", BConfig.WebConfig.Session.SessionDomain)
+	BConfig.Log.AccessLogs = AppConfig.DefaultBool("LogAccessLogs", BConfig.Log.AccessLogs)
+	BConfig.Log.FileLineNum = AppConfig.DefaultBool("LogFileLineNum", BConfig.Log.FileLineNum)
 
 	if sd := AppConfig.String("StaticDir"); sd != "" {
 		for k := range BConfig.WebConfig.StaticDir {
@@ -274,7 +282,45 @@ func ParseConfig() (err error) {
 			BConfig.WebConfig.StaticExtensionsToGzip = fileExts
 		}
 	}
+
+	if lo := AppConfig.String("LogOutputs"); lo != "" {
+		los := strings.Split(lo, ";")
+		for _, v := range los {
+			if logType2Config := strings.SplitN(v, ",", 2); len(logType2Config) == 2 {
+				BConfig.Log.Outputs[logType2Config[0]] = logType2Config[1]
+			} else {
+				continue
+			}
+		}
+	}
+
+	//init log
+	BeeLogger.Close()
+	for adaptor, config := range BConfig.Log.Outputs {
+		err = BeeLogger.SetLogger(adaptor, config)
+		if err != nil {
+			fmt.Printf("%s with the config `%s` got err:%s\n", adaptor, config, err)
+		}
+	}
+	SetLogFuncCall(BConfig.Log.FileLineNum)
+
 	return nil
+}
+
+// LoadAppConfig allow developer to apply a config file
+func LoadAppConfig(configPath string, adapterName string) error {
+	absConfigPath, err := filepath.Abs(configPath)
+	if err != nil {
+		return err
+	}
+	if absConfigPath == AppConfigPath {
+		return nil
+	}
+
+	AppConfigPath = absConfigPath
+	AppConfigProvider = adapterName
+
+	return parseConfig(AppConfigPath)
 }
 
 type beegoAppConfig struct {

--- a/logs/log.go
+++ b/logs/log.go
@@ -361,4 +361,5 @@ func (bl *BeeLogger) Close() {
 		l.Flush()
 		l.Destroy()
 	}
+	bl.outputs = nil
 }

--- a/staticfile_test.go
+++ b/staticfile_test.go
@@ -8,9 +8,11 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"path/filepath"
 )
 
-const licenseFile = "./LICENSE"
+var currentWorkDir, _ = os.Getwd()
+var licenseFile = filepath.Join(currentWorkDir, "LICENSE")
 
 func testOpenFile(encoding string, content []byte, t *testing.T) {
 	fi, _ := os.Stat(licenseFile)


### PR DESCRIPTION
try to fix issue #1597 issue #1601 

Make a little adjustment to the logic of config module：

- Add `beego.LoadAppConfig`：it will parse config file immediately when called
- No more to automatically parse config file in `initBeforeHTTPRun`
- `beego.LoadAppConfig` will call `parseConfig`, the last part of `parseConfig` will try to init log writers again