### PR TITLE
redis poolsize could set to zero

### DIFF
--- a/session/redis/sess_redis.go
+++ b/session/redis/sess_redis.go
@@ -128,7 +128,7 @@ func (rp *Provider) SessionInit(maxlifetime int64, savePath string) error {
 	}
 	if len(configs) > 1 {
 		poolsize, err := strconv.Atoi(configs[1])
-		if err != nil || poolsize <= 0 {
+		if err != nil || poolsize < 0 {
 			rp.poolsize = MaxPoolSize
 		} else {
 			rp.poolsize = poolsize


### PR DESCRIPTION
让session的redis驱动可以通过配置关闭掉连接池