### PR TITLE
beego/config:remove temp file after parse done which ParseData created

### DIFF
--- a/config/ini.go
+++ b/config/ini.go
@@ -184,6 +184,8 @@ func (ini *IniConfig) ParseData(data []byte) (Configer, error) {
 	if err := ioutil.WriteFile(tmpName, data, 0655); err != nil {
 		return nil, err
 	}
+	defer os.Remove(tmpName)
+
 	return ini.Parse(tmpName)
 }
 

--- a/config/xml/xml.go
+++ b/config/xml/xml.go
@@ -81,6 +81,8 @@ func (xc *Config) ParseData(data []byte) (config.Configer, error) {
 	if err := ioutil.WriteFile(tmpName, data, 0655); err != nil {
 		return nil, err
 	}
+	defer os.Remove(tmpName)
+
 	return xc.Parse(tmpName)
 }
 

--- a/config/yaml/yaml.go
+++ b/config/yaml/yaml.go
@@ -69,6 +69,8 @@ func (yaml *Config) ParseData(data []byte) (config.Configer, error) {
 	if err := ioutil.WriteFile(tmpName, data, 0655); err != nil {
 		return nil, err
 	}
+	defer os.Remove(tmpName)
+
 	return yaml.Parse(tmpName)
 }
 


### PR DESCRIPTION
temp files should removed after works done.