### PR TITLE
fixed handle config issue

### DIFF
--- a/config.go
+++ b/config.go
@@ -193,7 +193,9 @@ func init() {
 		return
 	}
 
-	parseConfig(appConfigPath)
+	if err := parseConfig(appConfigPath); err != nil {
+		panic(err)
+	}
 }
 
 // now only support ini, next will support json.

--- a/config/ini.go
+++ b/config/ini.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"path"
 	"strconv"
@@ -134,7 +135,9 @@ func (ini *IniConfig) parseFile(name string) (*IniConfigContainer, error) {
 				}
 				i, err := ini.parseFile(otherfile)
 				if err != nil {
-					return nil, err
+					// ignore error
+					log.Printf("[warn] handle config %q error, %s \n", key, err.Error())
+					continue
 				}
 				for sec, dt := range i.data {
 					if _, ok := cfg.data[sec]; !ok {

--- a/config/ini.go
+++ b/config/ini.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 	"strconv"
@@ -135,9 +134,7 @@ func (ini *IniConfig) parseFile(name string) (*IniConfigContainer, error) {
 				}
 				i, err := ini.parseFile(otherfile)
 				if err != nil {
-					// ignore error
-					log.Printf("[warn] handle config %q error, %s \n", key, err.Error())
-					continue
+					return nil, err
 				}
 				for sec, dt := range i.data {
 					if _, ok := cfg.data[sec]; !ok {


### PR DESCRIPTION
First parse config  error need handle. so need panic error in init application. <del>Then don't end application by include other config handle failure .<del>

current app will stop if include config file not exist , e.g:
```ini
appname = demo
httpport = 8080
runmode = dev

# 不存在的配置文件
include  APPTEST.conf
```