### PR TITLE
add os.Chmod when create log file

### DIFF
--- a/logs/file.go
+++ b/logs/file.go
@@ -161,7 +161,7 @@ func (w *fileLogWriter) createLogFile() (*os.File, error) {
 	fd, err := os.OpenFile(w.Filename, os.O_WRONLY|os.O_APPEND|os.O_CREATE, os.FileMode(perm))
 	if err == nil {
 		// Make sure file perm is user set perm cause of `os.OpenFile` will obey umask
-		os.Chmod(w.Filename, w.Perm)
+		os.Chmod(w.Filename, os.FileMode(perm))
 	}
 	return fd, err
 }

--- a/logs/file.go
+++ b/logs/file.go
@@ -159,6 +159,10 @@ func (w *fileLogWriter) createLogFile() (*os.File, error) {
 		return nil, err
 	}
 	fd, err := os.OpenFile(w.Filename, os.O_WRONLY|os.O_APPEND|os.O_CREATE, os.FileMode(perm))
+	if err == nil {
+		// Make sure file perm is user set perm cause of `os.OpenFile` will obey umask
+		os.Chmod(w.Filename, w.Perm)
+	}
 	return fd, err
 }
 

--- a/logs/file_test.go
+++ b/logs/file_test.go
@@ -26,7 +26,8 @@ import (
 
 func TestFilePerm(t *testing.T) {
 	log := NewLogger(10000)
-	log.SetLogger("file", `{"filename":"test.log", "perm": "0600"}`)
+	// use 0666 as test perm cause the default umask is 022
+	log.SetLogger("file", `{"filename":"test.log", "perm": "0666"}`)
 	log.Debug("debug")
 	log.Informational("info")
 	log.Notice("notice")
@@ -39,7 +40,7 @@ func TestFilePerm(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if file.Mode() != 0600 {
+	if file.Mode() != 0666 {
 		t.Fatal("unexpected log file permission")
 	}
 	os.Remove("test.log")


### PR DESCRIPTION
`os.OpenFile` will obey the `umask`, so the log file permission is not same as user set, need one step more to make sure that