### PR TITLE
Update ini.go: change the key to lowercase when set a new key for ini configer

### DIFF
--- a/config/ini.go
+++ b/config/ini.go
@@ -416,7 +416,7 @@ func (c *IniConfigContainer) Set(key, value string) error {
 
 	var (
 		section, k string
-		sectionKey = strings.Split(key, "::")
+		sectionKey = strings.Split(strings.ToLower(key), "::")
 	)
 
 	if len(sectionKey) >= 2 {


### PR DESCRIPTION
change the key to lowercase when set a new key for ini configer

我看在 ini configer 中调用 getdata 时使用的小写去读取，当 Set 时如果输入大写字母将会读取不到配置项