### PR TITLE
Fixed InsertOrUpdate bug

### DIFF
--- a/orm/db.go
+++ b/orm/db.go
@@ -592,7 +592,7 @@ func (d *dbBase) InsertOrUpdate(q dbQuerier, mi *modelInfo, ind reflect.Value, a
 	row := q.QueryRow(query, values...)
 	var id int64
 	err = row.Scan(&id)
-	if err.Error() == `pq: syntax error at or near "ON"` {
+	if err != nil && err.Error() == `pq: syntax error at or near "ON"` {
 		err = fmt.Errorf("postgres version must 9.5 or higher")
 	}
 	return id, err


### PR DESCRIPTION
We should check **err** for nil before calling **err.Error()**:

> Handler crashed with error runtime error: invalid memory address or nil pointer dereference
> /home/ubuntu/golang/src/github.com/astaxie/beego/orm/db.go:595