### PR TITLE
modify the error log for registerModel.

### DIFF
--- a/orm/models_boot.go
+++ b/orm/models_boot.go
@@ -66,7 +66,7 @@ func registerModel(prefix string, model interface{}) {
 		}
 
 		if info.fields.pk == nil {
-			fmt.Printf("<orm.RegisterModel> `%s` need a primary key field\n", name)
+			fmt.Printf("<orm.RegisterModel> `%s` need a primary key field, default use 'id' if not set\n", name)
 			os.Exit(2)
 		}
 


### PR DESCRIPTION
 Tell user the default hard code PK is 'id' if not set.

As some one doesn't use id as primary key, here needs to tell the user the hard code value in beego. The log is more friendly for debugging, otherwise, has to go into details to go through the source code.

 