### PR TITLE
replace kill() with Signal(syscall.SIGINT) 

### DIFF
--- a/grace/server.go
+++ b/grace/server.go
@@ -65,7 +65,9 @@ func (srv *Server) ListenAndServe() (err error) {
 			log.Println(err)
 			return err
 		}
-		err = process.Kill()
+		//Do not use process.Kill() it will force the pprocess exit.
+		//which lead to all the post handler not work at all.
+		err = process.Signal(syscall.SIGINT)
 		if err != nil {
 			return err
 		}
@@ -120,7 +122,7 @@ func (srv *Server) ListenAndServeTLS(certFile, keyFile string) (err error) {
 			log.Println(err)
 			return err
 		}
-		err = process.Kill()
+		err = process.Signal(syscall.SIGINT)
 		if err != nil {
 			return err
 		}

--- a/grace/server.go
+++ b/grace/server.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -242,6 +243,7 @@ func (srv *Server) serverTimeout(d time.Duration) {
 			break
 		}
 		srv.wg.Done()
+		runtime.Gosched()
 	}
 }
 


### PR DESCRIPTION
Kill signal will force the process exit, so it won't work in graceful mode