### PR TITLE
Name fix

### DIFF
--- a/admin_test.go
+++ b/admin_test.go
@@ -65,7 +65,7 @@ func oldMap() map[string]interface{} {
 	m["BConfig.WebConfig.Session.SessionCookieLifeTime"] = BConfig.WebConfig.Session.SessionCookieLifeTime
 	m["BConfig.WebConfig.Session.SessionAutoSetCookie"] = BConfig.WebConfig.Session.SessionAutoSetCookie
 	m["BConfig.WebConfig.Session.SessionDomain"] = BConfig.WebConfig.Session.SessionDomain
-	m["BConfig.WebConfig.Session.DisableHTTPOnly"] = BConfig.WebConfig.Session.SessionDisableHTTPOnly
+	m["BConfig.WebConfig.Session.SessionDisableHTTPOnly"] = BConfig.WebConfig.Session.SessionDisableHTTPOnly
 	m["BConfig.Log.AccessLogs"] = BConfig.Log.AccessLogs
 	m["BConfig.Log.FileLineNum"] = BConfig.Log.FileLineNum
 	m["BConfig.Log.Outputs"] = BConfig.Log.Outputs

--- a/admin_test.go
+++ b/admin_test.go
@@ -65,7 +65,7 @@ func oldMap() map[string]interface{} {
 	m["BConfig.WebConfig.Session.SessionCookieLifeTime"] = BConfig.WebConfig.Session.SessionCookieLifeTime
 	m["BConfig.WebConfig.Session.SessionAutoSetCookie"] = BConfig.WebConfig.Session.SessionAutoSetCookie
 	m["BConfig.WebConfig.Session.SessionDomain"] = BConfig.WebConfig.Session.SessionDomain
-	m["BConfig.WebConfig.Session.DisableHTTPOnly"] = BConfig.WebConfig.Session.DisableHTTPOnly
+	m["BConfig.WebConfig.Session.DisableHTTPOnly"] = BConfig.WebConfig.Session.SessionDisableHTTPOnly
 	m["BConfig.Log.AccessLogs"] = BConfig.Log.AccessLogs
 	m["BConfig.Log.FileLineNum"] = BConfig.Log.FileLineNum
 	m["BConfig.Log.Outputs"] = BConfig.Log.Outputs

--- a/admin_test.go
+++ b/admin_test.go
@@ -65,6 +65,7 @@ func oldMap() map[string]interface{} {
 	m["BConfig.WebConfig.Session.SessionCookieLifeTime"] = BConfig.WebConfig.Session.SessionCookieLifeTime
 	m["BConfig.WebConfig.Session.SessionAutoSetCookie"] = BConfig.WebConfig.Session.SessionAutoSetCookie
 	m["BConfig.WebConfig.Session.SessionDomain"] = BConfig.WebConfig.Session.SessionDomain
+	m["BConfig.WebConfig.Session.DisableHTTPOnly"] = BConfig.WebConfig.Session.DisableHTTPOnly
 	m["BConfig.Log.AccessLogs"] = BConfig.Log.AccessLogs
 	m["BConfig.Log.FileLineNum"] = BConfig.Log.FileLineNum
 	m["BConfig.Log.Outputs"] = BConfig.Log.Outputs

--- a/config.go
+++ b/config.go
@@ -94,7 +94,7 @@ type SessionConfig struct {
 	SessionCookieLifeTime   int
 	SessionAutoSetCookie    bool
 	SessionDomain           string
-	DisableHTTPOnly         bool // used to allow for cross domain cookies/javascript cookies.
+	SessionDisableHTTPOnly  bool // used to allow for cross domain cookies/javascript cookies.
 	EnableSidInHttpHeader   bool //	enable store/get the sessionId into/from http headers
 	SessionNameInHttpHeader string
 	EnableSidInUrlQuery     bool //	enable get the sessionId from Url Query params
@@ -227,7 +227,7 @@ func newBConfig() *Config {
 				SessionName:             "beegosessionID",
 				SessionGCMaxLifetime:    3600,
 				SessionProviderConfig:   "",
-				DisableHTTPOnly:         false,
+				SessionDisableHTTPOnly:  false,
 				SessionCookieLifeTime:   0, //set cookie default is the browser life
 				SessionAutoSetCookie:    true,
 				SessionDomain:           "",

--- a/config.go
+++ b/config.go
@@ -94,6 +94,7 @@ type SessionConfig struct {
 	SessionCookieLifeTime   int
 	SessionAutoSetCookie    bool
 	SessionDomain           string
+	DisableHTTPOnly         bool // used to allow for cross domain cookies/javascript cookies.
 	EnableSidInHttpHeader   bool //	enable store/get the sessionId into/from http headers
 	SessionNameInHttpHeader string
 	EnableSidInUrlQuery     bool //	enable get the sessionId from Url Query params
@@ -226,6 +227,7 @@ func newBConfig() *Config {
 				SessionName:             "beegosessionID",
 				SessionGCMaxLifetime:    3600,
 				SessionProviderConfig:   "",
+				DisableHTTPOnly:         false,
 				SessionCookieLifeTime:   0, //set cookie default is the browser life
 				SessionAutoSetCookie:    true,
 				SessionDomain:           "",

--- a/config.go
+++ b/config.go
@@ -86,18 +86,18 @@ type WebConfig struct {
 
 // SessionConfig holds session related config
 type SessionConfig struct {
-	SessionOn               bool
-	SessionProvider         string
-	SessionName             string
-	SessionGCMaxLifetime    int64
-	SessionProviderConfig   string
-	SessionCookieLifeTime   int
-	SessionAutoSetCookie    bool
-	SessionDomain           string
-	SessionDisableHTTPOnly  bool // used to allow for cross domain cookies/javascript cookies.
-	EnableSidInHttpHeader   bool //	enable store/get the sessionId into/from http headers
-	SessionNameInHttpHeader string
-	EnableSidInUrlQuery     bool //	enable get the sessionId from Url Query params
+	SessionOn                    bool
+	SessionProvider              string
+	SessionName                  string
+	SessionGCMaxLifetime         int64
+	SessionProviderConfig        string
+	SessionCookieLifeTime        int
+	SessionAutoSetCookie         bool
+	SessionDomain                string
+	SessionDisableHTTPOnly       bool // used to allow for cross domain cookies/javascript cookies.
+	SessionEnableSidInHTTPHeader bool //	enable store/get the sessionId into/from http headers
+	SessionNameInHTTPHeader      string
+	SessionEnableSidInURLQuery   bool //	enable get the sessionId from Url Query params
 }
 
 // LogConfig holds Log related config
@@ -222,18 +222,18 @@ func newBConfig() *Config {
 			XSRFKey:                "beegoxsrf",
 			XSRFExpire:             0,
 			Session: SessionConfig{
-				SessionOn:               false,
-				SessionProvider:         "memory",
-				SessionName:             "beegosessionID",
-				SessionGCMaxLifetime:    3600,
-				SessionProviderConfig:   "",
-				SessionDisableHTTPOnly:  false,
-				SessionCookieLifeTime:   0, //set cookie default is the browser life
-				SessionAutoSetCookie:    true,
-				SessionDomain:           "",
-				EnableSidInHttpHeader:   false, //	enable store/get the sessionId into/from http headers
-				SessionNameInHttpHeader: "Beegosessionid",
-				EnableSidInUrlQuery:     false, //	enable get the sessionId from Url Query params
+				SessionOn:                    false,
+				SessionProvider:              "memory",
+				SessionName:                  "beegosessionID",
+				SessionGCMaxLifetime:         3600,
+				SessionProviderConfig:        "",
+				SessionDisableHTTPOnly:       false,
+				SessionCookieLifeTime:        0, //set cookie default is the browser life
+				SessionAutoSetCookie:         true,
+				SessionDomain:                "",
+				SessionEnableSidInHTTPHeader: false, //	enable store/get the sessionId into/from http headers
+				SessionNameInHTTPHeader:      "Beegosessionid",
+				SessionEnableSidInURLQuery:   false, //	enable get the sessionId from Url Query params
 			},
 		},
 		Log: LogConfig{

--- a/hooks.go
+++ b/hooks.go
@@ -53,7 +53,7 @@ func registerSession() error {
 			conf.Secure = BConfig.Listen.EnableHTTPS
 			conf.CookieLifeTime = BConfig.WebConfig.Session.SessionCookieLifeTime
 			conf.ProviderConfig = filepath.ToSlash(BConfig.WebConfig.Session.SessionProviderConfig)
-			conf.DisableHTTPOnly = BConfig.WebConfig.Session.DisableHTTPOnly
+			conf.DisableHTTPOnly = BConfig.WebConfig.Session.SessionDisableHTTPOnly
 			conf.Domain = BConfig.WebConfig.Session.SessionDomain
 			conf.EnableSidInHttpHeader = BConfig.WebConfig.Session.EnableSidInHttpHeader
 			conf.SessionNameInHttpHeader = BConfig.WebConfig.Session.SessionNameInHttpHeader

--- a/hooks.go
+++ b/hooks.go
@@ -55,9 +55,9 @@ func registerSession() error {
 			conf.ProviderConfig = filepath.ToSlash(BConfig.WebConfig.Session.SessionProviderConfig)
 			conf.DisableHTTPOnly = BConfig.WebConfig.Session.SessionDisableHTTPOnly
 			conf.Domain = BConfig.WebConfig.Session.SessionDomain
-			conf.EnableSidInHttpHeader = BConfig.WebConfig.Session.EnableSidInHttpHeader
-			conf.SessionNameInHttpHeader = BConfig.WebConfig.Session.SessionNameInHttpHeader
-			conf.EnableSidInUrlQuery = BConfig.WebConfig.Session.EnableSidInUrlQuery
+			conf.EnableSidInHttpHeader = BConfig.WebConfig.Session.SessionEnableSidInHTTPHeader
+			conf.SessionNameInHttpHeader = BConfig.WebConfig.Session.SessionNameInHTTPHeader
+			conf.EnableSidInUrlQuery = BConfig.WebConfig.Session.SessionEnableSidInURLQuery
 		} else {
 			if err = json.Unmarshal([]byte(sessionConfig), conf); err != nil {
 				return err

--- a/hooks.go
+++ b/hooks.go
@@ -53,6 +53,7 @@ func registerSession() error {
 			conf.Secure = BConfig.Listen.EnableHTTPS
 			conf.CookieLifeTime = BConfig.WebConfig.Session.SessionCookieLifeTime
 			conf.ProviderConfig = filepath.ToSlash(BConfig.WebConfig.Session.SessionProviderConfig)
+			conf.DisableHTTPOnly = BConfig.WebConfig.Session.DisableHTTPOnly
 			conf.Domain = BConfig.WebConfig.Session.SessionDomain
 			conf.EnableSidInHttpHeader = BConfig.WebConfig.Session.EnableSidInHttpHeader
 			conf.SessionNameInHttpHeader = BConfig.WebConfig.Session.SessionNameInHttpHeader

--- a/session/session.go
+++ b/session/session.go
@@ -86,6 +86,7 @@ type ManagerConfig struct {
 	EnableSetCookie         bool   `json:"enableSetCookie,omitempty"`
 	Gclifetime              int64  `json:"gclifetime"`
 	Maxlifetime             int64  `json:"maxLifetime"`
+	DisableHTTPOnly         bool   `json:"disableHTTPOnly"`
 	Secure                  bool   `json:"secure"`
 	CookieLifeTime          int    `json:"cookieLifeTime"`
 	ProviderConfig          string `json:"providerConfig"`
@@ -212,7 +213,7 @@ func (manager *Manager) SessionStart(w http.ResponseWriter, r *http.Request) (se
 		Name:     manager.config.CookieName,
 		Value:    url.QueryEscape(sid),
 		Path:     "/",
-		HttpOnly: true,
+		HttpOnly: !manager.config.DisableHTTPOnly,
 		Secure:   manager.isSecure(r),
 		Domain:   manager.config.Domain,
 	}
@@ -251,7 +252,7 @@ func (manager *Manager) SessionDestroy(w http.ResponseWriter, r *http.Request) {
 		expiration := time.Now()
 		cookie = &http.Cookie{Name: manager.config.CookieName,
 			Path:     "/",
-			HttpOnly: true,
+			HttpOnly: !manager.config.DisableHTTPOnly,
 			Expires:  expiration,
 			MaxAge:   -1}
 
@@ -285,7 +286,7 @@ func (manager *Manager) SessionRegenerateID(w http.ResponseWriter, r *http.Reque
 		cookie = &http.Cookie{Name: manager.config.CookieName,
 			Value:    url.QueryEscape(sid),
 			Path:     "/",
-			HttpOnly: true,
+			HttpOnly: !manager.config.DisableHTTPOnly,
 			Secure:   manager.isSecure(r),
 			Domain:   manager.config.Domain,
 		}


### PR DESCRIPTION
Makes the other values of SessionConfig match, by prefixing them with `Session`. Please stage this PR after https://github.com/astaxie/beego/pull/2216, as this one is branched off of that.

**Main Changes**: 
`EnableSidInUrlQuery`   =>`SessionEnableSidInURLQuery` 
`EnableSidInHttpHeader` => `SessionEnableSidInHTTPHeader`
`SessionNameInHttpHeader` => `SessionNameInHTTPHeader`