### PR TITLE
added functionality for column type time

### DIFF
--- a/orm/cmd_utils.go
+++ b/orm/cmd_utils.go
@@ -55,6 +55,8 @@ checkColumn:
 		col = fmt.Sprintf(T["string"], fieldSize)
 	case TypeTextField:
 		col = T["string-text"]
+	case TypeTimeField:
+		col = T["time.Time-clock"]
 	case TypeDateField:
 		col = T["time.Time-date"]
 	case TypeDateTimeField:
@@ -264,7 +266,7 @@ func getColumnDefault(fi *fieldInfo) string {
 
 	// These defaults will be useful if there no config value orm:"default" and NOT NULL is on
 	switch fi.fieldType {
-	case TypeDateField, TypeDateTimeField, TypeTextField:
+	case TypeTimeField, TypeDateField, TypeDateTimeField, TypeTextField:
 		return v
 
 	case TypeBitField, TypeSmallIntegerField, TypeIntegerField,

--- a/orm/db.go
+++ b/orm/db.go
@@ -24,6 +24,7 @@ import (
 )
 
 const (
+	formatTime    = "15:04:05"
 	formatDate     = "2006-01-02"
 	formatDateTime = "2006-01-02 15:04:05"
 )
@@ -175,7 +176,7 @@ func (d *dbBase) collectFieldValue(mi *modelInfo, fi *fieldInfo, ind reflect.Val
 						value = field.Float()
 					}
 				}
-			case TypeDateField, TypeDateTimeField:
+			case TypeTimeField, TypeDateField, TypeDateTimeField:
 				value = field.Interface()
 				if t, ok := value.(time.Time); ok {
 					d.ins.TimeToDB(&t, tz)
@@ -229,7 +230,7 @@ func (d *dbBase) collectFieldValue(mi *modelInfo, fi *fieldInfo, ind reflect.Val
 			}
 		}
 		switch fi.fieldType {
-		case TypeDateField, TypeDateTimeField:
+		case TypeTimeField, TypeDateField, TypeDateTimeField:
 			if fi.autoNow || fi.autoNowAdd && insert {
 				if insert {
 					if t, ok := value.(time.Time); ok && !t.IsZero() {
@@ -1098,7 +1099,7 @@ setValue:
 		} else {
 			value = str.String()
 		}
-	case fieldType == TypeDateField || fieldType == TypeDateTimeField:
+	case fieldType == TypeTimeField || fieldType == TypeDateField || fieldType == TypeDateTimeField:
 		if str == nil {
 			switch t := val.(type) {
 			case time.Time:
@@ -1118,15 +1119,20 @@ setValue:
 			if len(s) >= 19 {
 				s = s[:19]
 				t, err = time.ParseInLocation(formatDateTime, s, tz)
-			} else {
+			} else if len(s) >= 10 {
 				if len(s) > 10 {
 					s = s[:10]
 				}
 				t, err = time.ParseInLocation(formatDate, s, tz)
+			} else if len(s) >= 8 {
+				if len(s) > 8 {
+					s = s[:8]
+				}
+				t, err = time.ParseInLocation(formatTime, s, tz)
 			}
 			t = t.In(DefaultTimeLoc)
 
-			if err != nil && s != "0000-00-00" && s != "0000-00-00 00:00:00" {
+			if err != nil && s != "00:00:00" && s != "0000-00-00" && s != "0000-00-00 00:00:00" {
 				tErr = err
 				goto end
 			}
@@ -1255,7 +1261,7 @@ setValue:
 				field.SetString(value.(string))
 			}
 		}
-	case fieldType == TypeDateField || fieldType == TypeDateTimeField:
+	case fieldType == TypeTimeField || fieldType == TypeDateField || fieldType == TypeDateTimeField:
 		if isNative {
 			if value == nil {
 				value = time.Time{}

--- a/orm/db_utils.go
+++ b/orm/db_utils.go
@@ -74,24 +74,32 @@ outFor:
 		case reflect.String:
 			v := val.String()
 			if fi != nil {
-				if fi.fieldType == TypeDateField || fi.fieldType == TypeDateTimeField {
+				if fi.fieldType == TypeTimeField || fi.fieldType == TypeDateField || fi.fieldType == TypeDateTimeField {
 					var t time.Time
 					var err error
 					if len(v) >= 19 {
 						s := v[:19]
 						t, err = time.ParseInLocation(formatDateTime, s, DefaultTimeLoc)
-					} else {
+					} else if len(v) >= 10 {
 						s := v
 						if len(v) > 10 {
 							s = v[:10]
 						}
 						t, err = time.ParseInLocation(formatDate, s, tz)
+					} else {
+						s := v
+						if len(s) > 8 {
+							s = v[:8]
+						}
+						t, err = time.ParseInLocation(formatTime, s, tz)
 					}
 					if err == nil {
 						if fi.fieldType == TypeDateField {
 							v = t.In(tz).Format(formatDate)
-						} else {
+						} else if fi.fieldType == TypeDateTimeField {
 							v = t.In(tz).Format(formatDateTime)
+						} else {
+							v = t.In(tz).Format(formatTime)
 						}
 					}
 				}
@@ -137,8 +145,10 @@ outFor:
 			if v, ok := arg.(time.Time); ok {
 				if fi != nil && fi.fieldType == TypeDateField {
 					arg = v.In(tz).Format(formatDate)
-				} else {
+				} else if fi.fieldType == TypeDateTimeField {
 					arg = v.In(tz).Format(formatDateTime)
+				} else {
+					arg = v.In(tz).Format(formatTime)
 				}
 			} else {
 				typ := val.Type()

--- a/orm/models_fields.go
+++ b/orm/models_fields.go
@@ -25,6 +25,7 @@ const (
 	TypeBooleanField = 1 << iota
 	TypeCharField
 	TypeTextField
+	TypeTimeField
 	TypeDateField
 	TypeDateTimeField
 	TypeBitField
@@ -144,6 +145,59 @@ func (e *CharField) RawValue() interface{} {
 
 // verify CharField implement Fielder
 var _ Fielder = new(CharField)
+
+// A time, represented in go by a time.Time instance.
+// only date values like 10:00:00
+// Has a few extra, optional attr tag:
+//
+// auto_now:
+// Automatically set the field to now every time the object is saved. Useful for “last-modified” timestamps.
+// Note that the current date is always used; it’s not just a default value that you can override.
+//
+// auto_now_add:
+// Automatically set the field to now when the object is first created. Useful for creation of timestamps.
+// Note that the current date is always used; it’s not just a default value that you can override.
+//
+// eg: `orm:"auto_now"` or `orm:"auto_now_add"`
+type TimeField time.Time
+
+func (e TimeField) Value() time.Time {
+	return time.Time(e)
+}
+
+func (e *TimeField) Set(d time.Time) {
+	*e = TimeField(d)
+}
+
+func (e *TimeField) String() string {
+	return e.Value().String()
+}
+
+func (e *TimeField) FieldType() int {
+	return TypeDateField
+}
+
+func (e *TimeField) SetRaw(value interface{}) error {
+	switch d := value.(type) {
+	case time.Time:
+		e.Set(d)
+	case string:
+		v, err := timeParse(d, formatTime)
+		if err != nil {
+			e.Set(v)
+		}
+		return err
+	default:
+		return fmt.Errorf("<TimeField.SetRaw> unknown value `%s`", value)
+	}
+	return nil
+}
+
+func (e *TimeField) RawValue() interface{} {
+	return e.Value()
+}
+
+var _ Fielder = new(TimeField)
 
 // DateField A date, represented in go by a time.Time instance.
 // only date values like 2006-01-02

--- a/orm/models_info_f.go
+++ b/orm/models_info_f.go
@@ -248,6 +248,9 @@ checkType:
 		if fieldType == TypeDateTimeField && tags["type"] == "date" {
 			fieldType = TypeDateField
 		}
+		if fieldType == TypeTimeField && tags["type"] == "time" {
+			fieldType = TypeTimeField
+		}
 	}
 
 	switch fieldType {
@@ -353,7 +356,7 @@ checkType:
 	case TypeTextField:
 		fi.index = false
 		fi.unique = false
-	case TypeDateField, TypeDateTimeField:
+	case TypeTimeField, TypeDateField, TypeDateTimeField:
 		if attrs["auto_now"] {
 			fi.autoNow = true
 		} else if attrs["auto_now_add"] {
@@ -406,7 +409,7 @@ checkType:
 		fi.index = false
 	}
 
-	if fi.auto || fi.pk || fi.unique || fieldType == TypeDateField || fieldType == TypeDateTimeField {
+	if fi.auto || fi.pk || fi.unique || fieldType == TypeTimeField || fieldType == TypeDateField || fieldType == TypeDateTimeField {
 		// can not set default
 		initial.Clear()
 	}


### PR DESCRIPTION
Here is the original issue https://github.com/astaxie/beego/issues/1547
This enabled the use of the time column type in databases. Tested sqlite3 and mysql below. I don't have a postgres setup.

```
[b055@localhost beego]$ #### Sqlite3
[b055@localhost beego]$ export ORM_DRIVER=sqlite3
[b055@localhost beego]$ export ORM_SOURCE='file:memory_test?mode=memory'
[b055@localhost beego]$ go test -v github.com/astaxie/beego/orm
=== RUN   TestGetDB
--- PASS: TestGetDB (0.00s)
=== RUN   TestSyncDb
--- PASS: TestSyncDb (0.01s)
=== RUN   TestRegisterModels
--- PASS: TestRegisterModels (0.00s)
=== RUN   TestModelSyntax
--- PASS: TestModelSyntax (0.00s)
=== RUN   TestDataTypes
--- PASS: TestDataTypes (0.00s)
=== RUN   TestNullDataTypes
--- PASS: TestNullDataTypes (0.00s)
=== RUN   TestDataCustomTypes
--- PASS: TestDataCustomTypes (0.00s)
=== RUN   TestCRUD
--- PASS: TestCRUD (0.00s)
=== RUN   TestInsertTestData
--- PASS: TestInsertTestData (0.00s)
=== RUN   TestCustomField
--- PASS: TestCustomField (0.00s)
=== RUN   TestExpr
--- PASS: TestExpr (0.00s)
=== RUN   TestOperators
--- PASS: TestOperators (0.00s)
=== RUN   TestSetCond
--- PASS: TestSetCond (0.00s)
=== RUN   TestLimit
--- PASS: TestLimit (0.00s)
=== RUN   TestOffset
--- PASS: TestOffset (0.00s)
=== RUN   TestOrderBy
--- PASS: TestOrderBy (0.00s)
=== RUN   TestAll
--- PASS: TestAll (0.00s)
=== RUN   TestOne
--- PASS: TestOne (0.00s)
=== RUN   TestValues
--- PASS: TestValues (0.00s)
=== RUN   TestValuesList
--- PASS: TestValuesList (0.00s)
=== RUN   TestValuesFlat
--- PASS: TestValuesFlat (0.00s)
=== RUN   TestRelatedSel
--- PASS: TestRelatedSel (0.00s)
=== RUN   TestReverseQuery
--- PASS: TestReverseQuery (0.00s)
=== RUN   TestLoadRelated
--- PASS: TestLoadRelated (0.01s)
=== RUN   TestQueryM2M
--- PASS: TestQueryM2M (0.00s)
=== RUN   TestQueryRelate
--- PASS: TestQueryRelate (0.00s)
=== RUN   TestPkManyRelated
--- PASS: TestPkManyRelated (0.00s)
=== RUN   TestPrepareInsert
--- PASS: TestPrepareInsert (0.00s)
=== RUN   TestRawExec
--- PASS: TestRawExec (0.00s)
=== RUN   TestRawQueryRow
--- PASS: TestRawQueryRow (0.00s)
=== RUN   TestQueryRows
--- PASS: TestQueryRows (0.00s)
=== RUN   TestRawValues
--- PASS: TestRawValues (0.00s)
=== RUN   TestRawPrepare
--- PASS: TestRawPrepare (0.00s)
=== RUN   TestUpdate
--- PASS: TestUpdate (0.00s)
=== RUN   TestDelete
--- PASS: TestDelete (0.00s)
=== RUN   TestTransaction
--- PASS: TestTransaction (0.00s)
=== RUN   TestReadOrCreate
--- PASS: TestReadOrCreate (0.00s)
=== RUN   TestInLine
--- PASS: TestInLine (0.00s)
=== RUN   TestInLineOneToOne
--- PASS: TestInLineOneToOne (0.00s)
=== RUN   TestIntegerPk
--- PASS: TestIntegerPk (0.00s)
=== RUN   TestInsertAuto
--- PASS: TestInsertAuto (0.00s)
=== RUN   TestUintPk
--- PASS: TestUintPk (0.00s)
PASS
ok  	github.com/astaxie/beego/orm	0.056s
[b055@localhost beego]$ #### MySQL
[b055@localhost beego]$ mysql -u root -e 'create database orm_test;'
[b055@localhost beego]$ export ORM_DRIVER=mysql
[b055@localhost beego]$ export ORM_SOURCE="root:@/orm_test?charset=utf8&parseTime=true&loc=UTC"
[b055@localhost beego]$ go test -v github.com/astaxie/beego/orm
=== RUN   TestGetDB
--- PASS: TestGetDB (0.00s)
=== RUN   TestSyncDb
--- PASS: TestSyncDb (1.20s)
=== RUN   TestRegisterModels
--- PASS: TestRegisterModels (0.00s)
=== RUN   TestModelSyntax
--- PASS: TestModelSyntax (0.00s)
=== RUN   TestDataTypes
--- PASS: TestDataTypes (0.01s)
=== RUN   TestNullDataTypes
--- PASS: TestNullDataTypes (0.01s)
=== RUN   TestDataCustomTypes
--- PASS: TestDataCustomTypes (0.00s)
=== RUN   TestCRUD
--- PASS: TestCRUD (0.04s)
=== RUN   TestInsertTestData
--- PASS: TestInsertTestData (0.17s)
=== RUN   TestCustomField
--- PASS: TestCustomField (0.01s)
=== RUN   TestExpr
--- PASS: TestExpr (0.00s)
=== RUN   TestOperators
--- PASS: TestOperators (0.02s)
=== RUN   TestSetCond
--- PASS: TestSetCond (0.00s)
=== RUN   TestLimit
--- PASS: TestLimit (0.00s)
=== RUN   TestOffset
--- PASS: TestOffset (0.00s)
=== RUN   TestOrderBy
--- PASS: TestOrderBy (0.00s)
=== RUN   TestAll
--- PASS: TestAll (0.00s)
=== RUN   TestOne
--- PASS: TestOne (0.00s)
=== RUN   TestValues
--- PASS: TestValues (0.00s)
=== RUN   TestValuesList
--- PASS: TestValuesList (0.00s)
=== RUN   TestValuesFlat
--- PASS: TestValuesFlat (0.00s)
=== RUN   TestRelatedSel
--- PASS: TestRelatedSel (0.01s)
=== RUN   TestReverseQuery
--- PASS: TestReverseQuery (0.01s)
=== RUN   TestLoadRelated
--- PASS: TestLoadRelated (0.02s)
=== RUN   TestQueryM2M
--- PASS: TestQueryM2M (0.61s)
=== RUN   TestQueryRelate
--- PASS: TestQueryRelate (0.00s)
=== RUN   TestPkManyRelated
--- PASS: TestPkManyRelated (0.00s)
=== RUN   TestPrepareInsert
--- PASS: TestPrepareInsert (0.01s)
=== RUN   TestRawExec
--- PASS: TestRawExec (0.01s)
=== RUN   TestRawQueryRow
--- PASS: TestRawQueryRow (0.00s)
=== RUN   TestQueryRows
--- PASS: TestQueryRows (0.00s)
=== RUN   TestRawValues
--- PASS: TestRawValues (0.00s)
=== RUN   TestRawPrepare
--- PASS: TestRawPrepare (0.01s)
=== RUN   TestUpdate
--- PASS: TestUpdate (0.02s)
=== RUN   TestDelete
--- PASS: TestDelete (0.02s)
=== RUN   TestTransaction
--- PASS: TestTransaction (0.01s)
=== RUN   TestReadOrCreate
--- PASS: TestReadOrCreate (0.01s)
=== RUN   TestInLine
--- PASS: TestInLine (0.01s)
=== RUN   TestInLineOneToOne
--- PASS: TestInLineOneToOne (0.01s)
=== RUN   TestIntegerPk
--- PASS: TestIntegerPk (0.01s)
=== RUN   TestInsertAuto
--- PASS: TestInsertAuto (0.02s)
=== RUN   TestUintPk
--- PASS: TestUintPk (0.56s)
PASS
ok  	github.com/astaxie/beego/orm	2.823s
[b055@localhost beego]$ 
```
