### PR TITLE
add feature: get the remaining time by cache key

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -49,6 +49,8 @@ import (
 type Cache interface {
 	// get cached value by key.
 	Get(key string) interface{}
+	// get rest duration.
+	GetRestDuration(key string) time.Duration
 	// GetMulti is a batch version of Get.
 	GetMulti(keys []string) []interface{}
 	// set cached value with key and expire time.

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -95,6 +95,14 @@ func TestCache(t *testing.T) {
 	if vv[1].(string) != "author1" {
 		t.Error("GetMulti ERROR")
 	}
+	// test get rest duration
+	if err = bm.Put("astaxie2", "author", timeoutDuration); err != nil {
+		t.Error("set Error", err)
+	}
+	if rest := bm.GetRestDuration("astaxie2"); rest <= 0 {
+		t.Error("get wrong rest duration", rest)
+	}
+
 }
 
 func TestFileCache(t *testing.T) {
@@ -164,5 +172,12 @@ func TestFileCache(t *testing.T) {
 		t.Error("GetMulti ERROR")
 	}
 
+	// test get rest duration
+	if err = bm.Put("astaxie2", "author", timeoutDuration); err != nil {
+		t.Error("set Error", err)
+	}
+	if rest := bm.GetRestDuration("astaxie2"); rest <= 0 {
+		t.Error("get wrong rest duration", rest)
+	}
 	os.RemoveAll("cache")
 }

--- a/cache/file.go
+++ b/cache/file.go
@@ -129,6 +129,21 @@ func (fc *FileCache) Get(key string) interface{} {
 	return to.Data
 }
 
+// GetRestDuration rest duration.
+// if non-exist or expired, return time.Duration 0.
+func (fc *FileCache) GetRestDuration(key string) time.Duration {
+	fileData, err := FileGetContents(fc.getCacheFileName(key))
+	if err != nil {
+		return 0
+	}
+	var to FileCacheItem
+	GobDecode(fileData, &to)
+	if to.Expired.Before(time.Now()) {
+		return 0
+	}
+	return to.Expired.Sub(time.Now())
+}
+
 // GetMulti gets values from file cache.
 // if non-exist or expired, return empty string.
 func (fc *FileCache) GetMulti(keys []string) []interface{} {

--- a/cache/memcache/memcache.go
+++ b/cache/memcache/memcache.go
@@ -63,6 +63,11 @@ func (rc *Cache) Get(key string) interface{} {
 	return nil
 }
 
+// GetRestDuration rest duration by key.
+func (rc *Cache) GetRestDuration(key string) time.Duration {
+	return 0
+}
+
 // GetMulti get value from memcache.
 func (rc *Cache) GetMulti(keys []string) []interface{} {
 	size := len(keys)

--- a/cache/memory.go
+++ b/cache/memory.go
@@ -70,6 +70,20 @@ func (bc *MemoryCache) Get(name string) interface{} {
 	return nil
 }
 
+// GetRestDuration rest duration.
+// if non-exist or expired, return time.Duration 0.
+func (bc *MemoryCache) GetRestDuration(name string) time.Duration {
+	bc.RLock()
+	defer bc.RUnlock()
+	if itm, ok := bc.items[name]; ok {
+		if itm.isExpire() {
+			return 0
+		}
+		return itm.lifespan - time.Now().Sub(itm.createdTime)
+	}
+	return 0
+}
+
 // GetMulti gets caches from memory.
 // if non-existed or expired, return nil.
 func (bc *MemoryCache) GetMulti(names []string) []interface{} {

--- a/cache/redis/redis.go
+++ b/cache/redis/redis.go
@@ -75,6 +75,14 @@ func (rc *Cache) Get(key string) interface{} {
 	return nil
 }
 
+// GetRestDuration rest duration by key.
+func (rc *Cache) GetRestDuration(key string) time.Duration {
+	if v, err := rc.do("TTL", key); err == nil {
+		return time.Duration(v.(int64))
+	}
+	return 0
+}
+
 // GetMulti get cache from redis.
 func (rc *Cache) GetMulti(keys []string) []interface{} {
 	size := len(keys)

--- a/cache/redis/redis_test.go
+++ b/cache/redis/redis_test.go
@@ -103,4 +103,12 @@ func TestRedisCache(t *testing.T) {
 	if err = bm.ClearAll(); err != nil {
 		t.Error("clear all err")
 	}
+
+	// test get rest duration
+	if err = bm.Put("astaxie", "author", timeoutDuration); err != nil {
+		t.Error("set Error", err)
+	}
+	if rest := bm.GetRestDuration("astaxie"); rest == 0 {
+		t.Error("get wrong rest duration")
+	}
 }

--- a/cache/ssdb/ssdb.go
+++ b/cache/ssdb/ssdb.go
@@ -37,6 +37,11 @@ func (rc *Cache) Get(key string) interface{} {
 	return nil
 }
 
+// GetRestDuration rest duration by key.
+func (rc *Cache) GetRestDuration(key string) time.Duration {
+	return 0
+}
+
 // GetMulti get value from memcache.
 func (rc *Cache) GetMulti(keys []string) []interface{} {
 	size := len(keys)


### PR DESCRIPTION
# Cache
i add a new function for what i want to get the remaining time of a cache.
`func (rc *Cache) GetRestDuration(key string) time.Duration`  
eg:

|key |value |expired time |
|:---- |:---- |:---- |
|bang.{phone} |{count} |{duration} |

sometime i need get the remaining time of a banged user who has tried {count} times ,while the system has a Maximum number of attempts.i think it`s more convenient if i can get the get the remaining time of the cache rather then store the remaining time in another cache.

in the code,i didn`t finish the implement of memcache or ssdb. so i return a zero:
```
func (rc *Cache) GetRestDuration(key string) time.Duration {
	return 0
}
```

