### PR TITLE
use keyed fields to pass go vet

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -164,10 +164,10 @@ func genRouterCode() {
 			globalinfo = globalinfo + `
 	beego.GlobalControllerRouter["` + k + `"] = append(beego.GlobalControllerRouter["` + k + `"],
 		beego.ControllerComments{
-			"` + strings.TrimSpace(c.Method) + `",
-			` + "`" + c.Router + "`" + `,
-			` + allmethod + `,
-			` + params + `})
+			Method: "` + strings.TrimSpace(c.Method) + `",
+			` + "Router: `" + c.Router + "`" + `,
+			AllowHTTPMethods: ` + allmethod + `,
+			Params: ` + params + `})
 `
 		}
 	}


### PR DESCRIPTION
if use unkeyed fields to generate routers, these routers could not pass 'go vet'. Test results:
```
...
		beego.ControllerComments{
			Method: "Start",
			Router: `/start`,
			AllowHTTPMethods: []string{"post"},
			Params: nil})
...
```