### PR TITLE
Fix set cookie bug, zero max age is not valid.

### DIFF
--- a/context/output.go
+++ b/context/output.go
@@ -105,7 +105,7 @@ func (output *BeegoOutput) Cookie(name string, value string, others ...interface
 		switch {
 		case maxAge > 0:
 			fmt.Fprintf(&b, "; Expires=%s; Max-Age=%d", time.Now().Add(time.Duration(maxAge)*time.Second).UTC().Format(time.RFC1123), maxAge)
-		case maxAge < 0:
+		case maxAge <= 0:
 			fmt.Fprintf(&b, "; Max-Age=0")
 		}
 	}


### PR DESCRIPTION
When max age is set to 0, it will take no effect for SetCookie, this is needed for cleaning cookies.