### PR TITLE
Urgent : Correction for cookie in flash usage

### DIFF
--- a/context/output.go
+++ b/context/output.go
@@ -97,9 +97,10 @@ func (output *BeegoOutput) Cookie(name string, value string, others ...interface
 			maxAge = v
 		}
 
-		if maxAge > 0 {
+		switch {
+		case maxAge > 0:
 			fmt.Fprintf(&b, "; Expires=%s; Max-Age=%d", time.Now().Add(time.Duration(maxAge)*time.Second).UTC().Format(time.RFC1123), maxAge)
-		} else {
+		case maxAge == 0:
 			fmt.Fprintf(&b, "; Max-Age=0")
 		}
 	}

--- a/flash.go
+++ b/flash.go
@@ -85,7 +85,7 @@ func (fd *FlashData) Store(c *Controller) {
 	for key, value := range fd.Data {
 		flashValue += "\x00" + key + "\x23" + BConfig.WebConfig.FlashSeparator + "\x23" + value + "\x00"
 	}
-	c.Ctx.SetCookie(BConfig.WebConfig.FlashName, url.QueryEscape(flashValue), 0, "/")
+	c.Ctx.SetCookie(BConfig.WebConfig.FlashName, url.QueryEscape(flashValue), -1, "/")
 }
 
 // ReadFromRequest parsed flash data from encoded values in cookie.
@@ -103,7 +103,7 @@ func ReadFromRequest(c *Controller) *FlashData {
 			}
 		}
 		//read one time then delete it
-		c.Ctx.SetCookie(BConfig.WebConfig.FlashName, "", -1, "/")
+		c.Ctx.SetCookie(BConfig.WebConfig.FlashName, "", 0, "/")
 	}
 	c.Data["flash"] = flash.Data
 	return flash


### PR DESCRIPTION
Please ignore [Pull 1644](https://github.com/astaxie/beego/pull/1644). To fix cookie max-age problem for flash message, use this pull request for more sustainability.

**Explaination** :
Old function Cookie() in context/output.go don't use Max-Age when param set to 0 :
```
        switch v := others[0].(type) {
            case int:
            if v > 0 {
                fmt.Fprintf(&b, "; Expires=%s; Max-Age=%d", time.Now().Add(time.Duration(v) * time.Second).UTC().Format(time.RFC1123), v)
            } else if v < 0 {
                fmt.Fprintf(&b, "; Max-Age=0")
            }
            case int64:
            if v > 0 {
                fmt.Fprintf(&b, "; Expires=%s; Max-Age=%d", time.Now().Add(time.Duration(v) * time.Second).UTC().Format(time.RFC1123), v)
            } else if v < 0 {
                fmt.Fprintf(&b, "; Max-Age=0")
            }
            case int32:
            if v > 0 {
                fmt.Fprintf(&b, "; Expires=%s; Max-Age=%d", time.Now().Add(time.Duration(v) * time.Second).UTC().Format(time.RFC1123), v)
            } else if v < 0 {
                fmt.Fprintf(&b, "; Max-Age=0")
            }
        }
```

And old function Store() in flash.go :
`c.Ctx.SetCookie(FlashName, url.QueryEscape(flashValue), 0, "/")`
