### PR TITLE
Set it to 0 afterwards to prevent "multiple response.WriteHeader calls"

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -187,9 +187,13 @@ func (w *Response) Write(p []byte) (int, error) {
 // WriteHeader sends an HTTP response header with status code,
 // and sets `started` to true.
 func (w *Response) WriteHeader(code int) {
-	w.Status = code
-	w.Started = true
-	w.ResponseWriter.WriteHeader(code)
+	// Write status code if it has been set manually
+	// Set it to 0 afterwards to prevent "multiple response.WriteHeader calls"
+	if w.Status == 0 {
+		w.Status = code
+		w.Started = true
+		w.ResponseWriter.WriteHeader(code)
+	}
 }
 
 // Hijack hijacker for http


### PR DESCRIPTION
I rewrite error404 in my ErrorController,in ErrorControll I call ServerJSON(), Then It's responsed "http: multiple response.WriteHeader calls"

![image](https://cloud.githubusercontent.com/assets/546452/12919249/373ea3ca-cf7e-11e5-9b66-fd2dff780a40.png)
