### PR TITLE
beego/session: return proper error when session is not found

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -207,7 +207,7 @@ func (manager *Manager) SessionStart(w http.ResponseWriter, r *http.Request) (se
 
 	session, err = manager.provider.SessionRead(sid)
 	if err != nil {
-		return nil, errs
+		return nil, err
 	}
 	cookie := &http.Cookie{
 		Name:     manager.config.CookieName,


### PR DESCRIPTION
Parent errs was returned instead of err which is returned from the last statement.
