### PR TITLE
自定义log输出支持

### DIFF
--- a/logs/log.go
+++ b/logs/log.go
@@ -44,7 +44,8 @@ import (
 
 // RFC5424 log message levels.
 const (
-	LevelEmergency = iota
+	LevelCustom = iota // for custom
+	LevelEmergency
 	LevelAlert
 	LevelCritical
 	LevelError
@@ -52,6 +53,8 @@ const (
 	LevelNotice
 	LevelInformational
 	LevelDebug
+	CallDepthForCustom     = 1 // callDepth for custom
+	DefultLogFuncCallDepth = 2 // default callDepth
 )
 
 // Legacy loglevel constants to ensure backwards compatibility.
@@ -118,7 +121,7 @@ var logMsgPool *sync.Pool
 func NewLogger(channelLen int64) *BeeLogger {
 	bl := new(BeeLogger)
 	bl.level = LevelDebug
-	bl.loggerFuncCallDepth = 2
+	bl.loggerFuncCallDepth = DefultCallDepth
 	bl.msgChan = make(chan *logMsg, channelLen)
 	return bl
 }
@@ -183,8 +186,13 @@ func (bl *BeeLogger) writeToLoggers(msg string, level int) {
 }
 
 func (bl *BeeLogger) writeMsg(logLevel int, msg string) error {
-	if bl.enableFuncCallDepth {
-		_, file, line, ok := runtime.Caller(bl.loggerFuncCallDepth)
+	return bl.WriteMsg(bl.enableFuncCallDepth, bl.loggerFuncCallDepth+1, logLevel, msg)
+}
+
+//The custom to writeMsg
+func (bl *BeeLogger) WriteMsg(enableFuncCallDepth bool, loggerFuncCallDepth int, logLevel int, msg string) error {
+	if enableFuncCallDepth {
+		_, file, line, ok := runtime.Caller(loggerFuncCallDepth)
 		if !ok {
 			file = "???"
 			line = 0

--- a/logs/log.go
+++ b/logs/log.go
@@ -121,7 +121,7 @@ var logMsgPool *sync.Pool
 func NewLogger(channelLen int64) *BeeLogger {
 	bl := new(BeeLogger)
 	bl.level = LevelDebug
-	bl.loggerFuncCallDepth = DefultCallDepth
+	bl.loggerFuncCallDepth = DefultLogFuncCallDepth
 	bl.msgChan = make(chan *logMsg, channelLen)
 	return bl
 }


### PR DESCRIPTION
1.添加LevelCustom作为用户自定义Log输出级别，传入此级别都打印输出，级别过滤用户自己处理
2.添加WriteMsg提供给用户自定义Log输出(动态传入callDepth) 
例：自己输入callDepth为default就Ok，但还用到了mgo，它的loginterface有callDepth参数，这时全局设置会有问题
3.添加常量CallDepthForCustom,DefultCallDepth --用户可以基于它高度定制化log输出
CallDepthForCustom是自定义时的CallDepth与用户自己的相加就ok
DefultCallDepth ：用户使用此常量与自身程序callDepth相加，好处多多

以上