### PR TITLE
remove not support encoding

### DIFF
--- a/context/acceptencoder.go
+++ b/context/acceptencoder.go
@@ -209,9 +209,13 @@ func parseEncoding(r *http.Request) string {
 			continue
 		}
 		vs := strings.Split(v, ";")
+		var cf acceptEncoder
+		var ok bool
+		if cf, ok = encoderMap[vs[0]]; !ok {
+			continue
+		}
 		if len(vs) == 1 {
-			lastQ = q{vs[0], 1}
-			break
+			return cf.name
 		}
 		if len(vs) == 2 {
 			f, _ := strconv.ParseFloat(strings.Replace(vs[1], "q=", "", -1), 64)
@@ -219,12 +223,9 @@ func parseEncoding(r *http.Request) string {
 				continue
 			}
 			if f > lastQ.value {
-				lastQ = q{vs[0], f}
+				lastQ = q{cf.name, f}
 			}
 		}
 	}
-	if cf, ok := encoderMap[lastQ.name]; ok {
-		return cf.name
-	}
-	return ""
+	return lastQ.name
 }

--- a/context/acceptencoder_test.go
+++ b/context/acceptencoder_test.go
@@ -41,4 +41,19 @@ func Test_ExtractEncoding(t *testing.T) {
 	if parseEncoding(&http.Request{Header: map[string][]string{"Accept-Encoding": {"*"}}}) != "gzip" {
 		t.Fail()
 	}
+	if parseEncoding(&http.Request{Header: map[string][]string{"Accept-Encoding": {"x,gzip,deflate"}}}) != "gzip" {
+		t.Fail()
+	}
+	if parseEncoding(&http.Request{Header: map[string][]string{"Accept-Encoding": {"gzip,x,deflate"}}}) != "gzip" {
+		t.Fail()
+	}
+	if parseEncoding(&http.Request{Header: map[string][]string{"Accept-Encoding": {"gzip;q=0.5,x,deflate"}}}) != "deflate" {
+		t.Fail()
+	}
+	if parseEncoding(&http.Request{Header: map[string][]string{"Accept-Encoding": {"x"}}}) != "" {
+		t.Fail()
+	}
+	if parseEncoding(&http.Request{Header: map[string][]string{"Accept-Encoding": {"gzip;q=0.5,x;q=0.8"}}}) != "gzip" {
+		t.Fail()
+	}
 }


### PR DESCRIPTION
http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3

>  If multiple content-codings are **acceptable**, then the **acceptable content-coding** with the highest non-zero qvalue is preferred.