### PR TITLE
fix: README.md specifies wrong port in the Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ func main(){
 ```
 ######Congratulations! 
 You just built your first beego app.
-Open your browser and visit `http://localhost:8000`.
+Open your browser and visit `http://localhost:8080`.
 Please see [Documentation](http://beego.me/docs) for more.
 
 ## Features


### PR DESCRIPTION
The Quick Start invites new users to write the hello.go and then check
http://localhost:8000 while the correct port is 8080. This commit simply
fixies the typo in README.md

fixes: https://github.com/astaxie/beego/issues/1945