### PR TITLE
Fix for IndexExists in SQLite driver

### DIFF
--- a/orm/db_sqlite.go
+++ b/orm/db_sqlite.go
@@ -134,7 +134,7 @@ func (d *dbBaseSqlite) IndexExists(db dbQuerier, table string, name string) bool
 	defer rows.Close()
 	for rows.Next() {
 		var tmp, index sql.NullString
-		rows.Scan(&tmp, &index, &tmp)
+		rows.Scan(&tmp, &index, &tmp, &tmp, &tmp)
 		if name == index.String {
 			return true
 		}


### PR DESCRIPTION
they added the "origin" and "partial" columns to the index_list pragma.

see:  https://www.sqlite.org/src/info/2743846cdba572f6