### PR TITLE
log output format improvement

### DIFF
--- a/logs/log.go
+++ b/logs/log.go
@@ -260,12 +260,7 @@ func (bl *BeeLogger) writeMsg(logLevel int, msg string, v ...interface{}) error 
 		bl.setLogger(AdapterConsole)
 		bl.lock.Unlock()
 	}
-	if logLevel == levelLoggerImpl {
-		// set to emergency to ensure all log will be print out correctly
-		logLevel = LevelEmergency
-	} else {
-		msg = levelPrefix[logLevel] + msg
-	}
+
 	if len(v) > 0 {
 		msg = fmt.Sprintf(msg, v...)
 	}
@@ -279,6 +274,15 @@ func (bl *BeeLogger) writeMsg(logLevel int, msg string, v ...interface{}) error 
 		_, filename := path.Split(file)
 		msg = "[" + filename + ":" + strconv.FormatInt(int64(line), 10) + "] " + msg
 	}
+
+	//set level info in front of filename info
+	if logLevel == levelLoggerImpl {
+		// set to emergency to ensure all log will be print out correctly
+		logLevel = LevelEmergency
+	} else {
+		msg = levelPrefix[logLevel] + msg
+	}
+
 	if bl.asynchronous {
 		lm := logMsgPool.Get().(*logMsg)
 		lm.level = logLevel


### PR DESCRIPTION
move log level info ahead to filename info, better readability

current output:
2016/08/23 11:57:19 [beego_log_main.go:25] [D] debug
2016/08/23 11:57:19 [beego_log_main.go:26] [I] info
2016/08/23 11:57:19 [log.go:390] [I] info
2016/08/23 11:57:19 [beego_log_main.go:28] [N] notice
2016/08/23 11:57:19 [log.go:377] [W] warning
2016/08/23 11:57:19 [beego_log_main.go:30] [W] warn

log level info cannot be aligned because of the difference of filename info length, move log level info ahead to filename info, so that log level info can be aligned

target output:
2016/08/23 14:03:04 [D] [beego_log_main.go:25] debug
2016/08/23 14:03:04 [I] [beego_log_main.go:26] info
2016/08/23 14:03:04 [I] [log.go:394] info
2016/08/23 14:03:04 [N] [beego_log_main.go:28] notice
2016/08/23 14:03:04 [W] [log.go:381] warning
2016/08/23 14:03:04 [W] [beego_log_main.go:30] warn