### PR TITLE
prevent multiple response.WriteHeader calls

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -187,6 +187,10 @@ func (w *Response) Write(p []byte) (int, error) {
 // WriteHeader sends an HTTP response header with status code,
 // and sets `started` to true.
 func (w *Response) WriteHeader(code int) {
+	if w.Status > 0 {
+		//prevent multiple response.WriteHeader calls
+		return
+	}
 	w.Status = code
 	w.Started = true
 	w.ResponseWriter.WriteHeader(code)

--- a/router.go
+++ b/router.go
@@ -607,14 +607,19 @@ func (p *ControllerRegister) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 	)
 	context := p.pool.Get().(*beecontext.Context)
 	context.Reset(rw, r)
-	defer p.pool.Put(context)
-	defer p.recoverPanic(context)
+
+	defer func(){
+		p.recoverPanic(context)
+		p.pool.Put(context)
+	}()
 
 	context.Output.EnableGzip = BConfig.EnableGzip
 
 	if BConfig.RunMode == DEV {
 		context.Output.Header("Server", BConfig.ServerName)
 	}
+
+	context.Output.Header("Content-Type", "text/html; charset=utf-8")
 
 	var urlPath string
 	if !BConfig.RouterCaseSensitive {


### PR DESCRIPTION
sync.Pool will gc the objects in the pool and defer is fifo,so if put p.pool.Put before recoverPanic ,the context may by gc-ed and not exists when recover happens


Bug fixed at https://github.com/astaxie/beego/issues/1693

