### PR TITLE
Fix ini parsing error for multiple users on one machine.

### DIFF
--- a/config/ini.go
+++ b/config/ini.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -184,10 +185,17 @@ func (ini *IniConfig) parseData(dir string, data []byte) (*IniConfigContainer, e
 
 // ParseData parse ini the data
 // When include other.conf,other.conf is either absolute directory
-// or under beego in default temporary directory(/tmp/beego).
+// or under beego in default temporary directory(/tmp/beego[-username]).
 func (ini *IniConfig) ParseData(data []byte) (Configer, error) {
-	dir := filepath.Join(os.TempDir(), "beego")
-	os.MkdirAll(dir, os.ModePerm)
+	dir := "beego"
+	currentUser, err := user.Current()
+	if err == nil {
+		dir = "beego-" + currentUser.Username
+	}
+	dir = filepath.Join(os.TempDir(), dir)
+	if err = os.MkdirAll(dir, os.ModePerm); err != nil {
+		return nil, err
+	}
 
 	return ini.parseData(dir, data)
 }


### PR DESCRIPTION
If there were multiple users working on one machine, it's common that
"/tmp/beego" will be owned by one of them, and the others won't be able
to access to it. So, it's better to add an "id-like" postfix to the
temporary directory.