### PR TITLE
Filter by method

### DIFF
--- a/app.go
+++ b/app.go
@@ -361,6 +361,11 @@ func Handler(rootpath string, h http.Handler, options ...interface{}) *App {
 // beego.BeforeStatic, beego.BeforeRouter, beego.BeforeExec, beego.AfterExec and beego.FinishRouter.
 // The bool params is for setting the returnOnOutput value (false allows multiple filters to execute)
 func InsertFilter(pattern string, pos int, filter FilterFunc, params ...bool) *App {
-	BeeApp.Handlers.InsertFilter(pattern, pos, filter, params...)
+	BeeApp.Handlers.InsertFilter("*", pattern, pos, filter, params...)
+	return BeeApp
+}
+
+func InsertMethodFilter(method string, pattern string, pos int, filter FilterFunc, params ...bool) *App {
+	BeeApp.Handlers.InsertFilter(method, pattern, pos, filter, params...)
 	return BeeApp
 }

--- a/filter.go
+++ b/filter.go
@@ -26,6 +26,7 @@ type FilterRouter struct {
 	filterFunc     FilterFunc
 	tree           *Tree
 	pattern        string
+	method         string
 	returnOnOutput bool
 	resetParams    bool
 }
@@ -34,6 +35,9 @@ type FilterRouter struct {
 // If the request is matched, the values of the URL parameters defined
 // by the filter pattern are also returned.
 func (f *FilterRouter) ValidRouter(url string, ctx *context.Context) bool {
+	if f.method != "*" && ctx.Request.Method != f.method {
+		return false
+	}
 	isOk := f.tree.Match(url, ctx)
 	if isOk != nil {
 		if b, ok := isOk.(bool); ok {

--- a/filter_test.go
+++ b/filter_test.go
@@ -30,7 +30,7 @@ func TestFilter(t *testing.T) {
 	r, _ := http.NewRequest("GET", "/person/asta/Xie", nil)
 	w := httptest.NewRecorder()
 	handler := NewControllerRegister()
-	handler.InsertFilter("/person/:last/:first", BeforeRouter, FilterUser)
+	handler.InsertFilter("*", "/person/:last/:first", BeforeRouter, FilterUser)
 	handler.Add("/person/:last/:first", &TestController{})
 	handler.ServeHTTP(w, r)
 	if w.Body.String() != "i am astaXie" {
@@ -49,7 +49,7 @@ func TestPatternTwo(t *testing.T) {
 	r, _ := http.NewRequest("GET", "/admin/", nil)
 	w := httptest.NewRecorder()
 	handler := NewControllerRegister()
-	handler.InsertFilter("/admin/?:all", BeforeRouter, FilterAdminUser)
+	handler.InsertFilter("*", "/admin/?:all", BeforeRouter, FilterAdminUser)
 	handler.ServeHTTP(w, r)
 	if w.Body.String() != "i am admin" {
 		t.Errorf("filter /admin/ can't run")
@@ -60,9 +60,33 @@ func TestPatternThree(t *testing.T) {
 	r, _ := http.NewRequest("GET", "/admin/astaxie", nil)
 	w := httptest.NewRecorder()
 	handler := NewControllerRegister()
-	handler.InsertFilter("/admin/:all", BeforeRouter, FilterAdminUser)
+	handler.InsertFilter("*", "/admin/:all", BeforeRouter, FilterAdminUser)
 	handler.ServeHTTP(w, r)
 	if w.Body.String() != "i am admin" {
 		t.Errorf("filter /admin/astaxie can't run")
+	}
+}
+
+func TestMethodFilter(t *testing.T) {
+	r, _ := http.NewRequest("GET", "/person/asta/Xie", nil)
+	w := httptest.NewRecorder()
+	handler := NewControllerRegister()
+	handler.InsertFilter("GET", "/person/:last/:first", BeforeRouter, FilterUser)
+	handler.Add("/person/:last/:first", &TestController{})
+	handler.ServeHTTP(w, r)
+	if w.Body.String() != "i am astaXie" {
+		t.Errorf("user define func can't run")
+	}
+}
+
+func TestMethodNotFilter(t *testing.T) {
+	r, _ := http.NewRequest("POST", "/person/asta/Xie", nil)
+	w := httptest.NewRecorder()
+	handler := NewControllerRegister()
+	handler.InsertFilter("GET", "/person/:last/:first", BeforeRouter, FilterUser)
+	handler.Add("/person/:last/:first", &TestController{})
+	handler.ServeHTTP(w, r)
+	if w.Body.String() != "" {
+		t.Errorf("filter was called for wrong method")
 	}
 }

--- a/namespace.go
+++ b/namespace.go
@@ -68,7 +68,7 @@ func (n *Namespace) Cond(cond namespaceCond) *Namespace {
 		mr.tree.AddRouter("*", true)
 		n.handlers.filters[BeforeRouter] = append([]*FilterRouter{mr}, v...)
 	} else {
-		n.handlers.InsertFilter("*", BeforeRouter, fn)
+		n.handlers.InsertFilter("*", "*", BeforeRouter, fn)
 	}
 	return n
 }
@@ -91,7 +91,7 @@ func (n *Namespace) Filter(action string, filter ...FilterFunc) *Namespace {
 		a = FinishRouter
 	}
 	for _, f := range filter {
-		n.handlers.InsertFilter("*", a, f)
+		n.handlers.InsertFilter("*", "*", a, f)
 	}
 	return n
 }

--- a/plugins/cors/cors_test.go
+++ b/plugins/cors/cors_test.go
@@ -56,7 +56,7 @@ func (gr *HTTPHeaderGuardRecorder) Header() http.Header {
 func Test_AllowAll(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	handler := beego.NewControllerRegister()
-	handler.InsertFilter("*", beego.BeforeRouter, Allow(&Options{
+	handler.InsertFilter("*", "*", beego.BeforeRouter, Allow(&Options{
 		AllowAllOrigins: true,
 	}))
 	handler.Any("/foo", func(ctx *context.Context) {
@@ -73,7 +73,7 @@ func Test_AllowAll(t *testing.T) {
 func Test_AllowRegexMatch(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	handler := beego.NewControllerRegister()
-	handler.InsertFilter("*", beego.BeforeRouter, Allow(&Options{
+	handler.InsertFilter("*", "*", beego.BeforeRouter, Allow(&Options{
 		AllowOrigins: []string{"https://aaa.com", "https://*.foo.com"},
 	}))
 	handler.Any("/foo", func(ctx *context.Context) {
@@ -93,7 +93,7 @@ func Test_AllowRegexMatch(t *testing.T) {
 func Test_AllowRegexNoMatch(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	handler := beego.NewControllerRegister()
-	handler.InsertFilter("*", beego.BeforeRouter, Allow(&Options{
+	handler.InsertFilter("*", "*", beego.BeforeRouter, Allow(&Options{
 		AllowOrigins: []string{"https://*.foo.com"},
 	}))
 	handler.Any("/foo", func(ctx *context.Context) {
@@ -113,7 +113,7 @@ func Test_AllowRegexNoMatch(t *testing.T) {
 func Test_OtherHeaders(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	handler := beego.NewControllerRegister()
-	handler.InsertFilter("*", beego.BeforeRouter, Allow(&Options{
+	handler.InsertFilter("*", "*", beego.BeforeRouter, Allow(&Options{
 		AllowAllOrigins:  true,
 		AllowCredentials: true,
 		AllowMethods:     []string{"PATCH", "GET"},
@@ -157,7 +157,7 @@ func Test_OtherHeaders(t *testing.T) {
 func Test_DefaultAllowHeaders(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	handler := beego.NewControllerRegister()
-	handler.InsertFilter("*", beego.BeforeRouter, Allow(&Options{
+	handler.InsertFilter("*", "*", beego.BeforeRouter, Allow(&Options{
 		AllowAllOrigins: true,
 	}))
 	handler.Any("/foo", func(ctx *context.Context) {
@@ -176,7 +176,7 @@ func Test_DefaultAllowHeaders(t *testing.T) {
 func Test_Preflight(t *testing.T) {
 	recorder := NewRecorder()
 	handler := beego.NewControllerRegister()
-	handler.InsertFilter("*", beego.BeforeRouter, Allow(&Options{
+	handler.InsertFilter("*", "*", beego.BeforeRouter, Allow(&Options{
 		AllowAllOrigins: true,
 		AllowMethods:    []string{"PUT", "PATCH"},
 		AllowHeaders:    []string{"Origin", "X-whatever", "X-CaseSensitive"},
@@ -235,7 +235,7 @@ func Benchmark_WithCORS(b *testing.B) {
 	recorder := httptest.NewRecorder()
 	handler := beego.NewControllerRegister()
 	beego.BConfig.RunMode = beego.PROD
-	handler.InsertFilter("*", beego.BeforeRouter, Allow(&Options{
+	handler.InsertFilter("*", "*", beego.BeforeRouter, Allow(&Options{
 		AllowAllOrigins:  true,
 		AllowCredentials: true,
 		AllowMethods:     []string{"PATCH", "GET"},

--- a/router.go
+++ b/router.go
@@ -412,10 +412,11 @@ func (p *ControllerRegister) AddAutoPrefix(prefix string, c ControllerInterface)
 // params is for:
 //   1. setting the returnOnOutput value (false allows multiple filters to execute)
 //   2. determining whether or not params need to be reset.
-func (p *ControllerRegister) InsertFilter(pattern string, pos int, filter FilterFunc, params ...bool) error {
+func (p *ControllerRegister) InsertFilter(method string, pattern string, pos int, filter FilterFunc, params ...bool) error {
 	mr := &FilterRouter{
 		tree:           NewTree(),
 		pattern:        pattern,
+		method:         method,
 		filterFunc:     filter,
 		returnOnOutput: true,
 	}

--- a/router_test.go
+++ b/router_test.go
@@ -426,7 +426,7 @@ func TestInsertFilter(t *testing.T) {
 	testName := "TestInsertFilter"
 
 	mux := NewControllerRegister()
-	mux.InsertFilter("*", BeforeRouter, func(*context.Context) {})
+	mux.InsertFilter("*", "*", BeforeRouter, func(*context.Context) {})
 	if !mux.filters[BeforeRouter][0].returnOnOutput {
 		t.Errorf(
 			"%s: passing no variadic params should set returnOnOutput to true",
@@ -439,7 +439,7 @@ func TestInsertFilter(t *testing.T) {
 	}
 
 	mux = NewControllerRegister()
-	mux.InsertFilter("*", BeforeRouter, func(*context.Context) {}, false)
+	mux.InsertFilter("*", "*", BeforeRouter, func(*context.Context) {}, false)
 	if mux.filters[BeforeRouter][0].returnOnOutput {
 		t.Errorf(
 			"%s: passing false as 1st variadic param should set returnOnOutput to false",
@@ -447,7 +447,7 @@ func TestInsertFilter(t *testing.T) {
 	}
 
 	mux = NewControllerRegister()
-	mux.InsertFilter("*", BeforeRouter, func(*context.Context) {}, true, true)
+	mux.InsertFilter("*", "*", BeforeRouter, func(*context.Context) {}, true, true)
 	if !mux.filters[BeforeRouter][0].resetParams {
 		t.Errorf(
 			"%s: passing true as 2nd variadic param should set resetParams to true",
@@ -464,7 +464,7 @@ func TestParamResetFilter(t *testing.T) {
 
 	mux := NewControllerRegister()
 
-	mux.InsertFilter("*", BeforeExec, beegoResetParams, true, true)
+	mux.InsertFilter("*", "*", BeforeExec, beegoResetParams, true, true)
 
 	mux.Get(route, beegoHandleResetParams)
 
@@ -495,7 +495,7 @@ func TestFilterBeforeRouter(t *testing.T) {
 	url := "/beforeRouter"
 
 	mux := NewControllerRegister()
-	mux.InsertFilter(url, BeforeRouter, beegoBeforeRouter1)
+	mux.InsertFilter("*", url, BeforeRouter, beegoBeforeRouter1)
 
 	mux.Get(url, beegoFilterFunc)
 
@@ -517,8 +517,8 @@ func TestFilterBeforeExec(t *testing.T) {
 	url := "/beforeExec"
 
 	mux := NewControllerRegister()
-	mux.InsertFilter(url, BeforeRouter, beegoFilterNoOutput)
-	mux.InsertFilter(url, BeforeExec, beegoBeforeExec1)
+	mux.InsertFilter("*", url, BeforeRouter, beegoFilterNoOutput)
+	mux.InsertFilter("*", url, BeforeExec, beegoBeforeExec1)
 
 	mux.Get(url, beegoFilterFunc)
 
@@ -543,9 +543,9 @@ func TestFilterAfterExec(t *testing.T) {
 	url := "/afterExec"
 
 	mux := NewControllerRegister()
-	mux.InsertFilter(url, BeforeRouter, beegoFilterNoOutput)
-	mux.InsertFilter(url, BeforeExec, beegoFilterNoOutput)
-	mux.InsertFilter(url, AfterExec, beegoAfterExec1, false)
+	mux.InsertFilter("*", url, BeforeRouter, beegoFilterNoOutput)
+	mux.InsertFilter("*", url, BeforeExec, beegoFilterNoOutput)
+	mux.InsertFilter("*", url, AfterExec, beegoAfterExec1, false)
 
 	mux.Get(url, beegoFilterFunc)
 
@@ -573,10 +573,10 @@ func TestFilterFinishRouter(t *testing.T) {
 	url := "/finishRouter"
 
 	mux := NewControllerRegister()
-	mux.InsertFilter(url, BeforeRouter, beegoFilterNoOutput)
-	mux.InsertFilter(url, BeforeExec, beegoFilterNoOutput)
-	mux.InsertFilter(url, AfterExec, beegoFilterNoOutput)
-	mux.InsertFilter(url, FinishRouter, beegoFinishRouter1)
+	mux.InsertFilter("*", url, BeforeRouter, beegoFilterNoOutput)
+	mux.InsertFilter("*", url, BeforeExec, beegoFilterNoOutput)
+	mux.InsertFilter("*", url, AfterExec, beegoFilterNoOutput)
+	mux.InsertFilter("*", url, FinishRouter, beegoFinishRouter1)
 
 	mux.Get(url, beegoFilterFunc)
 
@@ -607,8 +607,8 @@ func TestFilterFinishRouterMultiFirstOnly(t *testing.T) {
 	url := "/finishRouterMultiFirstOnly"
 
 	mux := NewControllerRegister()
-	mux.InsertFilter(url, FinishRouter, beegoFinishRouter1, false)
-	mux.InsertFilter(url, FinishRouter, beegoFinishRouter2)
+	mux.InsertFilter("*", url, FinishRouter, beegoFinishRouter1, false)
+	mux.InsertFilter("*", url, FinishRouter, beegoFinishRouter2)
 
 	mux.Get(url, beegoFilterFunc)
 
@@ -634,8 +634,8 @@ func TestFilterFinishRouterMulti(t *testing.T) {
 	url := "/finishRouterMulti"
 
 	mux := NewControllerRegister()
-	mux.InsertFilter(url, FinishRouter, beegoFinishRouter1, false)
-	mux.InsertFilter(url, FinishRouter, beegoFinishRouter2, false)
+	mux.InsertFilter("*", url, FinishRouter, beegoFinishRouter1, false)
+	mux.InsertFilter("*", url, FinishRouter, beegoFinishRouter2, false)
 
 	mux.Get(url, beegoFilterFunc)
 


### PR DESCRIPTION
Proposal for new API `InsertMethodFilter`.

We are building RESTish API with beego. Therefore we heavy relay on HTTP method. Quite often we need different filters depend on action-method. Right now we have no choice but to write a little bit ugly code like this:

```go
beego.InsertFilter("/api/*", beego.BeforeRouter, func(ctx *context.Context) {
  switch ctx.Request.Method {
  case "GET":
      FilterGet(ctx)
      break
  case "POST":
      FilterPost(ctx)
      break
  case "PUT":
      FilterPut(ctx)
      break
})

beego.Router("/api/packages", &controllers.PackageController{})
beego.InsertFilter("/api/packages", beego.BeforeRouter, func(ctx *context.Context) {
  switch ctx.Request.Method {
  case "GET":
      PackageFilterGet(ctx)
      break
  case "POST":
      PackageFilterPost(ctx)
      break
})
```

it will be much cleaner to write like this:
```go
beego.Router("/api/packages", &controllers.PackageController{})
beego.InsertMethodFilter("GET", "/api/*", beego.BeforeRouter, FilterGet)
beego.InsertMethodFilter("POST", "/api/*", beego.BeforeRouter, FilterPost)
beego.InsertMethodFilter("PUT", "/api/*", beego.BeforeRouter, FilterPut)
beego.InsertMethodFilter("GET", "/api/packages", beego.BeforeRouter, PackageFilterGet)
beego.InsertMethodFilter("POST", "/api/packages", beego.BeforeRouter, PackageFilterPost)
```