### PR TITLE
fixbug: orm generate UNNECESSARY JOIN

### DIFF
--- a/orm/db.go
+++ b/orm/db.go
@@ -747,9 +747,10 @@ func (d *dbBase) ReadBatch(q dbQuerier, qs *querySet, mi *modelInfo, cond *Condi
 
 	Q := d.ins.TableQuote()
 
+	hasRel := len(qs.related) > 0 || qs.relDepth > 0
+
 	var tCols []string
 	if len(cols) > 0 {
-		hasRel := len(qs.related) > 0 || qs.relDepth > 0
 		tCols = make([]string, 0, len(cols))
 		var maps map[string]bool
 		if hasRel {
@@ -791,6 +792,11 @@ func (d *dbBase) ReadBatch(q dbQuerier, qs *querySet, mi *modelInfo, cond *Condi
 	limit := tables.getLimitSQL(mi, offset, rlimit)
 	join := tables.getJoinSQL()
 
+	// if not has rel when just do not peform join 
+	if !hasRel {
+		join = ""
+	}
+	
 	for _, tbl := range tables.tables {
 		if tbl.sel {
 			colsNum += len(tbl.mi.fields.dbcols)

--- a/orm/db.go
+++ b/orm/db.go
@@ -790,11 +790,10 @@ func (d *dbBase) ReadBatch(q dbQuerier, qs *querySet, mi *modelInfo, cond *Condi
 	groupBy := tables.getGroupSQL(qs.groups)
 	orderBy := tables.getOrderSQL(qs.orders)
 	limit := tables.getLimitSQL(mi, offset, rlimit)
-	join := tables.getJoinSQL()
-
+	join := "" 
 	// if not has rel when just do not peform join 
-	if !hasRel {
-		join = ""
+	if hasRel {
+		join = tables.getJoinSQL()
 	}
 	
 	for _, tbl := range tables.tables {


### PR DESCRIPTION
I was shocked when I spent a whole afternoon optimize my table index to improve performance ANd found that the `beego orm` generateed UNNECESSARY join when I use the beego `QuerySetter` . The querysetter while produce  a join query even though I don't use `RelatedSet()` at all. That is UNACCEPTABLE. 

 beego 的orm在查询表时即使没有使用`RelatedSet()`也会产生join查询， 这对于Mysql的索引优化是不可接受的， 所以提交了这个pullrequest, 

通过检查hasRel变量在hasRel为真时才去fetch join信息，

当然这个修复也是有问题的， 当有多个join表而只想join其中的一个时还是会用过多的join
望修复
