### PR TITLE
set perm of rotated log to 440

### DIFF
--- a/logs/file.go
+++ b/logs/file.go
@@ -270,6 +270,7 @@ func (w *fileLogWriter) doRotate(logTime time.Time) error {
 	// Rename the file to its new found name
 	// even if occurs error,we MUST guarantee to  restart new logger
 	err = os.Rename(w.Filename, fName)
+	err = os.Chmod(fName, os.FileMode(440))
 	// re-start logger
 RESTART_LOGGER:
 


### PR DESCRIPTION
把已经rotate的log权限设置为440，防止被误篡改。

issue: https://github.com/astaxie/beego/issues/2308