### PR TITLE
Add authenticated user name to the context, left blank if it's an anonymous user.

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -53,6 +53,7 @@ type Context struct {
 	Output         *BeegoOutput
 	Request        *http.Request
 	ResponseWriter *Response
+	User           string
 	_xsrfToken     string
 }
 

--- a/plugins/auth/basic.go
+++ b/plugins/auth/basic.go
@@ -59,7 +59,10 @@ func NewBasicAuthenticator(secrets SecretProvider, Realm string) beego.FilterFun
 	return func(ctx *context.Context) {
 		a := &BasicAuth{Secrets: secrets, Realm: Realm}
 		if username := a.CheckAuth(ctx.Request); username == "" {
+			ctx.User = ""
 			a.RequireAuth(ctx.ResponseWriter, ctx.Request)
+		} else {
+			ctx.User = username
 		}
 	}
 }


### PR DESCRIPTION
This PR solves https://github.com/astaxie/beego/issues/2612.

Currently, it works with the [built-in HTTP basic authentication](https://github.com/astaxie/beego/blob/master/plugins/auth/basic.go). Other authentication methods like OAuth should follow this design by setting ``context.User`` to the authenticated user name or ID or token.