### PR TITLE
fix to advice in #2187

### DIFF
--- a/config.go
+++ b/config.go
@@ -294,6 +294,10 @@ func assignConfig(ac config.Configer) error {
 	}
 
 	if lo := ac.String("LogOutputs"); lo != "" {
+		// if lo is not nil or empty
+		// means user has set his own LogOutputs
+		// clear the default setting to BConfig.Log.Outputs
+		BConfig.Log.Outputs = make(map[string]string)
 		los := strings.Split(lo, ";")
 		for _, v := range los {
 			if logType2Config := strings.SplitN(v, ",", 2); len(logType2Config) == 2 {


### PR DESCRIPTION
Clear BConfig.Log.Outputs's default value "console" while user has set "LogOutputs" in config file.