### PR TITLE
Ctx.Redirect patch

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -70,10 +70,8 @@ func (ctx *Context) Reset(rw http.ResponseWriter, r *http.Request) {
 }
 
 // Redirect does redirection to localurl with http header status code.
-// It sends http response header directly.
 func (ctx *Context) Redirect(status int, localurl string) {
-	ctx.Output.Header("Location", localurl)
-	ctx.ResponseWriter.WriteHeader(status)
+	http.Redirect(ctx.ResponseWriter, ctx.Request, localurl, status)
 }
 
 // Abort stops this request.


### PR DESCRIPTION
[http.Redirect](https://golang.org/src/net/http/server.go?s=48569:48637#L1653) follow more RFCs than beego's implementation. So maybe we should use package "net/http"