### PR TITLE
fix bug: session id undecoded when destroy and sesssion memory provider push wrong

### DIFF
--- a/session/sess_mem.go
+++ b/session/sess_mem.go
@@ -102,7 +102,6 @@ func (pder *MemProvider) SessionRead(sid string) (Store, error) {
 	pder.lock.RUnlock()
 	pder.lock.Lock()
 	newsess := &MemSessionStore{sid: sid, timeAccessed: time.Now(), value: make(map[interface{}]interface{})}
-	// fix bug: new session should be pushed into the head of list(more fresh)
 	element := pder.list.PushFront(newsess)
 	pder.sessions[sid] = element
 	pder.lock.Unlock()
@@ -135,7 +134,6 @@ func (pder *MemProvider) SessionRegenerate(oldsid, sid string) (Store, error) {
 	pder.lock.RUnlock()
 	pder.lock.Lock()
 	newsess := &MemSessionStore{sid: sid, timeAccessed: time.Now(), value: make(map[interface{}]interface{})}
-	// fix bug: new session should be pushed into the head of list(more fresh)
 	element := pder.list.PushFront(newsess)
 	pder.sessions[sid] = element
 	pder.lock.Unlock()

--- a/session/sess_mem.go
+++ b/session/sess_mem.go
@@ -102,7 +102,8 @@ func (pder *MemProvider) SessionRead(sid string) (Store, error) {
 	pder.lock.RUnlock()
 	pder.lock.Lock()
 	newsess := &MemSessionStore{sid: sid, timeAccessed: time.Now(), value: make(map[interface{}]interface{})}
-	element := pder.list.PushBack(newsess)
+	// fix bug: new session should be pushed into the head of list(more fresh)
+	element := pder.list.PushFront(newsess)
 	pder.sessions[sid] = element
 	pder.lock.Unlock()
 	return newsess, nil
@@ -134,7 +135,8 @@ func (pder *MemProvider) SessionRegenerate(oldsid, sid string) (Store, error) {
 	pder.lock.RUnlock()
 	pder.lock.Lock()
 	newsess := &MemSessionStore{sid: sid, timeAccessed: time.Now(), value: make(map[interface{}]interface{})}
-	element := pder.list.PushBack(newsess)
+	// fix bug: new session should be pushed into the head of list(more fresh)
+	element := pder.list.PushFront(newsess)
 	pder.sessions[sid] = element
 	pder.lock.Unlock()
 	return newsess, nil

--- a/session/session.go
+++ b/session/session.go
@@ -201,7 +201,7 @@ func (manager *Manager) SessionDestroy(w http.ResponseWriter, r *http.Request) {
 	if err != nil || cookie.Value == "" {
 		return
 	}
-	// fix bug: cookie.Value has been urlencoded, so should be decoded here
+
 	sid, _ := url.QueryUnescape(cookie.Value)
 	manager.provider.SessionDestroy(sid)
 	if manager.config.EnableSetCookie {

--- a/session/session.go
+++ b/session/session.go
@@ -201,7 +201,9 @@ func (manager *Manager) SessionDestroy(w http.ResponseWriter, r *http.Request) {
 	if err != nil || cookie.Value == "" {
 		return
 	}
-	manager.provider.SessionDestroy(cookie.Value)
+	// fix bug: cookie.Value has been urlencoded, so should be decoded here
+	sid, _ := url.QueryUnescape(cookie.Value)
+	manager.provider.SessionDestroy(sid)
 	if manager.config.EnableSetCookie {
 		expiration := time.Now()
 		cookie = &http.Cookie{Name: manager.config.CookieName,


### PR DESCRIPTION
1. session id undecoded when destroy.
2. sesssion memory provider push wrong.