### PR TITLE
Start timer task Multiple times

### DIFF
--- a/toolbox/task.go
+++ b/toolbox/task.go
@@ -389,11 +389,16 @@ func dayMatches(s *Schedule, t time.Time) bool {
 
 // StartTask start all tasks
 func StartTask() {
+    if isstart {
+        //If already started， no need to start another goroutine.
+        return
+    }
 	isstart = true
 	go run()
 }
 
 func run() {
+
 	now := time.Now().Local()
 	for _, t := range AdminTaskList {
 		t.SetNext(now)
@@ -417,7 +422,7 @@ func run() {
 				if e.GetNext() != effective {
 					break
 				}
-				go e.Run()
+                go e.Run()
 				e.SetPrev(e.GetNext())
 				e.SetNext(effective)
 			}
@@ -432,8 +437,11 @@ func run() {
 
 // StopTask stop all tasks
 func StopTask() {
-	isstart = false
-	stop <- true
+    if(isstart){
+        isstart = false
+        stop <- true
+    }
+
 }
 
 // AddTask add task with name

--- a/toolbox/task.go
+++ b/toolbox/task.go
@@ -389,16 +389,15 @@ func dayMatches(s *Schedule, t time.Time) bool {
 
 // StartTask start all tasks
 func StartTask() {
-    if isstart {
-        //If already started， no need to start another goroutine.
-        return
-    }
+	if isstart {
+		//If already started， no need to start another goroutine.
+		return
+	}
 	isstart = true
 	go run()
 }
 
 func run() {
-
 	now := time.Now().Local()
 	for _, t := range AdminTaskList {
 		t.SetNext(now)
@@ -422,7 +421,7 @@ func run() {
 				if e.GetNext() != effective {
 					break
 				}
-        go e.Run()
+				go e.Run()
 				e.SetPrev(e.GetNext())
 				e.SetNext(effective)
 			}
@@ -437,10 +436,10 @@ func run() {
 
 // StopTask stop all tasks
 func StopTask() {
-    if(isstart){
-        isstart = false
-        stop <- true
-    }
+	if isstart {
+		isstart = false
+		stop <- true
+	}
 
 }
 

--- a/toolbox/task.go
+++ b/toolbox/task.go
@@ -422,7 +422,7 @@ func run() {
 				if e.GetNext() != effective {
 					break
 				}
-                go e.Run()
+        go e.Run()
 				e.SetPrev(e.GetNext())
 				e.SetNext(effective)
 			}


### PR DESCRIPTION
Fix start time task twice when call   toolbox.StartTask() twice. One is in Admin module of beego, and the other is called by me. And I did not aware of admin module of beego call the StartTask(). 

So I fix it  as regardless of times that StartTask() has been called, it only start one time, create one routine to handle the elapsed event.