### PR TITLE
fix issue#1787: if `/m` is a static path mapping to a static dir，and we set `beego.BConfig.WebConfig.DirectoryIndex = true`, then it should redirect to `/m/`

### DIFF
--- a/staticfile.go
+++ b/staticfile.go
@@ -54,8 +54,13 @@ func serverStaticRouter(ctx *context.Context) {
 		return
 	}
 	if fileInfo.IsDir() {
-		//serveFile will list dir
-		http.ServeFile(ctx.ResponseWriter, ctx.Request, filePath)
+		requestURL := ctx.Input.URL()
+		if requestURL[len(requestURL)-1] != '/' {
+			ctx.Redirect(302, requestURL+"/")
+		} else {
+			//serveFile will list dir
+			http.ServeFile(ctx.ResponseWriter, ctx.Request, filePath)
+		}
 		return
 	}
 


### PR DESCRIPTION
R.T.

fix issue #1787