### PR TITLE
remove change work dir and set AppPath with Pwd and fix #1902

### DIFF
--- a/config.go
+++ b/config.go
@@ -115,9 +115,7 @@ var (
 )
 
 func init() {
-	AppPath, _ = filepath.Abs(filepath.Dir(os.Args[0]))
-
-	os.Chdir(AppPath)
+	AppPath, _ = os.Getwd()
 
 	BConfig = &Config{
 		AppName:             "beego",


### PR DESCRIPTION
删除改变当前目录
将AppPath设定为当前目录

这样可以修复go run main.go 无法读取配置文件的issue

参考issue #1902

我没有特别系统的读过beego代码，也不敢特别确定这样修改没有问题。test跑过了，在我的理解中应该是ok了。希望能帮我看看，如果我理解的不对，也能给我些指点~