### PR TITLE
Remove a regression on AppPath

### DIFF
--- a/config.go
+++ b/config.go
@@ -144,9 +144,6 @@ func init() {
 	if err = parseConfig(appConfigPath); err != nil {
 		panic(err)
 	}
-	if err = os.Chdir(AppPath); err != nil {
-		panic(err)
-	}
 }
 
 func recoverPanic(ctx *context.Context) {


### PR DESCRIPTION
The application path is incorrect on Windows with the command line "go run". AppPath is assigned to the temp directory instead the folder project