### PR TITLE
allow o.Raw(sql).QueryRows(&container) pass nested struct

### DIFF
--- a/orm/orm_raw.go
+++ b/orm/orm_raw.go
@@ -493,19 +493,33 @@ func (o *rawSet) QueryRows(containers ...interface{}) (int64, error) {
 					}
 				}
 			} else {
-				for i := 0; i < ind.NumField(); i++ {
-					f := ind.Field(i)
-					fe := ind.Type().Field(i)
-					_, tags := parseStructTag(fe.Tag.Get(defaultStructTagName))
-					var col string
-					if col = tags["column"]; col == "" {
-						col = snakeString(fe.Name)
-					}
-					if v, ok := columnsMp[col]; ok {
-						value := reflect.ValueOf(v).Elem().Interface()
-						o.setFieldValue(f, value)
+				// define recursive function
+				var recursiveSetField func(rv reflect.Value)
+				recursiveSetField = func(rv reflect.Value) {
+					for i := 0; i < rv.NumField(); i++ {
+						f := rv.Field(i)
+						fe := rv.Type().Field(i)
+
+						// check if the field is a Struct
+						// recursive the Struct type
+						if fe.Type.Kind() == reflect.Struct {
+							recursiveSetField(f)
+						}
+
+						_, tags := parseStructTag(fe.Tag.Get(defaultStructTagName))
+						var col string
+						if col = tags["column"]; col == "" {
+							col = snakeString(fe.Name)
+						}
+						if v, ok := columnsMp[col]; ok {
+							value := reflect.ValueOf(v).Elem().Interface()
+							o.setFieldValue(f, value)
+						}
 					}
 				}
+
+				// init call the recursive function
+				recursiveSetField(ind)
 			}
 
 			if eTyps[0].Kind() == reflect.Ptr {

--- a/orm/orm_test.go
+++ b/orm/orm_test.go
@@ -1661,6 +1661,13 @@ func TestRawQueryRow(t *testing.T) {
 	throwFail(t, AssertIs(pid, nil))
 }
 
+// user_profile table
+type userProfile struct {
+	User
+	Age   int
+	Money float64
+}
+
 func TestQueryRows(t *testing.T) {
 	Q := dDbBaser.TableQuote()
 
@@ -1731,6 +1738,19 @@ func TestQueryRows(t *testing.T) {
 	throwFailNow(t, AssertIs(usernames[1], "astaxie"))
 	throwFailNow(t, AssertIs(ids[2], 4))
 	throwFailNow(t, AssertIs(usernames[2], "nobody"))
+
+	//test query rows by nested struct
+	var l []userProfile
+	query = fmt.Sprintf("SELECT * FROM %suser_profile%s LEFT JOIN %suser%s ON %suser_profile%s.%sid%s = %suser%s.%sid%s", Q, Q, Q, Q, Q, Q, Q, Q, Q, Q, Q, Q)
+	num, err = dORM.Raw(query).QueryRows(&l)
+	throwFailNow(t, err)
+	throwFailNow(t, AssertIs(num, 2))
+	throwFailNow(t, AssertIs(len(l), 2))
+	throwFailNow(t, AssertIs(l[0].UserName, "slene"))
+	throwFailNow(t, AssertIs(l[0].Age, 28))
+	throwFailNow(t, AssertIs(l[1].UserName, "astaxie"))
+	throwFailNow(t, AssertIs(l[1].Age, 30))
+
 }
 
 func TestRawValues(t *testing.T) {


### PR DESCRIPTION
users表

id | name
--- | --- 
2| sunxinle 

user_extra表

user_id | nick
--- | --- 
2| alex


```golang
type Users struct {
  Id int `json:"id" orm:"column(id);auto"`
  Name string `json:"name" orm:"column(name)"`
}

type UserExtra struct {
  Users
  Nick string `json:"nick" orm:"column(nick)"`
}

func main() {
  qb, _ = orm.NewQueryBuilder("mysql")
  sql := qb.Select("u.*", "e.nick").
    From("users as u").
    LeftJoin("user_extra as e").On("e.user_id = u.id").
    String()
  o := orm.NewOrm()
  var l []UserExtra

  o.Raw(sql).QueryRows(&l)
}

```
I used the similar code in my project , but can not get the 'name' field in the query result
I see the source find the setFiledValue and found that there is no special deal to Struct.
so i try to fix it by recusive

我在项目中使用了类似的代码，但是没办法获得UserExtra嵌套的Struct中的字段，比如User中的'name'
然后在源码中找到setFiledValue这个地方，发现确实没有对Struct做特殊的处理，所以现在把原来的代码放入一个函数中，通过递归去处理setFiledValue

















