### PR TITLE
fix static pattern match for leaf

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -389,7 +389,7 @@ type leafInfo struct {
 func (leaf *leafInfo) match(wildcardValues []string, ctx *context.Context) (ok bool) {
 	//fmt.Println("Leaf:", wildcardValues, leaf.wildcards, leaf.regexps)
 	if leaf.regexps == nil {
-		if len(wildcardValues) == 0 { // static path
+		if len(wildcardValues) == 0 && len(leaf.wildcards) == 0 { // static path
 			return true
 		}
 		// match *

--- a/tree_test.go
+++ b/tree_test.go
@@ -97,6 +97,21 @@ func TestTreeRouters(t *testing.T) {
 	}
 }
 
+func TestStaticPath(t *testing.T) {
+	tr := NewTree()
+	tr.AddRouter("/topic/:id", "wildcard")
+	tr.AddRouter("/topic", "static")
+	ctx := context.NewContext()
+	obj := tr.Match("/topic", ctx)
+	if obj == nil || obj.(string) != "static" {
+		t.Fatal("/topic is  a static route")
+	}
+	obj = tr.Match("/topic/1", ctx)
+	if obj == nil || obj.(string) != "wildcard" {
+		t.Fatal("/topic/1 is a wildcard route")
+	}
+}
+
 func TestAddTree(t *testing.T) {
 	tr := NewTree()
 	tr.AddRouter("/shop/:id/account", "astaxie")


### PR DESCRIPTION
修复/topic 被错误匹配到 『/topic/:id』 的 handler 的问题
