### PR TITLE
fix fk field null value

### DIFF
--- a/orm/db.go
+++ b/orm/db.go
@@ -927,12 +927,17 @@ func (d *dbBase) Count(q dbQuerier, qs *querySet, mi *modelInfo, cond *Condition
 	tables.parseRelated(qs.related, qs.relDepth)
 
 	where, args := tables.getCondSQL(cond, false, tz)
+	groupBy := tables.getGroupSQL(qs.groups)
 	tables.getOrderSQL(qs.orders)
 	join := tables.getJoinSQL()
 
 	Q := d.ins.TableQuote()
 
-	query := fmt.Sprintf("SELECT COUNT(*) FROM %s%s%s T0 %s%s", Q, mi.table, Q, join, where)
+	query := fmt.Sprintf("SELECT COUNT(*) FROM %s%s%s T0 %s%s%s", Q, mi.table, Q, join, where, groupBy)
+
+	if groupBy != "" {
+		query = fmt.Sprintf("SELECT COUNT(*) FROM (%s) AS T", query)
+	}
 
 	d.ins.ReplaceMarks(&query)
 

--- a/orm/orm_raw.go
+++ b/orm/orm_raw.go
@@ -342,7 +342,13 @@ func (o *rawSet) QueryRow(containers ...interface{}) error {
 				for _, col := range columns {
 					if fi := sMi.fields.GetByColumn(col); fi != nil {
 						value := reflect.ValueOf(columnsMp[col]).Elem().Interface()
-						o.setFieldValue(ind.FieldByIndex(fi.fieldIndex), value)
+						field := ind.FieldByIndex(fi.fieldIndex)
+						if fi.fieldType&IsRelField > 0 {
+							mf := reflect.New(fi.relModelInfo.addrField.Elem().Type())
+							field.Set(mf)
+							field = mf.Elem().FieldByIndex(fi.relModelInfo.fields.pk.fieldIndex)
+						}
+						o.setFieldValue(field, value)
 					}
 				}
 			} else {
@@ -480,7 +486,13 @@ func (o *rawSet) QueryRows(containers ...interface{}) (int64, error) {
 				for _, col := range columns {
 					if fi := sMi.fields.GetByColumn(col); fi != nil {
 						value := reflect.ValueOf(columnsMp[col]).Elem().Interface()
-						o.setFieldValue(ind.FieldByIndex(fi.fieldIndex), value)
+						field := ind.FieldByIndex(fi.fieldIndex)
+						if fi.fieldType&IsRelField > 0 {
+							mf := reflect.New(fi.relModelInfo.addrField.Elem().Type())
+							field.Set(mf)
+							field = mf.Elem().FieldByIndex(fi.relModelInfo.fields.pk.fieldIndex)
+						}
+						o.setFieldValue(field, value)
 					}
 				}
 			} else {


### PR DESCRIPTION
QueryRow 和 QueryRows 查询获取数据后外键字段不填充值

```
type App struct {
	Id         uint      `orm:"auto;pk"`
	Name       string    `orm:"size(100);unique"`
	CreateTime time.Time `orm:"auto_now_add;type(datetime)"`
}

type AppPerm struct {
	Id         uint      `orm:"auto;pk"`
	App        *App      `orm:"column(app_id);rel(fk)"`
	Name       string    `orm:"size(100)"`
	CreateTime time.Time `orm:"auto_now_add;type(datetime)"`
}

sql := "SELECT * FROM app_perm WHERE id=?"
perm := AppPerm{}
if err := orm.NewOrm().Raw(sql, 1).QueryRow(&perm); err == nil {
	// perm.App is nil
}
```

