### PR TITLE
Add template prefix field to controller

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -71,6 +71,7 @@ type Controller struct {
 	TplName        string
 	Layout         string
 	LayoutSections map[string]string // the key is the section name and the value is the template name
+	TplPrefix      string
 	TplExt         string
 	EnableRender   bool
 
@@ -226,6 +227,9 @@ func (c *Controller) renderTemplate() (bytes.Buffer, error) {
 	var buf bytes.Buffer
 	if c.TplName == "" {
 		c.TplName = strings.ToLower(c.controllerName) + "/" + strings.ToLower(c.actionName) + "." + c.TplExt
+		if c.TplPrefix != "" {
+			c.TplName = c.TplPrefix + c.TplName
+		}
 	}
 	if BConfig.RunMode == DEV {
 		buildFiles := []string{c.TplName}

--- a/controller.go
+++ b/controller.go
@@ -227,9 +227,9 @@ func (c *Controller) renderTemplate() (bytes.Buffer, error) {
 	var buf bytes.Buffer
 	if c.TplName == "" {
 		c.TplName = strings.ToLower(c.controllerName) + "/" + strings.ToLower(c.actionName) + "." + c.TplExt
-		if c.TplPrefix != "" {
-			c.TplName = c.TplPrefix + c.TplName
-		}
+	}
+	if c.TplPrefix != "" {
+		c.TplName = c.TplPrefix + c.TplName
 	}
 	if BConfig.RunMode == DEV {
 		buildFiles := []string{c.TplName}


### PR DESCRIPTION
When I move some controllers to controllers dir, for example: app/controllers/client/authorization.go. It will be cool to specify some folder from which all templates will be fetched. For this purpose, I add field TplPrefix

Usage example:
app/controllers/client/client.go:

    type ClientController struct {
	    controllers.ApplicationController
    }
    func (c *ClientController) Prepare() {
    	    c.TplPrefix = "client/"
    }

app/controllers/client/authorization.go:

    type Authorization struct {
	    ClientController
    }

After that, all controllers, which will extend ClientController will fetch templates from directory client/<controller_name>/<action_name>.<ext>