### PR TITLE
fix issue #1598

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -286,7 +286,6 @@ func (c *Controller) Abort(code string) {
 
 // CustomAbort stops controller handler and show the error data, it's similar Aborts, but support status code and body.
 func (c *Controller) CustomAbort(status int, body string) {
-	c.Ctx.ResponseWriter.WriteHeader(status)
 	// first panic from ErrorMaps, is is user defined error functions.
 	if _, ok := ErrorMaps[body]; ok {
 		panic(body)


### PR DESCRIPTION
If there was an ```ErrorController``` set to beego, calling ```Controller.Abort()``` would cause ```http: multiple response.WriteHeader calls``` since that another ```WriteHeader``` will be called before ```ControllerRegister.ServeHTTP()``` function return.

The 1st ```WriteHeader``` in ```Controller.CustomAbort()``` is redundant.