### PR TITLE
Changing content type for template

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -185,7 +185,11 @@ func (c *Controller) Render() error {
 	if err != nil {
 		return err
 	}
-	c.Ctx.Output.Header("Content-Type", "text/html; charset=utf-8")
+
+	if c.Ctx.ResponseWriter.Header().Get("Content-Type") == "" {
+		c.Ctx.Output.Header("Content-Type", "text/html; charset=utf-8")
+	}
+
 	return c.Ctx.Output.Body(rb)
 }
 


### PR DESCRIPTION
In the rendering of the template, the render function will overwrite the content type, this PR, will enable the dev to alter the content type even if he uses templating, as use case of this functionality, the ability to generate dynamic JS or CSS files.