### PR TITLE
Add RouterPattern to context.Input

### DIFF
--- a/router.go
+++ b/router.go
@@ -712,10 +712,8 @@ func (p *ControllerRegister) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 	}
 
 	if routerInfo != nil {
-		if BConfig.RunMode == DEV {
-			//store router pattern into context
-			context.Input.SetData("RouterPattern", routerInfo.pattern)
-		}
+		//store router pattern into context
+		context.Input.SetData("RouterPattern", routerInfo.pattern)
 		if routerInfo.routerType == routerTypeRESTFul {
 			if _, ok := routerInfo.methods[r.Method]; ok {
 				isRunnable = true


### PR DESCRIPTION
Right now beego adds this param only in dev mode, but I noticed that it's very useful to have in prod environment to.
My current use case - filter that sends logs in newrelic. Pattern there will help a lot to generate correct transaction name.