### PR TITLE
Suggest all authentication modules to store the user name at the same place

### DIFF
--- a/plugins/auth/basic.go
+++ b/plugins/auth/basic.go
@@ -59,7 +59,6 @@ func NewBasicAuthenticator(secrets SecretProvider, Realm string) beego.FilterFun
 	return func(ctx *context.Context) {
 		a := &BasicAuth{Secrets: secrets, Realm: Realm}
 		if username := a.CheckAuth(ctx.Request); username == "" {
-			ctx.Input.SetData("username", "")
 			a.RequireAuth(ctx.ResponseWriter, ctx.Request)
 		} else {
 			ctx.Input.SetData("username", username)

--- a/plugins/auth/basic.go
+++ b/plugins/auth/basic.go
@@ -59,7 +59,10 @@ func NewBasicAuthenticator(secrets SecretProvider, Realm string) beego.FilterFun
 	return func(ctx *context.Context) {
 		a := &BasicAuth{Secrets: secrets, Realm: Realm}
 		if username := a.CheckAuth(ctx.Request); username == "" {
+			ctx.Input.SetData("username", "")
 			a.RequireAuth(ctx.ResponseWriter, ctx.Request)
+		} else {
+			ctx.Input.SetData("username", username)
 		}
 	}
 }


### PR DESCRIPTION
Store the user name authenticated by HTTP basic authentication into the context input as key "username", all other authentication modules should follow this design.

This is to solve https://github.com/astaxie/beego/issues/2612