### PR TITLE
update the default value for "CopyRequestBody"

### DIFF
--- a/config.go
+++ b/config.go
@@ -149,7 +149,7 @@ func newBConfig() *Config {
 		RouterCaseSensitive: true,
 		ServerName:          "beegoServer:" + VERSION,
 		RecoverPanic:        true,
-		CopyRequestBody:     false,
+		CopyRequestBody:     true,
 		EnableGzip:          false,
 		MaxMemory:           1 << 26, //64MB
 		EnableErrorsShow:    true,


### PR DESCRIPTION
The default value for the "CopyRequestBody" in the development document is true, but the default value in the source code is false.
url:http://beego.me/docs/mvc/controller/config.md