### PR TITLE
fix the bug to prevent rewrite t

### DIFF
--- a/template.go
+++ b/template.go
@@ -224,7 +224,7 @@ func getTplDeep(root, file, parent string, t *template.Template) (*template.Temp
 			if !HasTemplateExt(m[1]) {
 				continue
 			}
-			t, _, err = getTplDeep(root, m[1], file, t)
+			_, _, err = getTplDeep(root, m[1], file, t)
 			if err != nil {
 				return nil, [][]string{}, err
 			}


### PR DESCRIPTION
the t have parsed in line 212,and t is a point , and it will rewrite in the getTplDeep function, so  the origin date will be removed.
the t.New(file) operate in line 212 product a new template from t and extend some information about t.
if you debug it when the tpl file has line like 
{{ template "" .}}
the file info of parent tpl  will become of the file above of.