### PR TITLE
Don't print nil error

### DIFF
--- a/session/sess_file.go
+++ b/session/sess_file.go
@@ -88,10 +88,14 @@ func (fs *FileSessionStore) SessionRelease(w http.ResponseWriter) {
 	var f *os.File
 	if err == nil {
 		f, err = os.OpenFile(path.Join(filepder.savePath, string(fs.sid[0]), string(fs.sid[1]), fs.sid), os.O_RDWR, 0777)
-		SLogger.Println(err)
+		if err != nil {
+			SLogger.Println(err)
+		}
 	} else if os.IsNotExist(err) {
 		f, err = os.Create(path.Join(filepder.savePath, string(fs.sid[0]), string(fs.sid[1]), fs.sid))
-		SLogger.Println(err)
+		if err != nil {
+			SLogger.Println(err)
+		}
 	} else {
 		return
 	}


### PR DESCRIPTION
SLogger 打印err时,加判断为nil时不打印