### PR TITLE
Router Filter Improve

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -196,7 +196,7 @@ func listConf(rw http.ResponseWriter, r *http.Request) {
 				BeforeExec:   "Before Exec",
 				AfterExec:    "After Exec",
 				FinishRouter: "Finish Router"} {
-				if bf, ok := BeeApp.Handlers.filters[k]; ok {
+				if bf := BeeApp.Handlers.filters[k]; len(bf) > 0 {
 					filterType = fr
 					filterTypes = append(filterTypes, filterType)
 					resultList := new([][]string)

--- a/namespace.go
+++ b/namespace.go
@@ -44,7 +44,7 @@ func NewNamespace(prefix string, params ...LinkNamespace) *Namespace {
 	return ns
 }
 
-// Cond set condtion function
+// Cond set condition function
 // if cond return true can run this namespace, else can't
 // usage:
 // ns.Cond(func (ctx *context.Context) bool{
@@ -60,7 +60,7 @@ func (n *Namespace) Cond(cond namespaceCond) *Namespace {
 			exception("405", ctx)
 		}
 	}
-	if v, ok := n.handlers.filters[BeforeRouter]; ok {
+	if v := n.handlers.filters[BeforeRouter]; len(v) > 0 {
 		mr := new(FilterRouter)
 		mr.tree = NewTree()
 		mr.pattern = "*"

--- a/router.go
+++ b/router.go
@@ -115,7 +115,6 @@ type ControllerRegister struct {
 	routers      map[string]*Tree
 	enableFilter bool
 	filters      [FinishRouter + 1][]*FilterRouter
-	filterFlag   [FinishRouter + 1]bool
 	pool         sync.Pool
 }
 
@@ -431,7 +430,6 @@ func (p *ControllerRegister) insertFilterRouter(pos int, mr *FilterRouter) (err 
 		return
 	}
 	p.enableFilter = true
-	p.filterFlag[pos] = true
 	p.filters[pos] = append(p.filters[pos], mr)
 	return nil
 }
@@ -630,7 +628,7 @@ func (p *ControllerRegister) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 	}
 
 	// filter for static file
-	if p.filterFlag[BeforeStatic] && p.execFilter(context, urlPath, BeforeStatic) {
+	if len(p.filters[BeforeStatic]) > 0 && p.execFilter(context, urlPath, BeforeStatic) {
 		goto Admin
 	}
 
@@ -663,7 +661,7 @@ func (p *ControllerRegister) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 			}
 		}()
 	}
-	if p.filterFlag[BeforeRouter] && p.execFilter(context, urlPath, BeforeRouter) {
+	if len(p.filters[BeforeRouter]) > 0 && p.execFilter(context, urlPath, BeforeRouter) {
 		goto Admin
 	}
 
@@ -692,7 +690,7 @@ func (p *ControllerRegister) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 
 	if findRouter {
 		//execute middleware filters
-		if p.filterFlag[BeforeExec] && p.execFilter(context, urlPath, BeforeExec) {
+		if len(p.filters[BeforeExec]) > 0 && p.execFilter(context, urlPath, BeforeExec) {
 			goto Admin
 		}
 		isRunnable := false
@@ -793,11 +791,11 @@ func (p *ControllerRegister) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 		}
 
 		//execute middleware filters
-		if p.filterFlag[AfterExec] && p.execFilter(context, urlPath, AfterExec) {
+		if len(p.filters[AfterExec]) > 0 && p.execFilter(context, urlPath, AfterExec) {
 			goto Admin
 		}
 	}
-	if p.filterFlag[FinishRouter] && p.execFilter(context, urlPath, FinishRouter) {
+	if len(p.filters[FinishRouter]) > 0 && p.execFilter(context, urlPath, FinishRouter) {
 		goto Admin
 	}
 

--- a/router.go
+++ b/router.go
@@ -618,7 +618,7 @@ func (p *ControllerRegister) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 	var urlPath = r.URL.Path
 
 	if !BConfig.RouterCaseSensitive {
-		urlPath = strings.ToLower(r.URL.Path)
+		urlPath = strings.ToLower(urlPath)
 	}
 
 	// filter wrong http method

--- a/router.go
+++ b/router.go
@@ -652,7 +652,7 @@ func (p *ControllerRegister) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 		if err != nil {
 			Error(err)
 			exception("503", context)
-			return
+			goto Admin
 		}
 		defer func() {
 			if context.Input.CruSession != nil {


### PR DESCRIPTION
I change the `ControllerRegister.filters` from map to array,which makes filters-access  7.5 times faster than before , I think. Here is test code 

```
package main

import (
	"fmt"
	"time"
)

func main() {
	fm := map[int][]int{
		0: []int{0},
		1: []int{0, 1},
		2: []int{0, 1, 2},
		3: []int{0, 1, 2, 3},
		4: []int{0, 1, 2, 3, 4},
	}
	fi := [5][]int{{0}, {0, 1}, {0, 1, 2}, {0, 1, 2, 3}, {0, 1, 2, 3, 4}}
	max := int(1e7)
	{
		t := time.Now()
		for i := 0; i < max; i++ {
			for l := 0; l < 5; l++ {
				if _, ok := fm[l]; ok {
				}
			}
		}
		fmt.Println(time.Now().UnixNano() - t.UnixNano())
	}
	{
		t := time.Now()
		for i := 0; i < max; i++ {
			for l := 0; l < 5; l++ {
				if len(fi[l]) > 0 {
				}
			}
		}
		fmt.Println(time.Now().UnixNano() - t.UnixNano())
	}
}
```

The result
![image](https://cloud.githubusercontent.com/assets/707691/13775996/9a41d06c-eae2-11e5-8b15-12235f7173ab.png)
