### PR TITLE
typo fix in comments, Getfiles-->GetFiles

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -492,7 +492,7 @@ func (c *Controller) GetFile(key string) (multipart.File, *multipart.FileHeader,
 }
 
 // GetFiles return multi-upload files
-// files, err:=c.Getfiles("myfiles")
+// files, err:=c.GetFiles("myfiles")
 //	if err != nil {
 //		http.Error(w, err.Error(), http.StatusNoContent)
 //		return


### PR DESCRIPTION
修正 文件controller.go示例代码中的函数名错误。
Getfiles 修正为 GetFiles
