### PR TITLE
enrich the funtion of toolbox.NewTaskDevelop

### DIFF
--- a/toolbox/task.go
+++ b/toolbox/task.go
@@ -438,7 +438,7 @@ func run() {
 				if e.GetNext() != effective {
 					break
 				}
-				// if the task it's running and it's delay type equals true, then ignore this calling
+				// if the task is running and its delay type equals true, then ignore this calling
 				if e.IsRunning() && e.IsDelay() {
 					e.SetPrev(e.GetNext())
 					e.SetNext(effective)


### PR DESCRIPTION
if i want a task start another thread to do it's job after current job shutting down, current api cannot support my our feeds. so i suggest adding another param named delayType, to make this work. if we do this, a task T can start a thread t1, and start another thread t2 after t1 it's done in period we set.