### PR TITLE
Emailer : Should use config Username only if no From is provided.

### DIFF
--- a/utils/mail.go
+++ b/utils/mail.go
@@ -232,14 +232,16 @@ func (e *Email) Send() error {
 		return errors.New("Must specify at least one To address")
 	}
 
-	from, err := mail.ParseAddress(e.Username)
+	// Use the username if no From is provided
+	if len(e.From) == 0 {
+		e.From = e.Username
+	}
+
+	from, err := mail.ParseAddress(e.From)
 	if err != nil {
 		return err
 	}
 
-	if len(e.From) == 0 {
-		e.From = e.Username
-	}
 	// use mail's RFC 2047 to encode any string
 	e.Subject = qEncode("utf-8", e.Subject)
 


### PR DESCRIPTION
Should fix the case where Username is not an email.