### PR TITLE
修复windows上app.conf中include其他配置文件时找不到文件的BUG

### DIFF
--- a/config/ini.go
+++ b/config/ini.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -132,8 +133,8 @@ func (ini *IniConfig) parseFile(name string) (*IniConfigContainer, error) {
 			includefiles := strings.Fields(key)
 			if includefiles[0] == "include" && len(includefiles) == 2 {
 				otherfile := strings.Trim(includefiles[1], "\"")
-				if !path.IsAbs(otherfile) {
-					otherfile = path.Join(path.Dir(name), otherfile)
+				if !filepath.IsAbs(otherfile) {
+					otherfile = filepath.Join(filepath.Dir(name), otherfile)
 				}
 				i, err := ini.parseFile(otherfile)
 				if err != nil {


### PR DESCRIPTION
修复windows上app.conf中include其他配置文件时找不到文件的BUG  
config包init时，使用filepath.Abs取得项目路径，此路径格式为d:\a\b\c（与操作系统相关）
而在解析include的文件时使用了path.Dir，此函数使用"/"做为分隔符，所以后续会找不到文件，应该使用filepath包中的函数