### PR TITLE
EnableGZip=true,then content-length header missing

### DIFF
--- a/context/output.go
+++ b/context/output.go
@@ -67,9 +67,9 @@ func (output *BeegoOutput) Body(content []byte) error {
 	}
 	if b, n, _ := WriteBody(encoding, buf, content); b {
 		output.Header("Content-Encoding", n)
-	} else {
-		output.Header("Content-Length", strconv.Itoa(len(content)))
-	}
+	} 
+	output.Header("Content-Length", strconv.Itoa(len(content)))
+	
 	// Write status code if it has been set manually
 	// Set it to 0 afterwards to prevent "multiple response.WriteHeader calls"
 	if output.Status != 0 {

--- a/context/output.go
+++ b/context/output.go
@@ -67,8 +67,11 @@ func (output *BeegoOutput) Body(content []byte) error {
 	}
 	if b, n, _ := WriteBody(encoding, buf, content); b {
 		output.Header("Content-Encoding", n)
-	} 
-	output.Header("Content-Length", strconv.Itoa(len(content)))
+		output.Header("Content-Length", strconv.Itoa(buf.Len()))
+	} else {
+		output.Header("Content-Length", strconv.Itoa(len(content)))
+	}
+
 	
 	// Write status code if it has been set manually
 	// Set it to 0 afterwards to prevent "multiple response.WriteHeader calls"


### PR DESCRIPTION
This results in responses with Content-Type as gzip as opposed to original content type.
This affects ServeJSON() function.

Also content-type is set wrong in this case , resulting in loss of functionality to gzip encode JSON output.