### PR TITLE
Add LengthRange and mod cache module

### DIFF
--- a/cache/memcache/memcache.go
+++ b/cache/memcache/memcache.go
@@ -95,6 +95,12 @@ func (rc *Cache) Put(key string, val interface{}, timeout time.Duration) error {
 			return err
 		}
 	}
+	ttl := int32(timeout / time.Second)
+	if ttl < 0{
+		ttl = 0
+	}else if ttl == 0 {
+		ttl = -1
+	}
 	item := memcache.Item{Key: key, Expiration: int32(timeout / time.Second)}
 	if v, ok := val.([]byte); ok {
 		item.Value = v

--- a/cache/redis/redis.go
+++ b/cache/redis/redis.go
@@ -111,10 +111,14 @@ ERROR:
 // Put put cache to redis.
 func (rc *Cache) Put(key string, val interface{}, timeout time.Duration) error {
 	var err error
-	if _, err = rc.do("SETEX", key, int64(timeout/time.Second), val); err != nil {
+	if timeout < 0 {
+		 _, err = rc.do("SET", key, val)
+	}else{
+		_,err = rc.do("SETEX", key, int64(timeout/time.Second), val)
+	}
+	if err != nil {
 		return err
 	}
-
 	if _, err = rc.do("HSET", rc.key, key, true); err != nil {
 		return err
 	}

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -153,7 +153,7 @@ func (v *Validation) Max(obj interface{}, max int, key string) *Result {
 	return v.apply(Max{max, key}, obj)
 }
 
-// Range Test that the obj is between mni and max if obj's type is int
+// Range Test that the obj is between min and max if obj's type is int
 func (v *Validation) Range(obj interface{}, min, max int, key string) *Result {
 	return v.apply(Range{Min{Min: min}, Max{Max: max}, key}, obj)
 }
@@ -171,6 +171,11 @@ func (v *Validation) MaxSize(obj interface{}, max int, key string) *Result {
 // Length Test that the obj is same length to n if type is string or slice
 func (v *Validation) Length(obj interface{}, n int, key string) *Result {
 	return v.apply(Length{n, key}, obj)
+}
+
+// LengthRange Test that the obj is between min and max if obj's type is int
+func (v *Validation) LengthRange(obj interface{}, min, max int, key string) *Result {
+	return v.apply(LengthRange{Min{Min: min}, Max{Max: max}, key}, obj)
 }
 
 // Alpha Test that the obj is [a-zA-Z] if type is string

--- a/validation/validators.go
+++ b/validation/validators.go
@@ -31,6 +31,7 @@ var MessageTmpls = map[string]string{
 	"MinSize":      "Minimum size is %d",
 	"MaxSize":      "Maximum size is %d",
 	"Length":       "Required length is %d",
+	"LengthRange":  "Length Range is %d to %d",
 	"Alpha":        "Must be valid alpha characters",
 	"Numeric":      "Must be valid numeric characters",
 	"AlphaNumeric": "Must be valid alpha or numeric characters",
@@ -684,4 +685,44 @@ func (z ZipCode) GetKey() string {
 // GetLimitValue return the limit value
 func (z ZipCode) GetLimitValue() interface{} {
 	return nil
+}
+
+
+// Range Requires an integer to be within Min, Max inclusive.
+type LengthRange struct {
+	Min int
+	Max int
+	Key string
+}
+
+// IsSatisfied judge whether obj is valid
+func (r LengthRange) IsSatisfied(obj interface{}) bool {
+	if str, ok := obj.(string); ok {
+		strLen := utf8.RuneCountInString(str)
+		if r.Min <= strLen && strLen <=r.Max{
+			return true
+		}
+	}
+	v := reflect.ValueOf(obj)
+	if v.Kind() == reflect.Slice {
+		if r.Min <= v.Len() && v.Len() <= r.Max{
+			return true
+		}
+	}
+	return false
+}
+
+// DefaultMessage return the default Range error message
+func (r LengthRange) DefaultMessage() string {
+	return fmt.Sprintf(MessageTmpls["LengthRange"], r.Min, r.Max)
+}
+
+// GetKey return the m.Key
+func (r LengthRange) GetKey() string {
+	return r.Key
+}
+
+// GetLimitValue return the limit value, Max
+func (r LengthRange) GetLimitValue() interface{} {
+	return []int{r.Min, r.Max}
 }


### PR DESCRIPTION
1. 添加LengthRange函数, 用于密码校验时候长度校验范围
2. 修改了cache里面的redis , 和memcached的函数, 用于可以长久保存

#注: ssdb里面已经有相应的长期保存函数, 而memcached只要把时间变成0就可以长期保存,此处做了修改, 而redis则需要更换set命令才能用于长期保存, 这个用时间做判断.

pls check