### PR TITLE
make template execution be expected

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -208,7 +208,7 @@ func (c *Controller) RenderBytes() ([]byte, error) {
 					continue
 				}
 				buf.Reset()
-				err = executeTemplate(&buf, sectionTpl, c.Data)
+				err = ExecuteTemplate(&buf, sectionTpl, c.Data)
 				if err != nil {
 					return nil, err
 				}
@@ -217,7 +217,7 @@ func (c *Controller) RenderBytes() ([]byte, error) {
 		}
 
 		buf.Reset()
-		executeTemplate(&buf, c.Layout, c.Data)
+		ExecuteTemplate(&buf, c.Layout, c.Data)
 	}
 	return buf.Bytes(), err
 }
@@ -242,7 +242,7 @@ func (c *Controller) renderTemplate() (bytes.Buffer, error) {
 		}
 		BuildTemplate(BConfig.WebConfig.ViewsPath, buildFiles...)
 	}
-	return buf, executeTemplate(&buf, c.TplName, c.Data)
+	return buf, ExecuteTemplate(&buf, c.TplName, c.Data)
 }
 
 // Redirect sends the redirection response to url with status code.

--- a/template.go
+++ b/template.go
@@ -41,7 +41,10 @@ var (
 	beeTemplateEngines = map[string]templateHandler{}
 )
 
-func executeTemplate(wr io.Writer, name string, data interface{}) error {
+// ExecuteTemplate applies the template with name  to the specified data object,
+// writing the output to wr.
+// A template will be executed safely in parallel.
+func ExecuteTemplate(wr io.Writer, name string, data interface{}) error {
 	if BConfig.RunMode == DEV {
 		templatesLock.RLock()
 		defer templatesLock.RUnlock()


### PR DESCRIPTION
ExecuteTemplate applies the template with name  to the specified data object, writing the output to wr.
So beego users can render a template to io.Writer