### PR TITLE
Create copy of beegoTplFuncMap for use by custom rendering

### DIFF
--- a/template.go
+++ b/template.go
@@ -94,6 +94,16 @@ func AddFuncMap(key string, fn interface{}) error {
 	return nil
 }
 
+// BeegoTplFuncMap returns a copy of the beego template func map, which may then be used for
+// rendering templates directly (e.g., with another template engine).
+func BeegoTplFuncMap() template.FuncMap {
+	mapCopy := make(template.FuncMap)
+	for k, v := range beegoTplFuncMap {
+		mapCopy[k] = v
+	}
+	return mapCopy
+}
+
 type templateHandler func(root, path string, funcs template.FuncMap) (TemplateRenderer, error)
 type TemplateRenderer interface {
 	ExecuteTemplate(wr io.Writer, name string, data interface{}) error


### PR DESCRIPTION
The beego template func map needs to be exported in some way to allow these functions to be used with 3rd party template engines, (as described  [here](https://groups.google.com/forum/#!topic/beego-framework/_z2tH4-KkkM)).

This pull request adds a function that returns a copy of the beego func map (so it can be mutated freely without affecting beego).

I ran across this problem when integrating the [Ace template engine](https://github.com/yosssi/ace) for use within my project.  Our existing templates made use of beego template functions, and when I rendered with Ace instead of beego, this resulted in errors.  Now I'll be able to add the beego functions to the template returned by Ace.

