### PR TITLE
fix oracle issue #1800

### DIFF
--- a/orm/orm_raw.go
+++ b/orm/orm_raw.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"reflect"
 	"time"
+    "strings"
 )
 
 // raw sql string prepared statement
@@ -321,7 +322,8 @@ func (o *rawSet) QueryRow(containers ...interface{}) error {
 			refs = make([]interface{}, 0, len(columns))
 			for _, col := range columns {
 				var ref interface{}
-				columnsMp[col] = &ref
+                colName := strings.ToLower(col)
+				columnsMp[colName] = &ref
 				refs = append(refs, &ref)
 			}
 
@@ -453,7 +455,8 @@ func (o *rawSet) QueryRows(containers ...interface{}) (int64, error) {
 			refs = make([]interface{}, 0, len(columns))
 			for _, col := range columns {
 				var ref interface{}
-				columnsMp[col] = &ref
+                colName := strings.ToLower(col)
+				columnsMp[colName] = &ref
 				refs = append(refs, &ref)
 			}
 


### PR DESCRIPTION
oracle查询返回columnName为大写，而snakeString方法返回值为小写，导致columnsMp[col]无法得到响应的值，这里将columnsMp构建时的key改成了小写。