### PR TITLE
close socket when http client request over

### DIFF
--- a/httplib/httplib.go
+++ b/httplib/httplib.go
@@ -409,9 +409,10 @@ func (b *BeegoHTTPRequest) DoRequest() (*http.Response, error) {
 	if trans == nil {
 		// create default transport
 		trans = &http.Transport{
-			TLSClientConfig: b.setting.TLSClientConfig,
-			Proxy:           b.setting.Proxy,
-			Dial:            TimeoutDialer(b.setting.ConnectTimeout, b.setting.ReadWriteTimeout),
+			TLSClientConfig: 	b.setting.TLSClientConfig,
+			Proxy:           	b.setting.Proxy,
+			Dial:            	TimeoutDialer(b.setting.ConnectTimeout, b.setting.ReadWriteTimeout),
+			MaxIdleConnsPerHost: 	-1,
 		}
 	} else {
 		// if b.transport is *http.Transport then set the settings.


### PR DESCRIPTION
Transport use link pool, so we use http client to send request, but we don't close the socket.
Until the server reach keepalive_timeout, and close the socket.  If you use tcpdump, you will find the phenomenon.

Set MaxIdleConnsPerHost = -1 can solve the problem

Test code:
``` go
package main

import (
	"fmt"
	"github.com/astaxie/beego/httplib"
	"log"
	"net/http"
)

func HttpClientTest(w http.ResponseWriter, r *http.Request) {
	req := httplib.Get("http://x.x.x.x:x")
	str, err := req.String()
	if err != nil {
		fmt.Println(err)
		return
	}
	fmt.Println(str)
}

func main() {
	http.HandleFunc("/", HttpClientTest)
	err := http.ListenAndServe(":7123", nil)
	if err != nil {
		log.Fatal("ListenAndServe: ", err)
	}
}

```