### PR TITLE
[WIP]Have Required validator trim strings to fix #2361

### DIFF
--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -35,6 +35,12 @@ func TestRequired(t *testing.T) {
 	if valid.Required("", "string").Ok {
 		t.Error("\"'\" string should be false")
 	}
+	if valid.Required(" ", "string").Ok {
+		t.Error("\" \" string should be false") // For #2361
+	}
+	if valid.Required("\n", "string").Ok {
+		t.Error("new line string should be false") // For #2361
+	}
 	if !valid.Required("astaxie", "string").Ok {
 		t.Error("string should be true")
 	}

--- a/validation/validators.go
+++ b/validation/validators.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strings"
 	"time"
 	"unicode/utf8"
 )
@@ -98,7 +99,7 @@ func (r Required) IsSatisfied(obj interface{}) bool {
 	}
 
 	if str, ok := obj.(string); ok {
-		return len(str) > 0
+		return len(strings.TrimSpace(str)) > 0
 	}
 	if _, ok := obj.(bool); ok {
 		return true


### PR DESCRIPTION
This will cause the Required validator not to consider fields that has
only spaces or new lines to be regarded as valid. This is done by
checking if the trimmed version of the string is valid.