### PR TITLE
Add trim ability in validator.Valid() for all string fields

### DIFF
--- a/validation/validation.go
+++ b/validation/validation.go
@@ -321,6 +321,15 @@ func (v *Validation) Valid(obj interface{}) (b bool, err error) {
 
 	for i := 0; i < objT.NumField(); i++ {
 		var vfs []ValidFunc
+		field := objV.Field(i)
+		// Trim spaces from string fields
+		if field.Kind() == reflect.String && field.CanSet() {
+			str := field.String()
+			trim := strings.TrimSpace(str)
+			if str != trim {
+				field.SetString(trim)
+			}
+		}
 		if vfs, err = getValidFuncs(objT.Field(i)); err != nil {
 			return
 		}

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -348,6 +348,20 @@ func TestValid(t *testing.T) {
 	if valid.Errors[0].Key != "Age.Range" {
 		t.Errorf("Message key should be `Name.Match` but got %s", valid.Errors[0].Key)
 	}
+
+	// Test if spaces was trimmed
+	u = user{Name: "   \ntest@/test/;com ", Age: 40}
+	valid.Clear()
+	b, err = valid.Valid(&u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !b {
+		t.Error("validation should be passed")
+	}
+	if u.Name != "test@/test/;com" {
+		t.Errorf("validation should have trimmed `Name`, but returned %s", u.Name)
+	}
 }
 
 func TestRecursiveValid(t *testing.T) {


### PR DESCRIPTION
This will allow all string fields for structs that are passed by
reference to validator.Valid() to have their value trimmed
automatically.

This will prevent a bypass on all validators (like Length,
MinSize and Maxsize) by just adding enough spaces. And it will help
to prevent DBs from becoming polluted with padding spaces.