### PR TITLE
fix log func call depth bug

### DIFF
--- a/logs/log.go
+++ b/logs/log.go
@@ -380,7 +380,10 @@ func (bl *BeeLogger) Error(format string, v ...interface{}) {
 
 // Warning Log WARNING level message.
 func (bl *BeeLogger) Warning(format string, v ...interface{}) {
-	bl.Warn(format, v...)
+	if LevelWarn > bl.level {
+		return
+	}
+	bl.writeMsg(LevelWarn, format, v...)
 }
 
 // Notice Log NOTICE level message.
@@ -393,7 +396,10 @@ func (bl *BeeLogger) Notice(format string, v ...interface{}) {
 
 // Informational Log INFORMATIONAL level message.
 func (bl *BeeLogger) Informational(format string, v ...interface{}) {
-	bl.Info(format, v...)
+	if LevelInfo > bl.level {
+		return
+	}
+	bl.writeMsg(LevelInfo, format, v...)
 }
 
 // Debug Log DEBUG level message.
@@ -425,7 +431,10 @@ func (bl *BeeLogger) Info(format string, v ...interface{}) {
 // Trace Log TRACE level message.
 // compatibility alias for Debug()
 func (bl *BeeLogger) Trace(format string, v ...interface{}) {
-	bl.Debug(format, v...)
+	if LevelDebug > bl.level {
+		return
+	}
+	bl.writeMsg(LevelDebug, format, v...)
 }
 
 // Flush flush all chan data.


### PR DESCRIPTION
beego/logs中的相同级别但存在别名的日志打印函数是通过调用实现的，虽然效果相同但是会导致调用深度不同，无法正确打印调用位置的信息。改为使用代码复制替代调用实现。