### PR TITLE
fix filter with __ne bug

### DIFF
--- a/orm/db.go
+++ b/orm/db.go
@@ -48,6 +48,7 @@ var (
 		"lte":         true,
 		"eq":          true,
 		"nq":          true,
+		"ne":	       true,
 		"startswith":  true,
 		"endswith":    true,
 		"istartswith": true,


### PR DESCRIPTION
db_mysql.go 里面mysqlOperators有ne这个key，但是在db.go里面检查时候没有ne这个，所以会报错，造成无法用类似这种查询qs.Filter("status__ne","1")