### PR TITLE
Add an authorization plugin that supports ACL, RBAC based on casbin.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ install:
   - go get github.com/ssdb/gossdb/ssdb
   - go get github.com/cloudflare/golz4
   - go get github.com/gogo/protobuf/proto
+  - go get github.com/Knetic/govaluate
+  - go get github.com/hsluoyz/casbin
   - go get -u honnef.co/go/tools/cmd/gosimple
   - go get -u github.com/mdempsky/unconvert
   - go get -u github.com/gordonklaus/ineffassign

--- a/plugins/authz/authz.go
+++ b/plugins/authz/authz.go
@@ -1,0 +1,86 @@
+// Copyright 2014 beego Author. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package authz provides handlers to enable ACL, RBAC, ABAC authorization support.
+// Simple Usage:
+//	import(
+//		"github.com/astaxie/beego"
+//		"github.com/astaxie/beego/plugins/authz"
+//		"github.com/hsluoyz/casbin"
+//	)
+//
+//	func main(){
+//		// mediate the access for every request
+//		beego.InsertFilter("*", beego.BeforeRouter, authz.NewAuthorizer(casbin.NewEnforcer("authz_model.conf", "authz_policy.csv")))
+//		beego.Run()
+//	}
+//
+//
+// Advanced Usage:
+//
+//	func main(){
+//		e := casbin.NewEnforcer("authz_model.conf", "")
+//		e.AddRoleForUser("alice", "admin")
+//		e.AddPolicy(...)
+//
+//		beego.InsertFilter("*", beego.BeforeRouter, authz.NewAuthorizer(e))
+//		beego.Run()
+//	}
+package authz
+
+import (
+	"github.com/astaxie/beego"
+	"github.com/astaxie/beego/context"
+	"github.com/hsluoyz/casbin"
+	"net/http"
+)
+
+// NewAuthorizer returns the authorizer.
+// Use a casbin enforcer as input
+func NewAuthorizer(e *casbin.Enforcer) beego.FilterFunc {
+	return func(ctx *context.Context) {
+		a := &BasicAuthorizer{enforcer: e}
+
+		if !a.CheckPermission(ctx.Request) {
+			a.RequirePermission(ctx.ResponseWriter)
+		}
+	}
+}
+
+// BasicAuthorizer stores the casbin handler
+type BasicAuthorizer struct {
+	enforcer *casbin.Enforcer
+}
+
+// GetUserName gets the user name from the request.
+// Currently, only HTTP basic authentication is supported
+func (a *BasicAuthorizer) GetUserName(r *http.Request) string {
+	username, _, _ := r.BasicAuth()
+	return username
+}
+
+// CheckPermission checks the user/method/path combination from the request.
+// Returns true (permission granted) or false (permission forbidden)
+func (a *BasicAuthorizer) CheckPermission(r *http.Request) bool {
+	user := a.GetUserName(r)
+	method := r.Method
+	path := r.URL.Path
+	return a.enforcer.Enforce(user, path, method)
+}
+
+// RequirePermission returns the 403 Forbidden to the client
+func (a *BasicAuthorizer) RequirePermission(w http.ResponseWriter) {
+	w.WriteHeader(403)
+	w.Write([]byte("403 Forbidden\n"))
+}

--- a/plugins/authz/authz_model.conf
+++ b/plugins/authz/authz_model.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub, obj, act
+
+[role_definition]
+g = _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = g(r.sub, p.sub) && keyMatch(r.obj, p.obj) && (r.act == p.act || p.act == "*")

--- a/plugins/authz/authz_policy.csv
+++ b/plugins/authz/authz_policy.csv
@@ -1,0 +1,7 @@
+p, alice, /dataset1/*, GET
+p, alice, /dataset1/resource1, POST
+p, bob, /dataset2/resource1, *
+p, bob, /dataset2/resource2, GET
+p, bob, /dataset2/folder1/*, POST
+p, dataset1_admin, /dataset1/*, *
+g, cathy, dataset1_admin

--- a/plugins/authz/authz_test.go
+++ b/plugins/authz/authz_test.go
@@ -1,0 +1,107 @@
+// Copyright 2014 beego Author. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authz
+
+import (
+	"github.com/astaxie/beego"
+	"github.com/astaxie/beego/context"
+	"github.com/astaxie/beego/plugins/auth"
+	"github.com/hsluoyz/casbin"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func testRequest(t *testing.T, handler *beego.ControllerRegister, user string, path string, method string, code int) {
+	r, _ := http.NewRequest(method, path, nil)
+	r.SetBasicAuth(user, "123")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != code {
+		t.Errorf("%s, %s, %s: %d, supposed to be %d", user, path, method, w.Code, code)
+	}
+}
+
+func TestBasic(t *testing.T) {
+	handler := beego.NewControllerRegister()
+
+	handler.InsertFilter("*", beego.BeforeRouter, auth.Basic("alice", "123"))
+	handler.InsertFilter("*", beego.BeforeRouter, NewAuthorizer(casbin.NewEnforcer("authz_model.conf", "authz_policy.csv")))
+
+	handler.Any("*", func(ctx *context.Context) {
+		ctx.Output.SetStatus(200)
+	})
+
+	testRequest(t, handler, "alice", "/dataset1/resource1", "GET", 200)
+	testRequest(t, handler, "alice", "/dataset1/resource1", "POST", 200)
+	testRequest(t, handler, "alice", "/dataset1/resource2", "GET", 200)
+	testRequest(t, handler, "alice", "/dataset1/resource2", "POST", 403)
+}
+
+func TestPathWildcard(t *testing.T) {
+	handler := beego.NewControllerRegister()
+
+	handler.InsertFilter("*", beego.BeforeRouter, auth.Basic("bob", "123"))
+	handler.InsertFilter("*", beego.BeforeRouter, NewAuthorizer(casbin.NewEnforcer("authz_model.conf", "authz_policy.csv")))
+
+	handler.Any("*", func(ctx *context.Context) {
+		ctx.Output.SetStatus(200)
+	})
+
+	testRequest(t, handler, "bob", "/dataset2/resource1", "GET", 200)
+	testRequest(t, handler, "bob", "/dataset2/resource1", "POST", 200)
+	testRequest(t, handler, "bob", "/dataset2/resource1", "DELETE", 200)
+	testRequest(t, handler, "bob", "/dataset2/resource2", "GET", 200)
+	testRequest(t, handler, "bob", "/dataset2/resource2", "POST", 403)
+	testRequest(t, handler, "bob", "/dataset2/resource2", "DELETE", 403)
+
+	testRequest(t, handler, "bob", "/dataset2/folder1/item1", "GET", 403)
+	testRequest(t, handler, "bob", "/dataset2/folder1/item1", "POST", 200)
+	testRequest(t, handler, "bob", "/dataset2/folder1/item1", "DELETE", 403)
+	testRequest(t, handler, "bob", "/dataset2/folder1/item2", "GET", 403)
+	testRequest(t, handler, "bob", "/dataset2/folder1/item2", "POST", 200)
+	testRequest(t, handler, "bob", "/dataset2/folder1/item2", "DELETE", 403)
+}
+
+func TestRBAC(t *testing.T) {
+	handler := beego.NewControllerRegister()
+
+	handler.InsertFilter("*", beego.BeforeRouter, auth.Basic("cathy", "123"))
+	e := casbin.NewEnforcer("authz_model.conf", "authz_policy.csv")
+	handler.InsertFilter("*", beego.BeforeRouter, NewAuthorizer(e))
+
+	handler.Any("*", func(ctx *context.Context) {
+		ctx.Output.SetStatus(200)
+	})
+
+	// cathy can access all /dataset1/* resources via all methods because it has the dataset1_admin role.
+	testRequest(t, handler, "cathy", "/dataset1/item", "GET", 200)
+	testRequest(t, handler, "cathy", "/dataset1/item", "POST", 200)
+	testRequest(t, handler, "cathy", "/dataset1/item", "DELETE", 200)
+	testRequest(t, handler, "cathy", "/dataset2/item", "GET", 403)
+	testRequest(t, handler, "cathy", "/dataset2/item", "POST", 403)
+	testRequest(t, handler, "cathy", "/dataset2/item", "DELETE", 403)
+
+	// delete all roles on user cathy, so cathy cannot access any resources now.
+	e.DeleteRolesForUser("cathy")
+
+	testRequest(t, handler, "cathy", "/dataset1/item", "GET", 403)
+	testRequest(t, handler, "cathy", "/dataset1/item", "POST", 403)
+	testRequest(t, handler, "cathy", "/dataset1/item", "DELETE", 403)
+	testRequest(t, handler, "cathy", "/dataset2/item", "GET", 403)
+	testRequest(t, handler, "cathy", "/dataset2/item", "POST", 403)
+	testRequest(t, handler, "cathy", "/dataset2/item", "DELETE", 403)
+}


### PR DESCRIPTION
Add an authorization plugin that supports ACL, RBAC based on [casbin](https://github.com/hsluoyz/casbin).

It requires the built-in HTTP basic authentication by default, so the authz can get the user name and enforce the access control.

Test is also added in ``authz_test.go``.

This PR is to solve: https://github.com/astaxie/beego/issues/740