### PR TITLE
To support `go run`

### DIFF
--- a/config.go
+++ b/config.go
@@ -106,6 +106,8 @@ var (
 	AppConfig *beegoAppConfig
 	// AppPath is the absolute path to the app
 	AppPath string
+	// workPath is the absolute path of the current dir
+	workPath string
 	// GlobalSessions is the instance for the session manager
 	GlobalSessions *session.Manager
 
@@ -118,7 +120,8 @@ var (
 func init() {
 	AppPath, _ = filepath.Abs(filepath.Dir(os.Args[0]))
 
-	os.Chdir(AppPath)
+	workPath, _ = os.Getwd()
+	workPath, _ = filepath.Abs(workPath)
 
 	BConfig = &Config{
 		AppName:             "beego",
@@ -180,10 +183,13 @@ func init() {
 		},
 	}
 
-	appConfigPath = filepath.Join(AppPath, "conf", "app.conf")
+	appConfigPath = filepath.Join(workPath, "conf", "app.conf")
 	if !utils.FileExists(appConfigPath) {
-		AppConfig = &beegoAppConfig{innerConfig: config.NewFakeConfig()}
-		return
+		appConfigPath = filepath.Join(AppPath, "conf", "app.conf")
+		if !utils.FileExists(appConfigPath) {
+			AppConfig = &beegoAppConfig{innerConfig: config.NewFakeConfig()}
+			return
+		}
 	}
 
 	if err := parseConfig(appConfigPath); err != nil {

--- a/config.go
+++ b/config.go
@@ -106,8 +106,6 @@ var (
 	AppConfig *beegoAppConfig
 	// AppPath is the absolute path to the app
 	AppPath string
-	// workPath is the absolute path of the current dir
-	workPath string
 	// GlobalSessions is the instance for the session manager
 	GlobalSessions *session.Manager
 
@@ -118,11 +116,6 @@ var (
 )
 
 func init() {
-	AppPath, _ = filepath.Abs(filepath.Dir(os.Args[0]))
-
-	workPath, _ = os.Getwd()
-	workPath, _ = filepath.Abs(workPath)
-
 	BConfig = &Config{
 		AppName:             "beego",
 		RunMode:             DEV,
@@ -183,6 +176,16 @@ func init() {
 		},
 	}
 
+	var err error
+
+	if AppPath, err = filepath.Abs(filepath.Dir(os.Args[0])); err != nil {
+		panic(err)
+	}
+	workPath, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
 	appConfigPath = filepath.Join(workPath, "conf", "app.conf")
 	if !utils.FileExists(appConfigPath) {
 		appConfigPath = filepath.Join(AppPath, "conf", "app.conf")
@@ -192,7 +195,7 @@ func init() {
 		}
 	}
 
-	if err := parseConfig(appConfigPath); err != nil {
+	if err = parseConfig(appConfigPath); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
After running, beego does not change current dir to `AppPath`, and firstly try to parse config file in `workPath`, then `AppPath`.

When using `go run`, the `AppPath` is a temp dir, under that path, there is no config file.