### PR TITLE
Rework getFlatParams for time.Time

### DIFF
--- a/orm/db_utils.go
+++ b/orm/db_utils.go
@@ -147,8 +147,10 @@ outFor:
 					arg = v.In(tz).Format(formatDate)
 				} else if fi != nil && fi.fieldType == TypeDateTimeField {
 					arg = v.In(tz).Format(formatDateTime)
-				} else {
+				} else if fi != nil && fi.fieldType == TypeTimeField {
 					arg = v.In(tz).Format(formatTime)
+				} else {
+					arg = v.In(tz).Format(formatDateTime)
 				}
 			} else {
 				typ := val.Type()


### PR DESCRIPTION
Fixed bug when all "time.Time" params in raw sql queries formatted as time. (e.g. "00:00:00"). This happens because raw sql params don't have fieldType for the arguments
