### PR TITLE
Modify func camelString() to be more robust

### DIFF
--- a/orm/utils.go
+++ b/orm/utils.go
@@ -219,22 +219,15 @@ func snakeString(s string) string {
 // camel string, xx_yy to XxYy
 func camelString(s string) string {
 	data := make([]byte, 0, len(s))
-	j := false
-	k := false
-	num := len(s) - 1
+	flag, num := true, len(s)-1
 	for i := 0; i <= num; i++ {
 		d := s[i]
-		if k == false && d >= 'A' && d <= 'Z' {
-			k = true
-		}
-		if d >= 'a' && d <= 'z' && (j || k == false) {
-			d = d - 32
-			j = false
-			k = true
-		}
-		if k && d == '_' && num > i && s[i+1] >= 'a' && s[i+1] <= 'z' {
-			j = true
+		if d == '_' {
+			flag = true
 			continue
+		} else if flag == true && d >= 'a' && d <= 'z' {
+			d = d - 32
+			flag = false
 		}
 		data = append(data, d)
 	}


### PR DESCRIPTION
With the old version, the case "pic_url_1" will return "PicUrl_1". Actually, the answer "PicUrl1" will be more reasonable. 

More test cases(the right is output of our function) is as follow:
1. "pic_url": "PicUrl"
2. "hello_world_":"HelloWorld"
3. "hello__World":"HelloWorld"
4. "_HelLO_Word": "HelLOWord"
5. "pic_url_1" : "PicUrl1"
6. "pic_url__1": "PicUrl1"

Thanks.
