### PR TITLE
try to fix the little bug when calling Close or Flush in async mode

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,11 +15,11 @@
 package beego
 
 import (
+	"fmt"
 	"html/template"
 	"os"
 	"path/filepath"
 	"strings"
-	"fmt"
 
 	"github.com/astaxie/beego/config"
 	"github.com/astaxie/beego/session"
@@ -299,7 +299,7 @@ func parseConfig(appConfigPath string) (err error) {
 	}
 
 	//init log
-	BeeLogger.Close()
+	BeeLogger.Reset()
 	for adaptor, config := range BConfig.Log.Outputs {
 		err = BeeLogger.SetLogger(adaptor, config)
 		if err != nil {

--- a/logs/log.go
+++ b/logs/log.go
@@ -98,8 +98,8 @@ type BeeLogger struct {
 	loggerFuncCallDepth int
 	asynchronous        bool
 	msgChan             chan *logMsg
-	signalChan			chan string
-	wg					sync.WaitGroup
+	signalChan          chan string
+	wg                  sync.WaitGroup
 	outputs             []*nameLogger
 }
 
@@ -111,7 +111,7 @@ type nameLogger struct {
 type logMsg struct {
 	level int
 	msg   string
-	when time.Time
+	when  time.Time
 }
 
 var logMsgPool *sync.Pool
@@ -125,7 +125,6 @@ func NewLogger(channelLen int64) *BeeLogger {
 	bl.loggerFuncCallDepth = 2
 	bl.msgChan = make(chan *logMsg, channelLen)
 	bl.signalChan = make(chan string, 1)
-	bl.wg.Add(1)
 	return bl
 }
 
@@ -137,6 +136,7 @@ func (bl *BeeLogger) Async() *BeeLogger {
 			return &logMsg{}
 		},
 	}
+	bl.wg.Add(1)
 	go bl.startLogger()
 	return bl
 }
@@ -236,6 +236,7 @@ func (bl *BeeLogger) EnableFuncCallDepth(b bool) {
 // start logger chan reading.
 // when chan is not empty, write logs.
 func (bl *BeeLogger) startLogger() {
+	gameOver := false
 	for {
 		select {
 		case bm := <-bl.msgChan:
@@ -243,25 +244,18 @@ func (bl *BeeLogger) startLogger() {
 			logMsgPool.Put(bm)
 		case sg := <-bl.signalChan:
 			// Now should only send "flush" or "close" to bl.signalChan
-			for {
-				if len(bl.msgChan) > 0 {
-					bm := <-bl.msgChan
-					bl.writeToLoggers(bm.when, bm.msg, bm.level)
-					logMsgPool.Put(bm)
-					continue
-				}
-				break
-			}
-			for _, l := range bl.outputs {
-				l.Flush()
-			}
+			bl.flush()
 			if sg == "close" {
 				for _, l := range bl.outputs {
 					l.Destroy()
 				}
 				bl.outputs = nil
+				gameOver = true
 			}
 			bl.wg.Done()
+		}
+		if gameOver {
+			break
 		}
 	}
 }
@@ -370,16 +364,53 @@ func (bl *BeeLogger) Trace(format string, v ...interface{}) {
 
 // Flush flush all chan data.
 func (bl *BeeLogger) Flush() {
-	bl.signalChan <- "flush"
-	bl.wg.Wait()
-	bl.wg.Add(1)
+	if bl.asynchronous {
+		bl.signalChan <- "flush"
+		bl.wg.Wait()
+		bl.wg.Add(1)
+		return
+	}
+	bl.flush()
 }
 
 // Close close logger, flush all chan data and destroy all adapters in BeeLogger.
 func (bl *BeeLogger) Close() {
-	bl.signalChan <- "close"
-	bl.wg.Wait()
-	bl.wg.Add(1)
+	if bl.asynchronous {
+		bl.signalChan <- "close"
+		bl.wg.Wait()
+	} else {
+		bl.flush()
+		for _, l := range bl.outputs {
+			l.Destroy()
+		}
+		bl.outputs = nil
+	}
+	close(bl.msgChan)
+	close(bl.signalChan)
+}
+
+// Reset close all outputs, and set bl.outputs to nil
+func (bl *BeeLogger) Reset() {
+	bl.Flush()
+	for _, l := range bl.outputs {
+		l.Destroy()
+	}
+	bl.outputs = nil
+}
+
+func (bl *BeeLogger) flush() {
+	for {
+		if len(bl.msgChan) > 0 {
+			bm := <-bl.msgChan
+			bl.writeToLoggers(bm.when, bm.msg, bm.level)
+			logMsgPool.Put(bm)
+			continue
+		}
+		break
+	}
+	for _, l := range bl.outputs {
+		l.Flush()
+	}
 }
 
 func formatLogTime(when time.Time) string {


### PR DESCRIPTION
In the Async mode, calling the `func (bl *BeeLogger) Flush() ` or `func (bl *BeeLogger) Close()`, sometimes some log message may be discard, or the order of log may be wrong. Please see the example:

```go
package main

import (
	"github.com/astaxie/beego/logs"
)

var log *logs.BeeLogger

func init() {
	log = logs.NewLogger(10000)
	log.SetLogger("console", `{"level": 10}`)
	log.SetLevel(logs.LevelDebug)
	log.EnableFuncCallDepth(true)
	log.SetLogFuncCallDepth(3)
	log.Async()
}

func main() {
	log.Debug("1 log message")
	log.Debug("2 log message")
	log.Debug("3 log message")
	log.Debug("4 log message")
	log.Debug("5 log message")

	log.Close()
}
```

the output:

![image](https://cloud.githubusercontent.com/assets/834231/12646495/6ec57df4-c60b-11e5-9f3e-ef84a040b221.png)

you can see that first three times  the second log has been discard