### PR TITLE
avoid creating new file to implements Config

### DIFF
--- a/config/xml/xml.go
+++ b/config/xml/xml.go
@@ -35,11 +35,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/astaxie/beego/config"
 	"github.com/beego/x2j"
@@ -52,36 +50,26 @@ type Config struct{}
 
 // Parse returns a ConfigContainer with parsed xml config map.
 func (xc *Config) Parse(filename string) (config.Configer, error) {
-	file, err := os.Open(filename)
+	context, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
 
+	return xc.ParseData(context)
+}
+
+// ParseData xml data
+func (xc *Config) ParseData(data []byte) (config.Configer, error) {
 	x := &ConfigContainer{data: make(map[string]interface{})}
-	content, err := ioutil.ReadAll(file)
-	if err != nil {
-		return nil, err
-	}
 
-	d, err := x2j.DocToMap(string(content))
+	d, err := x2j.DocToMap(string(data))
 	if err != nil {
 		return nil, err
 	}
 
 	x.data = config.ExpandValueEnvForMap(d["config"].(map[string]interface{}))
-	return x, nil
-}
 
-// ParseData xml data
-func (xc *Config) ParseData(data []byte) (config.Configer, error) {
-	// Save memory data to temporary file
-	tmpName := path.Join(os.TempDir(), "beego", fmt.Sprintf("%d", time.Now().Nanosecond()))
-	os.MkdirAll(path.Dir(tmpName), os.ModePerm)
-	if err := ioutil.WriteFile(tmpName, data, 0655); err != nil {
-		return nil, err
-	}
-	return xc.Parse(tmpName)
+	return x, nil
 }
 
 // ConfigContainer A Config represents the xml configuration.

--- a/config/yaml/yaml.go
+++ b/config/yaml/yaml.go
@@ -37,10 +37,8 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/astaxie/beego/config"
 	"github.com/beego/goyaml2"
@@ -63,26 +61,30 @@ func (yaml *Config) Parse(filename string) (y config.Configer, err error) {
 
 // ParseData parse yaml data
 func (yaml *Config) ParseData(data []byte) (config.Configer, error) {
-	// Save memory data to temporary file
-	tmpName := path.Join(os.TempDir(), "beego", fmt.Sprintf("%d", time.Now().Nanosecond()))
-	os.MkdirAll(path.Dir(tmpName), os.ModePerm)
-	if err := ioutil.WriteFile(tmpName, data, 0655); err != nil {
+	cnf, err := parseYML(data)
+	if err != nil {
 		return nil, err
 	}
-	return yaml.Parse(tmpName)
+
+	return &ConfigContainer{
+		data: cnf,
+	}, nil
 }
 
 // ReadYmlReader Read yaml file to map.
 // if json like, use json package, unless goyaml2 package.
 func ReadYmlReader(path string) (cnf map[string]interface{}, err error) {
-	f, err := os.Open(path)
+	buf, err := ioutil.ReadFile(path)
 	if err != nil {
 		return
 	}
-	defer f.Close()
 
-	buf, err := ioutil.ReadAll(f)
-	if err != nil || len(buf) < 3 {
+	return parseYML(buf)
+}
+
+// parseYML parse yaml formatted []byte to map.
+func parseYML(buf []byte) (cnf map[string]interface{}, err error) {
+	if len(buf) < 3 {
 		return
 	}
 


### PR DESCRIPTION
There is no need to create new file in ParseData(data []byte) (Configer, error).
let's make code simply.

when handle include "other.conf", the otherfile is either absolute dir or in current directory.