### PR TITLE
Fixed some bug

### DIFF
--- a/beego.go
+++ b/beego.go
@@ -85,9 +85,11 @@ func initBeforeHTTPRun() {
 
 // TestBeegoInit is for test package init
 func TestBeegoInit(ap string) {
-	os.Setenv("BEEGO_RUNMODE", "test")
 	appConfigPath = filepath.Join(ap, "conf", "app.conf")
 	os.Chdir(ap)
-	LoadAppConfig(appConfigProvider, appConfigPath)
+	if err := LoadAppConfig(appConfigProvider, appConfigPath); err != nil {
+		panic(err)
+	}
+	BConfig.RunMode = "test"
 	initBeforeHTTPRun()
 }

--- a/config.go
+++ b/config.go
@@ -274,7 +274,7 @@ func assignConfig(ac config.Configer) error {
 	for adaptor, config := range BConfig.Log.Outputs {
 		err := logs.SetLogger(adaptor, config)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "%s with the config `%s` got err:%s\n", adaptor, config, err)
+			fmt.Fprintln(os.Stderr, fmt.Sprintf("%s with the config %q got err:%s", adaptor, config, err.Error()))
 		}
 	}
 	logs.SetLogFuncCall(BConfig.Log.FileLineNum)

--- a/context/output.go
+++ b/context/output.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -244,13 +245,15 @@ func (output *BeegoOutput) Download(file string, filename ...string) {
 		return
 	}
 
+	var fName string
+	if len(filename) > 0 && filename[0] != "" {
+		fName = filename[0]
+	} else {
+		fName = filepath.Base(file)
+	}
+	output.Header("Content-Disposition", "attachment; filename="+url.QueryEscape(fName))
 	output.Header("Content-Description", "File Transfer")
 	output.Header("Content-Type", "application/octet-stream")
-	if len(filename) > 0 && filename[0] != "" {
-		output.Header("Content-Disposition", "attachment; filename="+filename[0])
-	} else {
-		output.Header("Content-Disposition", "attachment; filename="+filepath.Base(file))
-	}
 	output.Header("Content-Transfer-Encoding", "binary")
 	output.Header("Expires", "0")
 	output.Header("Cache-Control", "must-revalidate")

--- a/session/session.go
+++ b/session/session.go
@@ -132,17 +132,13 @@ func NewManager(provideName, config string) (*Manager, error) {
 
 	if cf.EnableSidInHttpHeader {
 		if cf.SessionNameInHttpHeader == "" {
-			err = errors.New("SessionNameInHttpHeader is empty")
-			panic(err)
-			return nil, err
+			panic(errors.New("SessionNameInHttpHeader is empty"))
 		}
 
 		strMimeHeader := textproto.CanonicalMIMEHeaderKey(cf.SessionNameInHttpHeader)
 		if cf.SessionNameInHttpHeader != strMimeHeader {
 			strErrMsg := "SessionNameInHttpHeader (" + cf.SessionNameInHttpHeader + ") has the wrong format, it should be like this : " + strMimeHeader
-			err = errors.New(strErrMsg)
-			panic(err)
-			return nil, err
+			panic(errors.New(strErrMsg))
 		}
 	}
 


### PR DESCRIPTION
1. QueryEscape Download File Name, Garbled in IE
2. Print load logger error info by right way.
3. Don't need `return` after `panic` .
4. When run test mode, Need set RunMode with code shown but use environment variable