### PR TITLE
fix: log mode should be 0440 should not be 440

### DIFF
--- a/logs/file.go
+++ b/logs/file.go
@@ -270,7 +270,7 @@ func (w *fileLogWriter) doRotate(logTime time.Time) error {
 	// Rename the file to its new found name
 	// even if occurs error,we MUST guarantee to  restart new logger
 	err = os.Rename(w.Filename, fName)
-	err = os.Chmod(fName, os.FileMode(440))
+	err = os.Chmod(fName, os.FileMode(0440))
 	// re-start logger
 RESTART_LOGGER:
 

--- a/logs/file_test.go
+++ b/logs/file_test.go
@@ -162,7 +162,27 @@ func TestFileRotate_05(t *testing.T) {
 	testFileDailyRotate(t, fn1, fn2)
 	os.Remove(fn)
 }
-
+func TestFileRotate_06(t *testing.T) {//test file mode
+	log := NewLogger(10000)
+	log.SetLogger("file", `{"filename":"test3.log","maxlines":4}`)
+	log.Debug("debug")
+	log.Info("info")
+	log.Notice("notice")
+	log.Warning("warning")
+	log.Error("error")
+	log.Alert("alert")
+	log.Critical("critical")
+	log.Emergency("emergency")
+	rotateName := "test3" + fmt.Sprintf(".%s.%03d", time.Now().Format("2006-01-02"), 1) + ".log"
+	s,_:=os.Lstat(rotateName)
+	if s.Mode() != 0440 {
+		os.Remove(rotateName)
+		os.Remove("test3.log")
+		t.Fatal("rotate file mode error")
+	}
+	os.Remove(rotateName)
+	os.Remove("test3.log")
+}
 func testFileRotate(t *testing.T, fn1, fn2 string) {
 	fw := &fileLogWriter{
 		Daily:   true,


### PR DESCRIPTION
```
func (w *fileLogWriter) doRotate(logTime time.Time)
```
I found log file after rotate have error mode `-rw-rwx---` is mode `0670`, file mode is octal
`logs/file.go:273` the `440` is wrong, 440 base 10 equal 0670 base 8,so file mode will be `-rw-rwx---`
