### PR TITLE
Modify func camelString() to be more robust

### DIFF
--- a/orm/utils.go
+++ b/orm/utils.go
@@ -219,22 +219,17 @@ func snakeString(s string) string {
 // camel string, xx_yy to XxYy
 func camelString(s string) string {
 	data := make([]byte, 0, len(s))
-	j := false
-	k := false
-	num := len(s) - 1
+	flag, num := true, len(s)-1
 	for i := 0; i <= num; i++ {
 		d := s[i]
-		if k == false && d >= 'A' && d <= 'Z' {
-			k = true
-		}
-		if d >= 'a' && d <= 'z' && (j || k == false) {
-			d = d - 32
-			j = false
-			k = true
-		}
-		if k && d == '_' && num > i && s[i+1] >= 'a' && s[i+1] <= 'z' {
-			j = true
+		if d == '_' {
+			flag = true
 			continue
+		} else if flag == true {
+			if d >= 'a' && d <= 'z' {
+				d = d - 32
+			}
+			flag = false
 		}
 		data = append(data, d)
 	}

--- a/orm/utils_test.go
+++ b/orm/utils_test.go
@@ -1,0 +1,36 @@
+// Copyright 2014 beego Author. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orm
+
+import (
+	"testing"
+)
+
+func TestCamelString(t *testing.T) {
+	snake := []string{"pic_url", "hello_world_", "hello__World", "_HelLO_Word", "pic_url_1", "pic_url__1"}
+	camel := []string{"PicUrl", "HelloWorld", "HelloWorld", "HelLOWord", "PicUrl1", "PicUrl1"}
+
+	answer := make(map[string]string)
+	for i, v := range snake {
+		answer[v] = camel[i]
+	}
+
+	for _, v := range snake {
+		res := camelString(v)
+		if res != answer[v] {
+			t.Error("Unit Test Fail:", v, res, answer[v])
+		}
+	}
+}


### PR DESCRIPTION
Hello, in the previous pull request #2343 , I mix the history commits,  so I close it, and make a new one. Sorry for that.

Here is the points.
1. In previous edition, for case "pic_url_1", the func camelString() will return
"PicUrl_1", but "PicUrl1" seems to be more reasonable. So I make this change.
2. For my commit, test cases are as follow:
* "pic_url" -> "PicUrl" 
* "hello_world_" -> "HelloWorld"
* "hello__World" -> "HelloWorld"
* "_HelLO_Word" -> "HelLOWord"
* "pic_url_1" -> "PicUrl1"
* "pic_url__1" -> "PicUrl1"

about the test, please refer to file utils_test.go

Thanks.
