### PR TITLE
fix #1669 and return IO error

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,10 +16,6 @@ package beego
 
 import (
 	"fmt"
-<<<<<<< HEAD
-	"html/template"
-=======
->>>>>>> astaxie/develop
 	"os"
 	"path/filepath"
 	"strings"

--- a/config.go
+++ b/config.go
@@ -15,11 +15,11 @@
 package beego
 
 import (
+	"fmt"
 	"html/template"
 	"os"
 	"path/filepath"
 	"strings"
-	"fmt"
 
 	"github.com/astaxie/beego/config"
 	"github.com/astaxie/beego/session"

--- a/context/context.go
+++ b/context/context.go
@@ -24,11 +24,13 @@ package context
 
 import (
 	"bufio"
+	"bytes"
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
@@ -182,6 +184,14 @@ type Response struct {
 func (w *Response) Write(p []byte) (int, error) {
 	w.Started = true
 	return w.ResponseWriter.Write(p)
+}
+
+// Write writes the data to the connection as part of an HTTP reply,
+// and sets `started` to true.
+// started means the response has sent out.
+func (w *Response) Copy(buf *bytes.Buffer) (int64, error) {
+	w.Started = true
+	return io.Copy(w.ResponseWriter, buf)
 }
 
 // WriteHeader sends an HTTP response header with status code,

--- a/context/output.go
+++ b/context/output.go
@@ -56,7 +56,7 @@ func (output *BeegoOutput) Header(key, val string) {
 // Body sets response body content.
 // if EnableGzip, compress content string.
 // it sends out response body directly.
-func (output *BeegoOutput) Body(content []byte) {
+func (output *BeegoOutput) Body(content []byte) error {
 	var encoding string
 	var buf = &bytes.Buffer{}
 	if output.EnableGzip {
@@ -74,7 +74,8 @@ func (output *BeegoOutput) Body(content []byte) {
 		output.Status = 0
 	}
 
-	output.Context.ResponseWriter.Copy(buf)
+	_, err := output.Context.ResponseWriter.Copy(buf)
+	return err
 }
 
 // Cookie sets cookie value via given key.
@@ -185,8 +186,7 @@ func (output *BeegoOutput) JSON(data interface{}, hasIndent bool, coding bool) e
 	if coding {
 		content = []byte(stringsToJSON(string(content)))
 	}
-	output.Body(content)
-	return nil
+	return output.Body(content)
 }
 
 // JSONP writes jsonp to response body.
@@ -211,8 +211,7 @@ func (output *BeegoOutput) JSONP(data interface{}, hasIndent bool) error {
 	callbackContent.WriteString("(")
 	callbackContent.Write(content)
 	callbackContent.WriteString(");\r\n")
-	output.Body(callbackContent.Bytes())
-	return nil
+	return output.Body(callbackContent.Bytes())
 }
 
 // XML writes xml string to response body.
@@ -229,8 +228,7 @@ func (output *BeegoOutput) XML(data interface{}, hasIndent bool) error {
 		http.Error(output.Context.ResponseWriter, err.Error(), http.StatusInternalServerError)
 		return err
 	}
-	output.Body(content)
-	return nil
+	return output.Body(content)
 }
 
 // Download forces response for download file.

--- a/context/output.go
+++ b/context/output.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
-	"io"
 	"mime"
 	"net/http"
 	"path/filepath"
@@ -75,7 +74,7 @@ func (output *BeegoOutput) Body(content []byte) {
 		output.Status = 0
 	}
 
-	io.Copy(output.Context.ResponseWriter, buf)
+	output.Context.ResponseWriter.Copy(buf)
 }
 
 // Cookie sets cookie value via given key.

--- a/controller.go
+++ b/controller.go
@@ -185,8 +185,7 @@ func (c *Controller) Render() error {
 		return err
 	}
 	c.Ctx.Output.Header("Content-Type", "text/html; charset=utf-8")
-	c.Ctx.Output.Body(rb)
-	return nil
+	return c.Ctx.Output.Body(rb)
 }
 
 // RenderString returns the rendered template string. Do not send out response.

--- a/router_test.go
+++ b/router_test.go
@@ -65,6 +65,11 @@ func (tc *TestController) GetManyRouter() {
 	tc.Ctx.WriteString(tc.Ctx.Input.Query(":id") + tc.Ctx.Input.Query(":page"))
 }
 
+func (tc *TestController) GetEmptyBody() {
+	var res []byte
+	tc.Ctx.Output.Body(res)
+}
+
 type ResStatus struct {
 	Code int
 	Msg  string
@@ -236,6 +241,21 @@ func TestManyRoute(t *testing.T) {
 
 	if body != "3212" {
 		t.Errorf("url param set to [%s];", body)
+	}
+}
+
+// Test for issue #1669
+func TestEmptyResponse(t *testing.T) {
+
+	r, _ := http.NewRequest("GET", "/beego-empty.html", nil)
+	w := httptest.NewRecorder()
+
+	handler := NewControllerRegister()
+	handler.Add("/beego-empty.html", &TestController{}, "get:GetEmptyBody")
+	handler.ServeHTTP(w, r)
+
+	if body := w.Body.String(); body != "" {
+		t.Error("want empty body")
 	}
 }
 

--- a/staticfile_test.go
+++ b/staticfile_test.go
@@ -7,8 +7,8 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"testing"
 	"path/filepath"
+	"testing"
 )
 
 var currentWorkDir, _ = os.Getwd()


### PR DESCRIPTION
1. fix #1669 write empty body panic error

    io.copy can't call `writer.Write` when the buffer reader is empty.

2. return write body error	,IO Error should not be abandoned
 
3.  go fmt for other code