### PR TITLE
More flexible support for template engines

### DIFF
--- a/template.go
+++ b/template.go
@@ -38,7 +38,8 @@ var (
 	// beeTemplateExt stores the template extension which will build
 	beeTemplateExt = []string{"tpl", "html"}
 	// beeTemplatePreprocessors stores associations of extension -> preprocessor handler
-	beeTemplateEngines = map[string]templatePreProcessor{})
+	beeTemplateEngines = map[string]templatePreProcessor{}
+)
 
 // ExecuteTemplate applies the template with name  to the specified data object,
 // writing the output to wr.


### PR DESCRIPTION
Hi @astaxie, @JessonChan, @saturn4er,

I tried using the new support for template engines (PR #1762) to enable [ace](https://github.com/yosssi/ace) templates for my project.  That code works for the jade template engine given in the example, but does not work for ace templates.

- PR #1762 introduced the `TemplateRenderer` interface, which contains a single method matching the signature of `template.Template.ExecuteTemplate`.
- That solution requires the `templateHandler` to return a `TemplateRenderer` (template) with the name set to the exact same value as the controller's `c.TplName` value.
- Ace sets the name of the template internally, which results in the call to `t.ExecuteTemplate(wr, name, data)` to fail, as the `name` parameter does not match the name of `t` or any associated template.

This PR adds a bit more flexibility, by going back to `*template.Template` instead of `TemplateRenderer`, and allowing for the case where the template name does not match the value of `c.TplName`.

I hope you'll accept this change before the next release, as ace is much more popular (458 stars) than [jade](https://github.com/Joker/jade) (35 stars), and is feature complete.  I've tested this with ace using the following code:

```go

	beego.AddTemplateEngine("ace", func(root, path string, funcs template.FuncMap) (*template.Template, error) {
		aceOptions := &ace.Options{DynamicReload: true, FuncMap: funcs}
		aceBasePath := filepath.Join(root, "base/base")
		aceInnerPath := filepath.Join(root, strings.TrimSuffix(path, ".ace"))

		tpl, err := ace.Load(aceBasePath, aceInnerPath, aceOptions)
		if err != nil {
			return nil, fmt.Errorf("error loading ace template: %v", err)
		}

		return tpl, nil
	})
```