### PR TITLE
add/get session id into/from http header, check the session name in http header

### DIFF
--- a/config.go
+++ b/config.go
@@ -83,14 +83,17 @@ type WebConfig struct {
 
 // SessionConfig holds session related config
 type SessionConfig struct {
-	SessionOn             bool
-	SessionProvider       string
-	SessionName           string
-	SessionGCMaxLifetime  int64
-	SessionProviderConfig string
-	SessionCookieLifeTime int
-	SessionAutoSetCookie  bool
-	SessionDomain         string
+	SessionOn               bool
+	SessionProvider         string
+	SessionName             string
+	SessionGCMaxLifetime    int64
+	SessionProviderConfig   string
+	SessionCookieLifeTime   int
+	SessionAutoSetCookie    bool
+	SessionDomain           string
+	EnableSidInHttpHeader   bool //	enable store/get the sessionId into/from http headers
+	SessionNameInHttpHeader string
+	EnableSidInUrlQuery     bool //	enable get the sessionId from Url Query params
 }
 
 // LogConfig holds Log related config
@@ -183,14 +186,17 @@ func newBConfig() *Config {
 			XSRFKey:                "beegoxsrf",
 			XSRFExpire:             0,
 			Session: SessionConfig{
-				SessionOn:             false,
-				SessionProvider:       "memory",
-				SessionName:           "beegosessionID",
-				SessionGCMaxLifetime:  3600,
-				SessionProviderConfig: "",
-				SessionCookieLifeTime: 0, //set cookie default is the browser life
-				SessionAutoSetCookie:  true,
-				SessionDomain:         "",
+				SessionOn:               false,
+				SessionProvider:         "memory",
+				SessionName:             "beegosessionID",
+				SessionGCMaxLifetime:    3600,
+				SessionProviderConfig:   "",
+				SessionCookieLifeTime:   0, //set cookie default is the browser life
+				SessionAutoSetCookie:    true,
+				SessionDomain:           "",
+				EnableSidInHttpHeader:   false, //	enable store/get the sessionId into/from http headers
+				SessionNameInHttpHeader: "Beegosessionid",
+				EnableSidInUrlQuery:     false, //	enable get the sessionId from Url Query params
 			},
 		},
 		Log: LogConfig{

--- a/hooks.go
+++ b/hooks.go
@@ -47,13 +47,16 @@ func registerSession() error {
 		sessionConfig := AppConfig.String("sessionConfig")
 		if sessionConfig == "" {
 			conf := map[string]interface{}{
-				"cookieName":      BConfig.WebConfig.Session.SessionName,
-				"gclifetime":      BConfig.WebConfig.Session.SessionGCMaxLifetime,
-				"providerConfig":  filepath.ToSlash(BConfig.WebConfig.Session.SessionProviderConfig),
-				"secure":          BConfig.Listen.EnableHTTPS,
-				"enableSetCookie": BConfig.WebConfig.Session.SessionAutoSetCookie,
-				"domain":          BConfig.WebConfig.Session.SessionDomain,
-				"cookieLifeTime":  BConfig.WebConfig.Session.SessionCookieLifeTime,
+				"cookieName":              BConfig.WebConfig.Session.SessionName,
+				"gclifetime":              BConfig.WebConfig.Session.SessionGCMaxLifetime,
+				"providerConfig":          filepath.ToSlash(BConfig.WebConfig.Session.SessionProviderConfig),
+				"secure":                  BConfig.Listen.EnableHTTPS,
+				"enableSetCookie":         BConfig.WebConfig.Session.SessionAutoSetCookie,
+				"domain":                  BConfig.WebConfig.Session.SessionDomain,
+				"cookieLifeTime":          BConfig.WebConfig.Session.SessionCookieLifeTime,
+				"enableSidInHttpHeader":   BConfig.WebConfig.Session.EnableSidInHttpHeader,
+				"sessionNameInHttpHeader": BConfig.WebConfig.Session.SessionNameInHttpHeader,
+				"enableSidInUrlQuery":     BConfig.WebConfig.Session.EnableSidInUrlQuery,
 			}
 			confBytes, err := json.Marshal(conf)
 			if err != nil {


### PR DESCRIPTION
1. remove the invalid comments.
2. allow the user to config "Enable" store/get sessionId into/from http header
3. allow the user to config "Enable" get sessionId from Url query
4. when enable sessionId in http header, check the sessionName format as CanonicalMIMRHeaderKey, then panic if not.