### PR TITLE
Moved Security to Operation struct to support swagger API security auth

### DIFF
--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -32,7 +32,6 @@ type Swagger struct {
 	Paths               map[string]*Item    `json:"paths" yaml:"paths"`
 	Definitions         map[string]Schema   `json:"definitions,omitempty" yaml:"definitions,omitempty"`
 	SecurityDefinitions map[string]Security `json:"securityDefinitions,omitempty" yaml:"securityDefinitions,omitempty"`
-	Security            map[string][]string `json:"security,omitempty" yaml:"security,omitempty"`
 	Tags                []Tag               `json:"tags,omitempty" yaml:"tags,omitempty"`
 	ExternalDocs        *ExternalDocs       `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
 }
@@ -75,16 +74,17 @@ type Item struct {
 
 // Operation Describes a single API operation on a path.
 type Operation struct {
-	Tags        []string            `json:"tags,omitempty" yaml:"tags,omitempty"`
-	Summary     string              `json:"summary,omitempty" yaml:"summary,omitempty"`
-	Description string              `json:"description,omitempty" yaml:"description,omitempty"`
-	OperationID string              `json:"operationId,omitempty" yaml:"operationId,omitempty"`
-	Consumes    []string            `json:"consumes,omitempty" yaml:"consumes,omitempty"`
-	Produces    []string            `json:"produces,omitempty" yaml:"produces,omitempty"`
-	Schemes     []string            `json:"schemes,omitempty" yaml:"schemes,omitempty"`
-	Parameters  []Parameter         `json:"parameters,omitempty" yaml:"parameters,omitempty"`
-	Responses   map[string]Response `json:"responses,omitempty" yaml:"responses,omitempty"`
-	Deprecated  bool                `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	Tags        []string              `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Summary     string                `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description string                `json:"description,omitempty" yaml:"description,omitempty"`
+	OperationID string                `json:"operationId,omitempty" yaml:"operationId,omitempty"`
+	Consumes    []string              `json:"consumes,omitempty" yaml:"consumes,omitempty"`
+	Produces    []string              `json:"produces,omitempty" yaml:"produces,omitempty"`
+	Schemes     []string              `json:"schemes,omitempty" yaml:"schemes,omitempty"`
+	Parameters  []Parameter           `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Responses   map[string]Response   `json:"responses,omitempty" yaml:"responses,omitempty"`
+	Security    []map[string][]string `json:"security,omitempty" yaml:"security,omitempty"`
+	Deprecated  bool                  `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
 }
 
 // Parameter Describes a single operation parameter.

--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -22,18 +22,19 @@ package swagger
 
 // Swagger list the resource
 type Swagger struct {
-	SwaggerVersion      string              `json:"swagger,omitempty" yaml:"swagger,omitempty"`
-	Infos               Information         `json:"info" yaml:"info"`
-	Host                string              `json:"host,omitempty" yaml:"host,omitempty"`
-	BasePath            string              `json:"basePath,omitempty" yaml:"basePath,omitempty"`
-	Schemes             []string            `json:"schemes,omitempty" yaml:"schemes,omitempty"`
-	Consumes            []string            `json:"consumes,omitempty" yaml:"consumes,omitempty"`
-	Produces            []string            `json:"produces,omitempty" yaml:"produces,omitempty"`
-	Paths               map[string]*Item    `json:"paths" yaml:"paths"`
-	Definitions         map[string]Schema   `json:"definitions,omitempty" yaml:"definitions,omitempty"`
-	SecurityDefinitions map[string]Security `json:"securityDefinitions,omitempty" yaml:"securityDefinitions,omitempty"`
-	Tags                []Tag               `json:"tags,omitempty" yaml:"tags,omitempty"`
-	ExternalDocs        *ExternalDocs       `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
+	SwaggerVersion      string                `json:"swagger,omitempty" yaml:"swagger,omitempty"`
+	Infos               Information           `json:"info" yaml:"info"`
+	Host                string                `json:"host,omitempty" yaml:"host,omitempty"`
+	BasePath            string                `json:"basePath,omitempty" yaml:"basePath,omitempty"`
+	Schemes             []string              `json:"schemes,omitempty" yaml:"schemes,omitempty"`
+	Consumes            []string              `json:"consumes,omitempty" yaml:"consumes,omitempty"`
+	Produces            []string              `json:"produces,omitempty" yaml:"produces,omitempty"`
+	Paths               map[string]*Item      `json:"paths" yaml:"paths"`
+	Definitions         map[string]Schema     `json:"definitions,omitempty" yaml:"definitions,omitempty"`
+	SecurityDefinitions map[string]Security   `json:"securityDefinitions,omitempty" yaml:"securityDefinitions,omitempty"`
+	Security            []map[string][]string `json:"security,omitempty" yaml:"security,omitempty"`
+	Tags                []Tag                 `json:"tags,omitempty" yaml:"tags,omitempty"`
+	ExternalDocs        *ExternalDocs         `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
 }
 
 // Information Provides metadata about the API. The metadata can be used by the clients if needed.


### PR DESCRIPTION
# To support https://github.com/beego/bee/pull/436

Also changed `Security` field from 
```golang
Security map[string][]string
```
to 
```golang
Security []map[string][]string
```
as specified here: http://swagger.io/specification