### PR TITLE
New logs adaptor which supports writing to multiple files

### DIFF
--- a/logs/multi_file.go
+++ b/logs/multi_file.go
@@ -1,0 +1,129 @@
+package logs
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type multiFileLogWriter struct {
+	Maxlines int `json:"maxlines"`
+	// Rotate at size
+	Maxsize int `json:"maxsize"`
+	// Rotate daily
+	Daily   bool  `json:"daily"`
+	Maxdays int64 `json:"maxdays"`
+
+	Rotate    bool   `json:"rotate"`
+	Level     int    `json:"level"`
+	LevelName string `json:"levelname"`
+
+	LevelFiles []*struct {
+		LevelNames []string `json:"levelnames"`
+		Levels     []int
+		FileName   string `json:"filename"`
+	} `json:"levelfiles"`
+
+	levelLoggerMap map[int]Logger
+}
+
+func NewMultiFileLogWriter() Logger {
+	return &multiFileLogWriter{
+		Maxlines: 1000000,
+		Maxsize:  1 << 28, //256 MB
+		Daily:    true,
+		Maxdays:  7,
+		Rotate:   true,
+		Level:    LevelTrace,
+
+		levelLoggerMap: make(map[int]Logger),
+	}
+}
+
+func (w *multiFileLogWriter) Init(jsonconfig string) error {
+	err := json.Unmarshal([]byte(jsonconfig), w)
+	if err != nil {
+		return err
+	}
+	if len(w.LevelName) > 0 {
+		tmp, err := logLevelName2Int(w.LevelName)
+		if err == nil {
+			w.Level = tmp
+		}
+	}
+	if len(w.LevelFiles) == 0 {
+		return fmt.Errorf("levelfiles is empty")
+	}
+	for _, l := range w.LevelFiles {
+		if len(l.FileName) == 0 {
+			return fmt.Errorf("filename in levelfiles is empty")
+		}
+		if len(l.LevelNames) == 0 {
+			return fmt.Errorf("levelnames for file[%s] is empty", l.FileName)
+		}
+		l.Levels = make([]int, 0, len(l.LevelNames))
+		for _, levelName := range l.LevelNames {
+			level, err := logLevelName2Int(levelName)
+			if err != nil {
+				return err
+			}
+			l.Levels = append(l.Levels, level)
+		}
+	}
+
+	w.initInnerLoggers()
+
+	return nil
+}
+
+func (w *multiFileLogWriter) initInnerLoggers() error {
+	for _, l := range w.LevelFiles {
+		config := fmt.Sprintf(`
+		{
+			"filename": "%s",
+			"maxlines": %d,
+			"maxsize": %d,
+			"daily": %v,
+			"maxdays": %d,
+			"rotate": %v,
+			"level": %d
+		}
+		`, l.FileName, w.Maxlines, w.Maxsize, w.Daily, w.Maxdays, w.Rotate, LevelDebug /*use highest log level*/)
+		innerLogger := newFileWriter()
+		err := innerLogger.Init(config)
+		if err != nil {
+			return err
+		}
+		for _, level := range l.Levels {
+			w.levelLoggerMap[level] = innerLogger
+		}
+	}
+
+	return nil
+}
+
+func (w *multiFileLogWriter) WriteMsg(msg string, level int) error {
+	if level > w.Level {
+		return nil
+	}
+	logger, exist := w.levelLoggerMap[level]
+	if !exist {
+		return nil
+	}
+	return logger.WriteMsg(msg, level)
+}
+
+func (w *multiFileLogWriter) Destroy() {
+	for _, logger := range w.levelLoggerMap {
+		logger.Destroy()
+	}
+}
+
+func (w *multiFileLogWriter) Flush() {
+	for _, logger := range w.levelLoggerMap {
+		logger.Flush()
+	}
+}
+
+func init() {
+	Register("multi_file", NewMultiFileLogWriter)
+}

--- a/logs/multi_file.go
+++ b/logs/multi_file.go
@@ -1,3 +1,17 @@
+// Copyright 2014 beego Author. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package logs
 
 import (
@@ -5,6 +19,9 @@ import (
 	"fmt"
 )
 
+// multiFileLogWriter implements LoggerInterface.
+// It wraps fileLogWriter, supporting to write to different files according
+// to different log levels
 type multiFileLogWriter struct {
 	Maxlines int `json:"maxlines"`
 	// Rotate at size
@@ -13,8 +30,9 @@ type multiFileLogWriter struct {
 	Daily   bool  `json:"daily"`
 	Maxdays int64 `json:"maxdays"`
 
-	Rotate    bool   `json:"rotate"`
-	Level     int    `json:"level"`
+	Rotate bool `json:"rotate"`
+	Level  int  `json:"level"`
+	// Support level name instead of level integer
 	LevelName string `json:"levelname"`
 
 	LevelFiles []*struct {
@@ -47,6 +65,7 @@ func (w *multiFileLogWriter) Init(jsonconfig string) error {
 	if len(w.LevelName) > 0 {
 		tmp, err := logLevelName2Int(w.LevelName)
 		if err == nil {
+			// overwrite previous level
 			w.Level = tmp
 		}
 	}
@@ -77,6 +96,7 @@ func (w *multiFileLogWriter) Init(jsonconfig string) error {
 
 func (w *multiFileLogWriter) initInnerLoggers() error {
 	for _, l := range w.LevelFiles {
+		// use fileLogWriter config format
 		config := fmt.Sprintf(`
 		{
 			"filename": "%s",

--- a/logs/multi_file_test.go
+++ b/logs/multi_file_test.go
@@ -1,0 +1,154 @@
+package logs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestMultiFile1(t *testing.T) {
+	log := NewLogger(10000)
+	err := log.SetLogger("multi_file", `{}`)
+	if err == nil {
+		t.Fatal("shoud have err")
+	}
+}
+
+func TestMultiFile2(t *testing.T) {
+	debugFileName := "test_file2.debug.log"
+	os.Remove(debugFileName)
+	defer os.Remove(debugFileName)
+
+	log := NewLogger(10000)
+	err := log.SetLogger("multi_file", fmt.Sprintf(
+		`{
+			"levelfiles": [{
+				"levelnames": ["debug"],
+				"filename": "%s"
+			}]
+		}`, debugFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	log.Debug("debug msg")
+	b, err := hasContent(debugFileName)
+	if !b || err != nil {
+		t.Fatalf("log file[%s] doesn't exist", debugFileName)
+	}
+}
+
+func TestMultiFile3(t *testing.T) {
+	debugFileName := "test_file3.debug.log"
+	infoFileName := "test_file3.info.log"
+	os.Remove(debugFileName)
+	os.Remove(infoFileName)
+	defer os.Remove(debugFileName)
+	defer os.Remove(infoFileName)
+
+	log := NewLogger(10000)
+	err := log.SetLogger("multi_file", fmt.Sprintf(
+		`{
+			"levelfiles": [{
+				"levelnames": ["debug", "trace"],
+				"filename": "%s"
+			},{
+				"levelnames": ["info"],
+				"filename": "%s"
+			}]
+		}`, debugFileName, infoFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	log.Debug("debug msg")
+	log.Trace("trace msg")
+	{
+		b, err := hasContent(debugFileName)
+		if !b || err != nil {
+			t.Fatalf("log file[%s] doesn't exist", debugFileName)
+		}
+	}
+	{
+		lineNum, err := getFileLineNum(debugFileName)
+		if err != nil {
+			t.Fatalf("log file[%s] get lines err: %v", debugFileName, err)
+		}
+		if lineNum != 2 {
+			t.Fatalf("log file[%s] line number[%d] should be 2", debugFileName, lineNum)
+		}
+	}
+
+	log.Info("info msg")
+	{
+		b, err := hasContent(infoFileName)
+		if !b || err != nil {
+			t.Fatalf("log file[%s] doesn't exist", infoFileName)
+		}
+	}
+}
+
+func TestMultiFile4(t *testing.T) {
+	debugFileName := "test_file4.debug.log"
+	infoFileName := "test_file4.info.log"
+	os.Remove(debugFileName)
+	os.Remove(infoFileName)
+	defer os.Remove(debugFileName)
+	defer os.Remove(infoFileName)
+
+	log := NewLogger(10000)
+	err := log.SetLogger("multi_file", fmt.Sprintf(
+		`{
+			"levelname": "info",
+			"levelfiles": [{
+				"levelnames": ["debug"],
+				"filename": "%s"
+			},{
+				"levelnames": ["info"],
+				"filename": "%s"
+			}]
+		}`, debugFileName, infoFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	log.Debug("debug msg")
+	{
+		b, err := hasContent(debugFileName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if b {
+			t.Fatalf("log file[%s] should not have content", debugFileName)
+		}
+	}
+
+	log.Info("info msg")
+	{
+		b, err := hasContent(infoFileName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !b {
+			t.Fatalf("log file[%s] should have content", infoFileName)
+		}
+	}
+}
+
+func hasContent(path string) (bool, error) {
+	contentBytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	return len(contentBytes) > 0, nil
+}
+
+func getFileLineNum(path string) (int, error) {
+	contentBytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	return len(strings.Split(string(contentBytes), "\n")) - 1, nil
+}

--- a/logs/util.go
+++ b/logs/util.go
@@ -1,0 +1,36 @@
+package logs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/astaxie/beego/logs"
+)
+
+func logLevelName2Int(levelName string) (logLevel int, err error) {
+
+	switch strings.ToLower(levelName) {
+	case "emergency":
+		logLevel = logs.LevelEmergency
+	case "alert":
+		logLevel = logs.LevelAlert
+	case "critical":
+		logLevel = logs.LevelCritical
+	case "error":
+		logLevel = logs.LevelError
+	case "warning", "warn":
+		logLevel = logs.LevelWarning
+	case "notice":
+		logLevel = logs.LevelNotice
+	case "info", "informational":
+		logLevel = logs.LevelInformational
+	case "debug":
+		logLevel = logs.LevelDebug
+	case "trace":
+		logLevel = logs.LevelTrace
+	default:
+		err = fmt.Errorf("level name[%s] is invalid", levelName)
+	}
+
+	return logLevel, err
+}


### PR DESCRIPTION
Add an new beego logs adaptor, which supports writing different files according to different log level in configuration.

Configuration example:

        {  
            "levelfiles": [{
                "levelnames": ["debug", "trace"],
                "filename": "some.log.debug"
            },{
                "levelnames": ["info"],
                "filename": "some.log"
            },{
                "levelnames": ["warning", "critical"],
                "filename": "some.log.wf"
            }]
        }
