### PR TITLE
support for multiple view paths

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -69,6 +69,7 @@ type Controller struct {
 
 	// template data
 	TplName        string
+	ViewPath       string
 	Layout         string
 	LayoutSections map[string]string // the key is the section name and the value is the template name
 	TplPrefix      string
@@ -213,7 +214,7 @@ func (c *Controller) RenderBytes() ([]byte, error) {
 					continue
 				}
 				buf.Reset()
-				err = ExecuteTemplate(&buf, sectionTpl, c.Data)
+				err = ExecuteViewPathTemplate(&buf, sectionTpl, c.viewPath(), c.Data)
 				if err != nil {
 					return nil, err
 				}
@@ -222,7 +223,7 @@ func (c *Controller) RenderBytes() ([]byte, error) {
 		}
 
 		buf.Reset()
-		ExecuteTemplate(&buf, c.Layout, c.Data)
+		ExecuteViewPathTemplate(&buf, c.Layout, c.viewPath() ,c.Data)
 	}
 	return buf.Bytes(), err
 }
@@ -248,9 +249,16 @@ func (c *Controller) renderTemplate() (bytes.Buffer, error) {
 				}
 			}
 		}
-		BuildTemplate(BConfig.WebConfig.ViewsPath, buildFiles...)
+		BuildTemplate(c.viewPath() , buildFiles...)
 	}
-	return buf, ExecuteTemplate(&buf, c.TplName, c.Data)
+	return buf, ExecuteViewPathTemplate(&buf, c.TplName, c.viewPath(), c.Data)
+}
+
+func (c *Controller) viewPath() string {
+	if c.ViewPath == "" {
+		return BConfig.WebConfig.ViewsPath
+	}
+	return c.ViewPath
 }
 
 // Redirect sends the redirection response to url with status code.

--- a/controller_test.go
+++ b/controller_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/astaxie/beego/context"
+	"os"
+	"path/filepath"
 )
 
 func TestGetInt(t *testing.T) {
@@ -120,4 +122,60 @@ func TestGetUint64(t *testing.T) {
 	if val != math.MaxUint64 {
 		t.Errorf("TestGetUint64 expect %v,get %T,%v", uint64(math.MaxUint64), val, val)
 	}
+}
+
+func TestAdditionalViewPaths(t *testing.T) {
+	dir1 := "_beeTmp"
+	dir2 := "_beeTmp2"
+	defer os.RemoveAll(dir1)
+	defer os.RemoveAll(dir2)
+
+	dir1file := "file1.tpl"
+	dir2file := "file2.tpl"
+
+	genFile := func(dir string, name string, content string) {
+		os.MkdirAll(filepath.Dir(filepath.Join(dir, name)), 0777)
+		if f, err := os.Create(filepath.Join(dir, name)); err != nil {
+			t.Fatal(err)
+		} else {
+			defer f.Close()
+			f.WriteString(content)
+			f.Close()
+		}
+
+	}
+	genFile(dir1, dir1file, `<div>{{.Content}}</div>`)
+	genFile(dir2, dir2file, `<html>{{.Content}}</html>`)
+
+	AddViewPath(dir1)
+	AddViewPath(dir2)
+
+	ctrl := Controller{
+		TplName:  "file1.tpl",
+		ViewPath: dir1,
+	}
+	ctrl.Data = map[interface{}]interface{}{
+		"Content": "value2",
+	}
+	if result, err := ctrl.RenderString(); err != nil {
+		t.Fatal(err)
+	} else {
+		if result != "<div>value2</div>" {
+			t.Fatalf("TestAdditionalViewPaths expect %s got %s", "<div>value2</div>", result)
+		}
+	}
+
+	func() {
+		ctrl.TplName = "file2.tpl"
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("TestAdditionalViewPaths expected error")
+			}
+		}()
+		ctrl.RenderString();
+	}()
+
+	ctrl.TplName = "file2.tpl"
+	ctrl.ViewPath = dir2
+	ctrl.RenderString();
 }

--- a/hooks.go
+++ b/hooks.go
@@ -72,7 +72,7 @@ func registerSession() error {
 }
 
 func registerTemplate() error {
-	if err := BuildTemplate(BConfig.WebConfig.ViewsPath); err != nil {
+	if err := AddViewPath(BConfig.WebConfig.ViewsPath); err != nil {
 		if BConfig.RunMode == DEV {
 			logs.Warn(err)
 		}

--- a/hooks.go
+++ b/hooks.go
@@ -72,6 +72,7 @@ func registerSession() error {
 }
 
 func registerTemplate() error {
+	defer lockViewPaths()
 	if err := AddViewPath(BConfig.WebConfig.ViewsPath); err != nil {
 		if BConfig.RunMode == DEV {
 			logs.Warn(err)

--- a/template_test.go
+++ b/template_test.go
@@ -67,9 +67,10 @@ func TestTemplate(t *testing.T) {
 			f.Close()
 		}
 	}
-	if err := BuildTemplate(dir); err != nil {
+	if err := AddViewPath(dir); err != nil {
 		t.Fatal(err)
 	}
+	beeTemplates := beeViewPathTemplates[dir]
 	if len(beeTemplates) != 3 {
 		t.Fatalf("should be 3 but got %v", len(beeTemplates))
 	}
@@ -103,6 +104,12 @@ var user = `<!DOCTYPE html>
 
 func TestRelativeTemplate(t *testing.T) {
 	dir := "_beeTmp"
+
+	//Just add dir to known viewPaths
+	if err := AddViewPath(dir); err != nil {
+		t.Fatal(err)
+	}
+
 	files := []string{
 		"easyui/public/menu.tpl",
 		"easyui/rbac/user.tpl",
@@ -126,6 +133,7 @@ func TestRelativeTemplate(t *testing.T) {
 	if err := BuildTemplate(dir, files[1]); err != nil {
 		t.Fatal(err)
 	}
+	beeTemplates := beeViewPathTemplates[dir]
 	if err := beeTemplates["easyui/rbac/user.tpl"].ExecuteTemplate(os.Stdout, "easyui/rbac/user.tpl", nil); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Added support for multiple view paths in addition to BConfig.WebConfig.ViewsPath
To use another path, call beego.AddViewPath() with the additional path and set the controller.ViewPath accordingly

