### PR TITLE
Support get environment variables in config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -119,11 +119,42 @@ func Getenv(env interface{}) (string, bool) {
 
 	// Onley support string key.
 	if key, ok := env.(string); ok {
+
 		if envKey := strings.TrimPrefix(key, envKeySign); envKey != key {
 			return os.Getenv(envKey), true
 		}
 	}
 	return "", false
+}
+
+// ConvertToStringMap convert interface to string config value only for map[string]interface{} config info.
+func ConvertToStringMap(m map[string]interface{}) map[string]string {
+	items := make(map[string]string, len(m))
+	if m == nil || len(m) == 0 {
+		return items
+	}
+
+	var s string
+	for k, v := range m {
+		s = ""
+		if v == nil {
+			s = ""
+		} else if str, ok := v.(string); ok {
+			s = str
+		} else if m, ok := v.(map[string]interface{}); ok {
+			s = fmt.Sprintf("%+v", ConvertToStringMap(m))
+		} else {
+			s = fmt.Sprintf("%+v", v)
+		}
+
+		if len(s) > 0 {
+			if env, ok := Getenv(s); ok {
+				s = env
+			}
+		}
+		items[k] = s
+	}
+	return items
 }
 
 // ParseBool returns the boolean value represented by the string.

--- a/config/config.go
+++ b/config/config.go
@@ -119,9 +119,8 @@ func Getenv(env interface{}) (string, bool) {
 
 	// Onley support string key.
 	if key, ok := env.(string); ok {
-		if len(key) > len(envKeySign) && strings.HasPrefix(key, envKeySign) {
-			key = strings.TrimLeft(key, envKeySign)
-			return os.Getenv(key), true
+		if envKey := strings.TrimPrefix(key, envKeySign); envKey != key {
+			return os.Getenv(envKey), true
 		}
 	}
 	return "", false

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,8 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"strings"
 )
 
 // Configer defines how to get and set value from configuration raw data.
@@ -105,6 +107,24 @@ func NewConfigData(adapterName string, data []byte) (Configer, error) {
 		return nil, fmt.Errorf("config: unknown adaptername %q (forgotten import?)", adapterName)
 	}
 	return adapter.ParseData(data)
+}
+
+const envKeySign = "$ENV_"
+
+// Getenv return environment variable if env has prefix "$ENV_".
+func Getenv(env interface{}) (string, bool) {
+	if env == nil {
+		return "", false
+	}
+
+	// Onley support string key.
+	if key, ok := env.(string); ok {
+		if len(key) > len(envKeySign) && strings.HasPrefix(key, envKeySign) {
+			key = strings.TrimLeft(key, envKeySign)
+			return os.Getenv(key), true
+		}
+	}
+	return "", false
 }
 
 // ParseBool returns the boolean value represented by the string.

--- a/config/config.go
+++ b/config/config.go
@@ -132,7 +132,7 @@ func ChooseRealValueForMap(m map[string]interface{}) map[string]interface{} {
 //
 // It accept value formats "$$env" , "$$env||" , "$$env||defaultValue" , "defaultvalue".
 // Examples:
-//	v1 := config.ChooseRealValue("$$GOROOT")			// return the GOROOT environment variable.
+//	v1 := config.ChooseRealValue("$$GOPATH")			// return the GOPATH environment variable.
 //	v2 := config.ChooseRealValue("$$GOAsta||/usr/local/go/")	// return the default value "/usr/local/go/".
 //	v3 := config.ChooseRealValue("Astaxie")				// return the value "Astaxie".
 func ChooseRealValue(value string) (realValue string) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,55 @@
+// Copyright 2016 beego Author. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestExpandValueEnv(t *testing.T) {
+
+	testCases := []struct {
+		item string
+		want string
+	}{
+		{"", ""},
+		{"$", "$"},
+		{"{", "{"},
+		{"{}", "{}"},
+		{"${}", ""},
+		{"${|}", ""},
+		{"${}", ""},
+		{"${{}}", ""},
+		{"${{||}}", "}"},
+		{"${pwd||}", ""},
+		{"${pwd||}", ""},
+		{"${pwd||}", ""},
+		{"${pwd||}}", "}"},
+		{"${pwd||{{||}}}", "{{||}}"},
+		{"${GOPATH}", os.Getenv("GOPATH")},
+		{"${GOPATH||}", os.Getenv("GOPATH")},
+		{"${GOPATH||root}", os.Getenv("GOPATH")},
+		{"${GOPATH_NOT||root}", "root"},
+		{"${GOPATH_NOT||||root}", "||root"},
+	}
+
+	for _, c := range testCases {
+		if got := ExpandValueEnv(c.item); got != c.want {
+			t.Errorf("expand value error, item %q want %q, got %q", c.item, c.want, got)
+		}
+	}
+
+}

--- a/config/fake.go
+++ b/config/fake.go
@@ -25,15 +25,7 @@ type fakeConfigContainer struct {
 }
 
 func (c *fakeConfigContainer) getData(key string) string {
-	if len(key) == 0 {
-		return ""
-	}
-
-	v := c.data[strings.ToLower(key)]
-	if env, ok := Getenv(v); ok {
-		return env
-	}
-	return v
+	return c.data[strings.ToLower(key)]
 }
 
 func (c *fakeConfigContainer) Set(key, val string) error {

--- a/config/fake.go
+++ b/config/fake.go
@@ -25,7 +25,15 @@ type fakeConfigContainer struct {
 }
 
 func (c *fakeConfigContainer) getData(key string) string {
-	return c.data[strings.ToLower(key)]
+	if len(key) == 0 {
+		return ""
+	}
+
+	v := c.data[strings.ToLower(key)]
+	if env, ok := Getenv(v); ok {
+		return env
+	}
+	return v
 }
 
 func (c *fakeConfigContainer) Set(key, val string) error {
@@ -38,7 +46,7 @@ func (c *fakeConfigContainer) String(key string) string {
 }
 
 func (c *fakeConfigContainer) DefaultString(key string, defaultval string) string {
-	v := c.getData(key)
+	v := c.String(key)
 	if v == "" {
 		return defaultval
 	}
@@ -46,7 +54,7 @@ func (c *fakeConfigContainer) DefaultString(key string, defaultval string) strin
 }
 
 func (c *fakeConfigContainer) Strings(key string) []string {
-	return strings.Split(c.getData(key), ";")
+	return strings.Split(c.String(key), ";")
 }
 
 func (c *fakeConfigContainer) DefaultStrings(key string, defaultval []string) []string {

--- a/config/ini.go
+++ b/config/ini.go
@@ -166,7 +166,7 @@ func (ini *IniConfig) parseFile(name string) (*IniConfigContainer, error) {
 			val = bytes.Trim(val, `"`)
 		}
 
-		cfg.data[section][key] = ChooseRealValue(string(val))
+		cfg.data[section][key] = ExpandValueEnv(string(val))
 		if comment.Len() > 0 {
 			cfg.keyComment[section+"."+key] = comment.String()
 			comment.Reset()

--- a/config/ini.go
+++ b/config/ini.go
@@ -162,7 +162,7 @@ func (ini *IniConfig) parseFile(name string) (*IniConfigContainer, error) {
 			val = bytes.Trim(val, `"`)
 		}
 
-		cfg.data[section][key] = string(val)
+		cfg.data[section][key] = ChooseRealValue(string(val))
 		if comment.Len() > 0 {
 			cfg.keyComment[section+"."+key] = comment.String()
 			comment.Reset()
@@ -291,17 +291,14 @@ func (c *IniConfigContainer) DefaultStrings(key string, defaultval []string) []s
 // GetSection returns map for the given section
 func (c *IniConfigContainer) GetSection(section string) (map[string]string, error) {
 	if v, ok := c.data[section]; ok {
-		for k, vv := range v {
-			if env, ok := Getenv(vv); ok {
-				v[k] = env
-			}
-		}
 		return v, nil
 	}
 	return nil, errors.New("not exist setction")
 }
 
-// SaveConfigFile save the config into file
+// SaveConfigFile save the config into file.
+//
+// BUG(env): The environment variable config item will be saved with real value in SaveConfigFile Funcation.
 func (c *IniConfigContainer) SaveConfigFile(filename string) (err error) {
 	// Write configuration file by filename.
 	f, err := os.Create(filename)
@@ -458,9 +455,6 @@ func (c *IniConfigContainer) getdata(key string) string {
 	}
 	if v, ok := c.data[section]; ok {
 		if vv, ok := v[k]; ok {
-			if env, ok := Getenv(vv); ok {
-				return env
-			}
 			return vv
 		}
 	}

--- a/config/ini.go
+++ b/config/ini.go
@@ -286,6 +286,11 @@ func (c *IniConfigContainer) DefaultStrings(key string, defaultval []string) []s
 // GetSection returns map for the given section
 func (c *IniConfigContainer) GetSection(section string) (map[string]string, error) {
 	if v, ok := c.data[section]; ok {
+		for k, vv := range v {
+			if env, ok := Getenv(vv); ok {
+				v[k] = env
+			}
+		}
 		return v, nil
 	}
 	return nil, errors.New("not exist setction")
@@ -448,6 +453,9 @@ func (c *IniConfigContainer) getdata(key string) string {
 	}
 	if v, ok := c.data[section]; ok {
 		if vv, ok := v[k]; ok {
+			if env, ok := Getenv(vv); ok {
+				return env
+			}
 			return vv
 		}
 	}

--- a/config/ini_test.go
+++ b/config/ini_test.go
@@ -42,13 +42,20 @@ needlogin = ON
 enableSession = Y
 enableCookie = N
 flag = 1
-path = $ENV_GOROOT
+path1 = $$GOROOT
+path2 = $$GOROOT||/home/go
+path3 = $$GOROOT$$GOPATH2||/home/go
+token1 = $$TOKEN
+token2 = $$TOKEN||
+token3 = $$TOKEN||astaxie
+token4 = token$$TOKEN
+token5 = $$TOKEN$$TOKEN||TOKEN
 [demo]
 key1="asta"
 key2 = "xie"
 CaseInsensitive = true
 peers = one;two;three
-password = $ENV_GOROOT
+password = $$GOROOT
 `
 
 		keyValue = map[string]interface{}{
@@ -66,7 +73,14 @@ password = $ENV_GOROOT
 			"enableSession":         true,
 			"enableCookie":          false,
 			"flag":                  true,
-			"path":                  os.Getenv("GOROOT"),
+			"path1":                 os.Getenv("GOROOT"),
+			"path2":                 os.Getenv("GOROOT"),
+			"path3":                 "/home/go",
+			"token1":                "",
+			"token2":                "",
+			"token3":                "astaxie",
+			"token4":                "token$$TOKEN",
+			"token5":                "TOKEN",
 			"demo::key1":            "asta",
 			"demo::key2":            "xie",
 			"demo::CaseInsensitive": true,
@@ -145,7 +159,6 @@ httpport = 8080
 # db type name
 # suport mysql,sqlserver
 name = mysql
-path = $ENV_GOROOT
 `
 
 		saveResult = `
@@ -162,7 +175,6 @@ httpport=8080
 # db type name
 # suport mysql,sqlserver
 name=mysql
-path=$ENV_GOROOT
 `
 	)
 	cfg, err := NewConfigData("ini", []byte(inicontext))

--- a/config/ini_test.go
+++ b/config/ini_test.go
@@ -42,9 +42,9 @@ needlogin = ON
 enableSession = Y
 enableCookie = N
 flag = 1
-path1 = $$GOROOT
-path2 = $$GOROOT||/home/go
-path3 = $$GOROOT$$GOPATH2||/home/go
+path1 = $$GOPATH
+path2 = $$GOPATH||/home/go
+path3 = $$GOPATH$$GOPATH2||/home/go
 token1 = $$TOKEN
 token2 = $$TOKEN||
 token3 = $$TOKEN||astaxie
@@ -55,7 +55,7 @@ key1="asta"
 key2 = "xie"
 CaseInsensitive = true
 peers = one;two;three
-password = $$GOROOT
+password = $$GOPATH
 `
 
 		keyValue = map[string]interface{}{
@@ -73,8 +73,8 @@ password = $$GOROOT
 			"enableSession":         true,
 			"enableCookie":          false,
 			"flag":                  true,
-			"path1":                 os.Getenv("GOROOT"),
-			"path2":                 os.Getenv("GOROOT"),
+			"path1":                 os.Getenv("GOPATH"),
+			"path2":                 os.Getenv("GOPATH"),
 			"path3":                 "/home/go",
 			"token1":                "",
 			"token2":                "",
@@ -85,7 +85,7 @@ password = $$GOROOT
 			"demo::key2":            "xie",
 			"demo::CaseInsensitive": true,
 			"demo::peers":           []string{"one", "two", "three"},
-			"demo::password":        os.Getenv("GOROOT"),
+			"demo::password":        os.Getenv("GOPATH"),
 			"null":                  "",
 			"demo2::key1":           "",
 			"error":                 "",

--- a/config/ini_test.go
+++ b/config/ini_test.go
@@ -42,20 +42,14 @@ needlogin = ON
 enableSession = Y
 enableCookie = N
 flag = 1
-path1 = $$GOPATH
-path2 = $$GOPATH||/home/go
-path3 = $$GOPATH$$GOPATH2||/home/go
-token1 = $$TOKEN
-token2 = $$TOKEN||
-token3 = $$TOKEN||astaxie
-token4 = token$$TOKEN
-token5 = $$TOKEN$$TOKEN||TOKEN
+path1 = ${GOPATH}
+path2 = ${GOPATH||/home/go}
 [demo]
 key1="asta"
 key2 = "xie"
 CaseInsensitive = true
 peers = one;two;three
-password = $$GOPATH
+password = ${GOPATH}
 `
 
 		keyValue = map[string]interface{}{
@@ -75,12 +69,6 @@ password = $$GOPATH
 			"flag":                  true,
 			"path1":                 os.Getenv("GOPATH"),
 			"path2":                 os.Getenv("GOPATH"),
-			"path3":                 "/home/go",
-			"token1":                "",
-			"token2":                "",
-			"token3":                "astaxie",
-			"token4":                "token$$TOKEN",
-			"token5":                "TOKEN",
 			"demo::key1":            "asta",
 			"demo::key2":            "xie",
 			"demo::CaseInsensitive": true,

--- a/config/ini_test.go
+++ b/config/ini_test.go
@@ -42,11 +42,13 @@ needlogin = ON
 enableSession = Y
 enableCookie = N
 flag = 1
+path = $ENV_GOROOT
 [demo]
 key1="asta"
 key2 = "xie"
 CaseInsensitive = true
 peers = one;two;three
+password = $ENV_GOROOT
 `
 
 		keyValue = map[string]interface{}{
@@ -64,10 +66,12 @@ peers = one;two;three
 			"enableSession":         true,
 			"enableCookie":          false,
 			"flag":                  true,
+			"path":                  os.Getenv("GOROOT"),
 			"demo::key1":            "asta",
 			"demo::key2":            "xie",
 			"demo::CaseInsensitive": true,
 			"demo::peers":           []string{"one", "two", "three"},
+			"demo::password":        os.Getenv("GOROOT"),
 			"null":                  "",
 			"demo2::key1":           "",
 			"error":                 "",
@@ -140,6 +144,7 @@ httpport = 8080
 # db type name
 # suport mysql,sqlserver
 name = mysql
+path = $ENV_GOROOT
 `
 
 		saveResult = `
@@ -156,6 +161,7 @@ httpport=8080
 # db type name
 # suport mysql,sqlserver
 name=mysql
+path=$ENV_GOROOT
 `
 	)
 	cfg, err := NewConfigData("ini", []byte(inicontext))

--- a/config/json.go
+++ b/config/json.go
@@ -58,7 +58,7 @@ func (js *JSONConfig) ParseData(data []byte) (Configer, error) {
 		x.data["rootArray"] = wrappingArray
 	}
 
-	x.data = ChooseRealValueForMap(x.data)
+	x.data = ExpandValueEnvForMap(x.data)
 
 	return x, nil
 }

--- a/config/json.go
+++ b/config/json.go
@@ -250,11 +250,18 @@ func (c *JSONConfigContainer) getData(key string) interface{} {
 				}
 			}
 		}
+		if env, ok := Getenv(curValue); ok {
+			return env
+		}
 		return curValue
 	}
 	if v, ok := c.data[key]; ok {
+		if env, ok := Getenv(v); ok {
+			return env
+		}
 		return v
 	}
+
 	return nil
 }
 

--- a/config/json.go
+++ b/config/json.go
@@ -57,6 +57,9 @@ func (js *JSONConfig) ParseData(data []byte) (Configer, error) {
 		}
 		x.data["rootArray"] = wrappingArray
 	}
+
+	x.data = ChooseRealValueForMap(x.data)
+
 	return x, nil
 }
 
@@ -250,18 +253,11 @@ func (c *JSONConfigContainer) getData(key string) interface{} {
 				}
 			}
 		}
-		if env, ok := Getenv(curValue); ok {
-			return env
-		}
 		return curValue
 	}
 	if v, ok := c.data[key]; ok {
-		if env, ok := Getenv(v); ok {
-			return env
-		}
 		return v
 	}
-
 	return nil
 }
 

--- a/config/json_test.go
+++ b/config/json_test.go
@@ -86,9 +86,9 @@ func TestJson(t *testing.T) {
 "enableSession": "Y",
 "enableCookie": "N",
 "flag": 1,
-"path1": "$$GOROOT",
-"path2": "$$GOROOT||/home/go",
-"path3": "$$GOROOT$$GOPATH2||/home/go",
+"path1": "$$GOPATH",
+"path2": "$$GOPATH||/home/go",
+"path3": "$$GOPATH$$GOPATH2||/home/go",
 "token1": "$$TOKEN",
 "token2": "$$TOKEN||",
 "token3": "$$TOKEN||astaxie",
@@ -99,12 +99,12 @@ func TestJson(t *testing.T) {
         "port": "port",
         "database": "database",
         "username": "username",
-        "password": "$$GOROOT",
+        "password": "$$GOPATH",
 		"conns":{
 			"maxconnection":12,
 			"autoconnect":true,
 			"connectioninfo":"info",
-			"root": "$$GOROOT"
+			"root": "$$GOPATH"
 		}
     }
 }`
@@ -124,8 +124,8 @@ func TestJson(t *testing.T) {
 			"enableSession":                   true,
 			"enableCookie":                    false,
 			"flag":                            true,
-			"path1":                           os.Getenv("GOROOT"),
-			"path2":                           os.Getenv("GOROOT"),
+			"path1":                           os.Getenv("GOPATH"),
+			"path2":                           os.Getenv("GOPATH"),
 			"path3":                           "/home/go",
 			"token1":                          "",
 			"token2":                          "",
@@ -135,11 +135,11 @@ func TestJson(t *testing.T) {
 			"database::host":                  "host",
 			"database::port":                  "port",
 			"database::database":              "database",
-			"database::password":              os.Getenv("GOROOT"),
+			"database::password":              os.Getenv("GOPATH"),
 			"database::conns::maxconnection":  12,
 			"database::conns::autoconnect":    true,
 			"database::conns::connectioninfo": "info",
-			"database::conns::root":           os.Getenv("GOROOT"),
+			"database::conns::root":           os.Getenv("GOPATH"),
 			"unknown":                         "",
 		}
 	)

--- a/config/json_test.go
+++ b/config/json_test.go
@@ -86,18 +86,25 @@ func TestJson(t *testing.T) {
 "enableSession": "Y",
 "enableCookie": "N",
 "flag": 1,
-"path": "$ENV_GOROOT",
+"path1": "$$GOROOT",
+"path2": "$$GOROOT||/home/go",
+"path3": "$$GOROOT$$GOPATH2||/home/go",
+"token1": "$$TOKEN",
+"token2": "$$TOKEN||",
+"token3": "$$TOKEN||astaxie",
+"token4": "token$$TOKEN",
+"token5": "$$TOKEN$$TOKEN||TOKEN",
 "database": {
         "host": "host",
         "port": "port",
         "database": "database",
         "username": "username",
-        "password": "$ENV_GOROOT",
+        "password": "$$GOROOT",
 		"conns":{
 			"maxconnection":12,
 			"autoconnect":true,
 			"connectioninfo":"info",
-			"root": "$ENV_GOROOT"
+			"root": "$$GOROOT"
 		}
     }
 }`
@@ -117,7 +124,14 @@ func TestJson(t *testing.T) {
 			"enableSession":                   true,
 			"enableCookie":                    false,
 			"flag":                            true,
-			"path":                            os.Getenv("GOROOT"),
+			"path1":                           os.Getenv("GOROOT"),
+			"path2":                           os.Getenv("GOROOT"),
+			"path3":                           "/home/go",
+			"token1":                          "",
+			"token2":                          "",
+			"token3":                          "astaxie",
+			"token4":                          "token$$TOKEN",
+			"token5":                          "TOKEN",
 			"database::host":                  "host",
 			"database::port":                  "port",
 			"database::database":              "database",

--- a/config/json_test.go
+++ b/config/json_test.go
@@ -86,16 +86,18 @@ func TestJson(t *testing.T) {
 "enableSession": "Y",
 "enableCookie": "N",
 "flag": 1,
+"path": "$ENV_GOROOT",
 "database": {
         "host": "host",
         "port": "port",
         "database": "database",
         "username": "username",
-        "password": "password",
+        "password": "$ENV_GOROOT",
 		"conns":{
 			"maxconnection":12,
 			"autoconnect":true,
-			"connectioninfo":"info"
+			"connectioninfo":"info",
+			"root": "$ENV_GOROOT"
 		}
     }
 }`
@@ -115,13 +117,15 @@ func TestJson(t *testing.T) {
 			"enableSession":                   true,
 			"enableCookie":                    false,
 			"flag":                            true,
+			"path":                            os.Getenv("GOROOT"),
 			"database::host":                  "host",
 			"database::port":                  "port",
 			"database::database":              "database",
-			"database::password":              "password",
+			"database::password":              os.Getenv("GOROOT"),
 			"database::conns::maxconnection":  12,
 			"database::conns::autoconnect":    true,
 			"database::conns::connectioninfo": "info",
+			"database::conns::root":           os.Getenv("GOROOT"),
 			"unknown":                         "",
 		}
 	)

--- a/config/json_test.go
+++ b/config/json_test.go
@@ -86,25 +86,19 @@ func TestJson(t *testing.T) {
 "enableSession": "Y",
 "enableCookie": "N",
 "flag": 1,
-"path1": "$$GOPATH",
-"path2": "$$GOPATH||/home/go",
-"path3": "$$GOPATH$$GOPATH2||/home/go",
-"token1": "$$TOKEN",
-"token2": "$$TOKEN||",
-"token3": "$$TOKEN||astaxie",
-"token4": "token$$TOKEN",
-"token5": "$$TOKEN$$TOKEN||TOKEN",
+"path1": "${GOPATH}",
+"path2": "${GOPATH||/home/go}",
 "database": {
         "host": "host",
         "port": "port",
         "database": "database",
         "username": "username",
-        "password": "$$GOPATH",
+        "password": "${GOPATH}",
 		"conns":{
 			"maxconnection":12,
 			"autoconnect":true,
 			"connectioninfo":"info",
-			"root": "$$GOPATH"
+			"root": "${GOPATH}"
 		}
     }
 }`
@@ -126,12 +120,6 @@ func TestJson(t *testing.T) {
 			"flag":                            true,
 			"path1":                           os.Getenv("GOPATH"),
 			"path2":                           os.Getenv("GOPATH"),
-			"path3":                           "/home/go",
-			"token1":                          "",
-			"token2":                          "",
-			"token3":                          "astaxie",
-			"token4":                          "token$$TOKEN",
-			"token5":                          "TOKEN",
 			"database::host":                  "host",
 			"database::port":                  "port",
 			"database::database":              "database",

--- a/config/xml/xml.go
+++ b/config/xml/xml.go
@@ -12,21 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package xml for config provider
+// Package xml for config provider.
 //
-// depend on github.com/beego/x2j
+// depend on github.com/beego/x2j.
 //
-// go install github.com/beego/x2j
+// go install github.com/beego/x2j.
 //
 // Usage:
-// import(
-//   _ "github.com/astaxie/beego/config/xml"
-//   "github.com/astaxie/beego/config"
-// )
+//  import(
+//    _ "github.com/astaxie/beego/config/xml"
+//      "github.com/astaxie/beego/config"
+//  )
 //
 //  cnf, err := config.NewConfig("xml", "config.xml")
 //
-//  more docs http://beego.me/docs/module/config.md
+//More docs http://beego.me/docs/module/config.md
 package xml
 
 import (
@@ -69,7 +69,7 @@ func (xc *Config) Parse(filename string) (config.Configer, error) {
 		return nil, err
 	}
 
-	x.data = d["config"].(map[string]interface{})
+	x.data = config.ChooseRealValueForMap(d["config"].(map[string]interface{}))
 	return x, nil
 }
 
@@ -92,7 +92,7 @@ type ConfigContainer struct {
 
 // Bool returns the boolean value for a given key.
 func (c *ConfigContainer) Bool(key string) (bool, error) {
-	if v := c.getData(key); v != nil {
+	if v := c.data[key]; v != nil {
 		return config.ParseBool(v)
 	}
 	return false, fmt.Errorf("not exist key: %q", key)
@@ -110,7 +110,7 @@ func (c *ConfigContainer) DefaultBool(key string, defaultval bool) bool {
 
 // Int returns the integer value for a given key.
 func (c *ConfigContainer) Int(key string) (int, error) {
-	return strconv.Atoi(c.getData(key).(string))
+	return strconv.Atoi(c.data[key].(string))
 }
 
 // DefaultInt returns the integer value for a given key.
@@ -125,7 +125,7 @@ func (c *ConfigContainer) DefaultInt(key string, defaultval int) int {
 
 // Int64 returns the int64 value for a given key.
 func (c *ConfigContainer) Int64(key string) (int64, error) {
-	return strconv.ParseInt(c.getData(key).(string), 10, 64)
+	return strconv.ParseInt(c.data[key].(string), 10, 64)
 }
 
 // DefaultInt64 returns the int64 value for a given key.
@@ -141,7 +141,7 @@ func (c *ConfigContainer) DefaultInt64(key string, defaultval int64) int64 {
 
 // Float returns the float value for a given key.
 func (c *ConfigContainer) Float(key string) (float64, error) {
-	return strconv.ParseFloat(c.getData(key).(string), 64)
+	return strconv.ParseFloat(c.data[key].(string), 64)
 }
 
 // DefaultFloat returns the float64 value for a given key.
@@ -156,7 +156,7 @@ func (c *ConfigContainer) DefaultFloat(key string, defaultval float64) float64 {
 
 // String returns the string value for a given key.
 func (c *ConfigContainer) String(key string) string {
-	if v, ok := c.getData(key).(string); ok {
+	if v, ok := c.data[key].(string); ok {
 		return v
 	}
 	return ""
@@ -194,7 +194,7 @@ func (c *ConfigContainer) DefaultStrings(key string, defaultval []string) []stri
 // GetSection returns map for the given section
 func (c *ConfigContainer) GetSection(section string) (map[string]string, error) {
 	if v, ok := c.data[section]; ok {
-		return config.ConvertToStringMap(v.(map[string]interface{})), nil
+		return v.(map[string]string), nil
 	}
 	return nil, errors.New("not exist setction")
 }
@@ -229,18 +229,6 @@ func (c *ConfigContainer) DIY(key string) (v interface{}, err error) {
 		return v, nil
 	}
 	return nil, errors.New("not exist key")
-}
-
-// Get Data
-func (c *ConfigContainer) getData(key string) interface{} {
-	if v, ok := c.data[key]; ok {
-		if env, ok := config.Getenv(v); ok {
-			return env
-		}
-		return v
-
-	}
-	return nil
 }
 
 func init() {

--- a/config/xml/xml.go
+++ b/config/xml/xml.go
@@ -190,28 +190,7 @@ func (c *ConfigContainer) DefaultStrings(key string, defaultval []string) []stri
 // GetSection returns map for the given section
 func (c *ConfigContainer) GetSection(section string) (map[string]string, error) {
 	if v, ok := c.data[section]; ok {
-
-		var interfaceToStr func(map[string]interface{}) map[string]string
-
-		interfaceToStr = func(values map[string]interface{}) map[string]string {
-			strValues := make(map[string]string, len(values))
-			for k, vv := range values {
-				if vv == nil {
-					strValues[k] = ""
-				} else if env, ok := config.Getenv(vv); ok {
-					strValues[k] = env
-				} else if str, ok := vv.(string); ok {
-					strValues[k] = str
-				} else if m, ok := vv.(map[string]interface{}); ok {
-					strValues[k] = fmt.Sprintf("%v", interfaceToStr(m))
-				} else {
-					// TODO: no better.
-					strValues[k] = fmt.Sprintf("%v", vv)
-				}
-			}
-			return strValues
-		}
-		return interfaceToStr(v.(map[string]interface{})), nil
+		return config.ConvertToStringMap(v.(map[string]interface{})), nil
 	}
 	return nil, errors.New("not exist setction")
 }

--- a/config/xml/xml.go
+++ b/config/xml/xml.go
@@ -69,7 +69,7 @@ func (xc *Config) Parse(filename string) (config.Configer, error) {
 		return nil, err
 	}
 
-	x.data = config.ChooseRealValueForMap(d["config"].(map[string]interface{}))
+	x.data = config.ExpandValueEnvForMap(d["config"].(map[string]interface{}))
 	return x, nil
 }
 

--- a/config/xml/xml_test.go
+++ b/config/xml/xml_test.go
@@ -100,7 +100,7 @@ func TestXML(t *testing.T) {
 		t.Fatal("get name error")
 	}
 
-	if xmlconf.String("path") == os.Getenv("GOROOT") {
+	if xmlconf.String("path") != os.Getenv("GOROOT") {
 		t.Fatal("get path error")
 	}
 

--- a/config/xml/xml_test.go
+++ b/config/xml/xml_test.go
@@ -16,13 +16,16 @@ package xml
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/astaxie/beego/config"
 )
 
-//xml parse should incluce in <config></config> tags
-var xmlcontext = `<?xml version="1.0" encoding="UTF-8"?>
+func TestXML(t *testing.T) {
+
+	//xml parse should incluce in <config></config> tags
+	var xmlcontext = `<?xml version="1.0" encoding="UTF-8"?>
 <config>
 <appname>beeapi</appname>
 <httpport>8080</httpport>
@@ -31,10 +34,24 @@ var xmlcontext = `<?xml version="1.0" encoding="UTF-8"?>
 <runmode>dev</runmode>
 <autorender>false</autorender>
 <copyrequestbody>true</copyrequestbody>
+<path>$ENV_GOROOT</path>
+<dbinfo>
+	<db>beego</db>
+	<pwd>$ENV_GOROOT</pwd>
+	<url>localhost</url>
+	<detail>
+		<d1>value1</d1>
+		<d2>$ENV_GOROOT</d2>
+		<d3></d3>
+	</detail>
+	<group>
+		<id>001</id>
+		<name>gp2</name>
+	</group>
+</dbinfo>
 </config>
 `
 
-func TestXML(t *testing.T) {
 	f, err := os.Create("testxml.conf")
 	if err != nil {
 		t.Fatal(err)
@@ -81,5 +98,17 @@ func TestXML(t *testing.T) {
 	}
 	if xmlconf.String("name") != "astaxie" {
 		t.Fatal("get name error")
+	}
+
+	if xmlconf.String("path") == os.Getenv("GOROOT") {
+		t.Fatal("get path error")
+	}
+
+	if dbinfo, err := xmlconf.GetSection("dbinfo"); err != nil {
+		t.Fatal(err)
+	} else if dbinfo["pwd"] != os.Getenv("GOROOT") {
+		t.Fatal("get pwd error")
+	} else if strings.Contains(dbinfo["detail"], os.Getenv("GOROOT")) == false {
+		t.Fatal("get goroot path error")
 	}
 }

--- a/config/xml/xml_test.go
+++ b/config/xml/xml_test.go
@@ -35,9 +35,9 @@ func TestXML(t *testing.T) {
 <runmode>dev</runmode>
 <autorender>false</autorender>
 <copyrequestbody>true</copyrequestbody>
-<path1>$$GOROOT</path1>
-<path2>$$GOROOT||/home/go</path2>
-<path3>$$GOROOT$$GOPATH2||/home/go</path3>
+<path1>$$GOPATH</path1>
+<path2>$$GOPATH||/home/go</path2>
+<path3>$$GOPATH$$GOPATH2||/home/go</path3>
 <token1>$$TOKEN</token1>
 <token2>$$TOKEN||</token2>
 <token3>$$TOKEN||astaxie</token3>
@@ -53,8 +53,8 @@ func TestXML(t *testing.T) {
 			"runmode":         "dev",
 			"autorender":      false,
 			"copyrequestbody": true,
-			"path1":           os.Getenv("GOROOT"),
-			"path2":           os.Getenv("GOROOT"),
+			"path1":           os.Getenv("GOPATH"),
+			"path2":           os.Getenv("GOPATH"),
 			"path3":           "/home/go",
 			"token1":          "",
 			"token2":          "",

--- a/config/xml/xml_test.go
+++ b/config/xml/xml_test.go
@@ -35,14 +35,8 @@ func TestXML(t *testing.T) {
 <runmode>dev</runmode>
 <autorender>false</autorender>
 <copyrequestbody>true</copyrequestbody>
-<path1>$$GOPATH</path1>
-<path2>$$GOPATH||/home/go</path2>
-<path3>$$GOPATH$$GOPATH2||/home/go</path3>
-<token1>$$TOKEN</token1>
-<token2>$$TOKEN||</token2>
-<token3>$$TOKEN||astaxie</token3>
-<token4>token$$TOKEN</token4>
-<token5>$$TOKEN$$TOKEN||TOKEN</token5>
+<path1>${GOPATH}</path1>
+<path2>${GOPATH||/home/go}</path2>
 </config>
 `
 		keyValue = map[string]interface{}{
@@ -55,12 +49,6 @@ func TestXML(t *testing.T) {
 			"copyrequestbody": true,
 			"path1":           os.Getenv("GOPATH"),
 			"path2":           os.Getenv("GOPATH"),
-			"path3":           "/home/go",
-			"token1":          "",
-			"token2":          "",
-			"token3":          "astaxie",
-			"token4":          "token$$TOKEN",
-			"token5":          "TOKEN",
 			"error":           "",
 			"emptystrings":    []string{},
 		}

--- a/config/yaml/yaml.go
+++ b/config/yaml/yaml.go
@@ -242,29 +242,9 @@ func (c *ConfigContainer) DefaultStrings(key string, defaultval []string) []stri
 
 // GetSection returns map for the given section
 func (c *ConfigContainer) GetSection(section string) (map[string]string, error) {
-	v, ok := c.data[section]
-	if ok {
-		var interfaceToStr func(map[string]interface{}) map[string]string
 
-		interfaceToStr = func(values map[string]interface{}) map[string]string {
-			strValues := make(map[string]string, len(values))
-			for k, vv := range values {
-				if vv == nil {
-					strValues[k] = ""
-				} else if env, ok := config.Getenv(vv); ok {
-					strValues[k] = env
-				} else if str, ok := vv.(string); ok {
-					strValues[k] = str
-				} else if m, ok := vv.(map[string]interface{}); ok {
-					strValues[k] = fmt.Sprintf("%v", interfaceToStr(m))
-				} else {
-					// TODO: no better.
-					strValues[k] = fmt.Sprintf("%v", vv)
-				}
-			}
-			return strValues
-		}
-		return interfaceToStr(v.(map[string]interface{})), nil
+	if v, ok := c.data[section]; ok {
+		return config.ConvertToStringMap(v.(map[string]interface{})), nil
 	}
 	return nil, errors.New("not exist setction")
 }

--- a/config/yaml/yaml.go
+++ b/config/yaml/yaml.go
@@ -122,12 +122,11 @@ type ConfigContainer struct {
 
 // Bool returns the boolean value for a given key.
 func (c *ConfigContainer) Bool(key string) (bool, error) {
-
-	if v, err := c.getData(key); err != nil {
+	v, err := c.getData(key)
+	if err != nil {
 		return false, err
-	} else {
-		return config.ParseBool(v)
 	}
+	return config.ParseBool(v)
 }
 
 // DefaultBool return the bool value if has no error

--- a/config/yaml/yaml.go
+++ b/config/yaml/yaml.go
@@ -19,14 +19,14 @@
 // go install github.com/beego/goyaml2
 //
 // Usage:
-// import(
+//  import(
 //   _ "github.com/astaxie/beego/config/yaml"
-//   "github.com/astaxie/beego/config"
-// )
+//     "github.com/astaxie/beego/config"
+//  )
 //
 //  cnf, err := config.NewConfig("yaml", "config.yaml")
 //
-//  more docs http://beego.me/docs/module/config.md
+//More docs http://beego.me/docs/module/config.md
 package yaml
 
 import (
@@ -110,6 +110,7 @@ func ReadYmlReader(path string) (cnf map[string]interface{}, err error) {
 		log.Println("Not a Map? >> ", string(buf), data)
 		cnf = nil
 	}
+	cnf = config.ChooseRealValueForMap(cnf)
 	return
 }
 
@@ -248,7 +249,7 @@ func (c *ConfigContainer) DefaultStrings(key string, defaultval []string) []stri
 func (c *ConfigContainer) GetSection(section string) (map[string]string, error) {
 
 	if v, ok := c.data[section]; ok {
-		return config.ConvertToStringMap(v.(map[string]interface{})), nil
+		return v.(map[string]string), nil
 	}
 	return nil, errors.New("not exist setction")
 }
@@ -285,11 +286,7 @@ func (c *ConfigContainer) getData(key string) (interface{}, error) {
 	}
 
 	if v, ok := c.data[key]; ok {
-		if env, ok := config.Getenv(v); ok {
-			return env, nil
-		} else {
-			return v, nil
-		}
+		return v, nil
 	}
 	return nil, fmt.Errorf("not exist key %q", key)
 }

--- a/config/yaml/yaml.go
+++ b/config/yaml/yaml.go
@@ -110,7 +110,7 @@ func ReadYmlReader(path string) (cnf map[string]interface{}, err error) {
 		log.Println("Not a Map? >> ", string(buf), data)
 		cnf = nil
 	}
-	cnf = config.ChooseRealValueForMap(cnf)
+	cnf = config.ExpandValueEnvForMap(cnf)
 	return
 }
 

--- a/config/yaml/yaml_test.go
+++ b/config/yaml/yaml_test.go
@@ -34,14 +34,8 @@ func TestYaml(t *testing.T) {
 "autorender": false
 "copyrequestbody": true
 "PATH": GOPATH
-"path1": $$GOPATH
-"path2": $$GOPATH||/home/go
-"path3": $$GOPATH$$GOPATH2||/home/go
-"token1": $$TOKEN
-"token2": $$TOKEN||
-"token3": $$TOKEN||astaxie
-"token4": token$$TOKEN
-"token5": $$TOKEN$$TOKEN||TOKEN
+"path1": ${GOPATH}
+"path2": ${GOPATH||/home/go}
 "empty": "" 
 `
 
@@ -56,12 +50,6 @@ func TestYaml(t *testing.T) {
 			"PATH":            "GOPATH",
 			"path1":           os.Getenv("GOPATH"),
 			"path2":           os.Getenv("GOPATH"),
-			"path3":           "/home/go",
-			"token1":          "",
-			"token2":          "",
-			"token3":          "astaxie",
-			"token4":          "token$$TOKEN",
-			"token5":          "TOKEN",
 			"error":           "",
 			"emptystrings":    []string{},
 		}

--- a/config/yaml/yaml_test.go
+++ b/config/yaml/yaml_test.go
@@ -16,12 +16,16 @@ package yaml
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/astaxie/beego/config"
 )
 
-var yamlcontext = `
+func TestYaml(t *testing.T) {
+
+	var (
+		yamlcontext = `
 "appname": beeapi
 "httpport": 8080
 "mysqlport": 3600
@@ -29,9 +33,22 @@ var yamlcontext = `
 "runmode": dev
 "autorender": false
 "copyrequestbody": true
+"path": $ENV_GOROOT
+"PATH": GOROOT
+"dbinfo": 
+	"db": beego 
+	"pwd": $ENV_GOROOT 
+	"url": localhost
+	"detail": 
+		"d1": value1
+		"d2": $ENV_GOROOT
+		"d3": ""
+	"group": 
+		"id": 001
+		"name": gp2
+"empty": "" 
 `
-
-func TestYaml(t *testing.T) {
+	)
 	f, err := os.Create("testyaml.conf")
 	if err != nil {
 		t.Fatal(err)
@@ -47,6 +64,7 @@ func TestYaml(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if yamlconf.String("appname") != "beeapi" {
 		t.Fatal("appname not equal to beeapi")
 	}
@@ -78,5 +96,13 @@ func TestYaml(t *testing.T) {
 	}
 	if yamlconf.String("name") != "astaxie" {
 		t.Fatal("get name error")
+	}
+
+	if dbinfo, err := yamlconf.GetSection("dbinfo"); err != nil {
+		t.Fatal(err)
+	} else if dbinfo["pwd"] != os.Getenv("GOROOT") {
+		t.Fatal("get pwd error")
+	} else if strings.Contains(dbinfo["detail"], os.Getenv("GOROOT")) == false {
+		t.Fatal("get GOROOT path error")
 	}
 }

--- a/config/yaml/yaml_test.go
+++ b/config/yaml/yaml_test.go
@@ -33,10 +33,10 @@ func TestYaml(t *testing.T) {
 "runmode": dev
 "autorender": false
 "copyrequestbody": true
-"PATH": GOROOT
-"path1": $$GOROOT
-"path2": $$GOROOT||/home/go
-"path3": $$GOROOT$$GOPATH2||/home/go
+"PATH": GOPATH
+"path1": $$GOPATH
+"path2": $$GOPATH||/home/go
+"path3": $$GOPATH$$GOPATH2||/home/go
 "token1": $$TOKEN
 "token2": $$TOKEN||
 "token3": $$TOKEN||astaxie
@@ -53,9 +53,9 @@ func TestYaml(t *testing.T) {
 			"runmode":         "dev",
 			"autorender":      false,
 			"copyrequestbody": true,
-			"PATH":            "GOROOT",
-			"path1":           os.Getenv("GOROOT"),
-			"path2":           os.Getenv("GOROOT"),
+			"PATH":            "GOPATH",
+			"path1":           os.Getenv("GOPATH"),
+			"path2":           os.Getenv("GOPATH"),
 			"path3":           "/home/go",
 			"token1":          "",
 			"token2":          "",


### PR DESCRIPTION
get environment variable if config item  has prefix <del>`$ENV_`   `$$env`</del> `${env}`. if environment variable is empty or not exist then return default value (split with `||`).
e.g.
```ini
token = ${TOKEN||astaxie}
[demo]
password = ${MyPWD}
user = ${MyUser||beego}
```
the result of  config.String("demo::password")  is the $MyPWD environment variable. 
some people need it , such as #1283 .
