### PR TITLE
Add support for time.Time pointer in struct types

### DIFF
--- a/orm/db.go
+++ b/orm/db.go
@@ -243,6 +243,9 @@ func (d *dbBase) collectFieldValue(mi *modelInfo, fi *fieldInfo, ind reflect.Val
 				if fi.isFielder {
 					f := field.Addr().Interface().(Fielder)
 					f.SetRaw(tnow.In(DefaultTimeLoc))
+				} else if field.Kind() == reflect.Ptr {
+					v := tnow.In(DefaultTimeLoc)
+					field.Set(reflect.ValueOf(&v))
 				} else {
 					field.Set(reflect.ValueOf(tnow.In(DefaultTimeLoc)))
 				}
@@ -1273,8 +1276,14 @@ setValue:
 		if isNative {
 			if value == nil {
 				value = time.Time{}
+			} else if field.Kind() == reflect.Ptr {
+				if value != nil {
+					v := value.(time.Time)
+					field.Set(reflect.ValueOf(&v))
+				}
+			} else {
+				field.Set(reflect.ValueOf(value))
 			}
-			field.Set(reflect.ValueOf(value))
 		}
 	case fieldType == TypePositiveBitField && field.Kind() == reflect.Ptr:
 		if value != nil {

--- a/orm/models_test.go
+++ b/orm/models_test.go
@@ -181,6 +181,9 @@ type DataNull struct {
 	Float32Ptr  *float32        `orm:"null"`
 	Float64Ptr  *float64        `orm:"null"`
 	DecimalPtr  *float64        `orm:"digits(8);decimals(4);null"`
+	TimePtr     *time.Time      `orm:"null;type(time)"`
+	DatePtr     *time.Time      `orm:"null;type(date)"`
+	DateTimePtr *time.Time      `orm:"null"`
 }
 
 type String string

--- a/orm/models_utils.go
+++ b/orm/models_utils.go
@@ -137,6 +137,8 @@ func getFieldType(val reflect.Value) (ft int, err error) {
 		ft = TypeBooleanField
 	case reflect.TypeOf(new(string)):
 		ft = TypeCharField
+	case reflect.TypeOf(new(time.Time)):
+		ft = TypeDateTimeField
 	default:
 		elm := reflect.Indirect(val)
 		switch elm.Kind() {

--- a/orm/orm_test.go
+++ b/orm/orm_test.go
@@ -350,6 +350,9 @@ func TestNullDataTypes(t *testing.T) {
 	throwFail(t, AssertIs(d.Float32Ptr, nil))
 	throwFail(t, AssertIs(d.Float64Ptr, nil))
 	throwFail(t, AssertIs(d.DecimalPtr, nil))
+	throwFail(t, AssertIs(d.TimePtr, nil))
+	throwFail(t, AssertIs(d.DatePtr, nil))
+	throwFail(t, AssertIs(d.DateTimePtr, nil))
 
 	_, err = dORM.Raw(`INSERT INTO data_null (boolean) VALUES (?)`, nil).Exec()
 	throwFail(t, err)
@@ -376,6 +379,9 @@ func TestNullDataTypes(t *testing.T) {
 	float32Ptr := float32(42.0)
 	float64Ptr := float64(42.0)
 	decimalPtr := float64(42.0)
+	timePtr := time.Now()
+	datePtr := time.Now()
+	dateTimePtr := time.Now()
 
 	d = DataNull{
 		DateTime:    time.Now(),
@@ -401,6 +407,9 @@ func TestNullDataTypes(t *testing.T) {
 		Float32Ptr:  &float32Ptr,
 		Float64Ptr:  &float64Ptr,
 		DecimalPtr:  &decimalPtr,
+		TimePtr:     &timePtr,
+		DatePtr:     &datePtr,
+		DateTimePtr: &dateTimePtr,
 	}
 
 	id, err = dORM.Insert(&d)
@@ -441,6 +450,9 @@ func TestNullDataTypes(t *testing.T) {
 	throwFail(t, AssertIs(*d.Float32Ptr, float32Ptr))
 	throwFail(t, AssertIs(*d.Float64Ptr, float64Ptr))
 	throwFail(t, AssertIs(*d.DecimalPtr, decimalPtr))
+	throwFail(t, AssertIs((*d.TimePtr).Format(testTime), timePtr.Format(testTime)))
+	throwFail(t, AssertIs((*d.DatePtr).Format(testDate), datePtr.Format(testDate)))
+	throwFail(t, AssertIs((*d.DateTimePtr).Format(testDateTime), dateTimePtr.Format(testDateTime)))
 }
 
 func TestDataCustomTypes(t *testing.T) {


### PR DESCRIPTION
This allows using pointers `*time.Time` as a type in struct in combination with `orm` tags.
```go
type User struct {
	ID         int        `orm:"column(id);auto" json:"id"`
	Username   string     `orm:"column(username);size(255);unique" json:"username"`
	Email      string     `orm:"column(email);size(255);unique" json:"email"`
	CreatedAt  time.Time  `orm:"column(created_at);auto_now_add;type(datetime)" json:"created_at"`
	UpdatedAt  time.Time  `orm:"column(updated_at);auto_now;type(datetime)" json:"updated_at"`
	DeletedAt  *time.Time `orm:"column(deleted_at);type(datetime);null" json:"deleted_at,omitempty"`
}
```
This is useful when there is a need to treat `time.Time` fields as "empty" in JSON marshaling/unmarshaling using `json:"omitempty"` tag. Without pointer, `omitempty` tag will be ignored since it's not a `nil` value and will result in `0001-01-01T00:00:00Z` when unmarshaling.

There is a good answer on [StackOverflow](http://stackoverflow.com/a/32646035) about `omitempty` with `time.Time`.

The should solve https://github.com/astaxie/beego/issues/1019 where the issue was first mentioned.