### PR TITLE
Provide permission to access old files to everyone

### DIFF
--- a/session/redis/sess_redis.go
+++ b/session/redis/sess_redis.go
@@ -179,7 +179,7 @@ func (rp *Provider) SessionRead(sid string) (session.Store, error) {
 	var kv map[interface{}]interface{}
 
 	kvs, err := redis.String(c.Do("GET", sid))
-	if err != redis.ErrNil {
+	if err != nil && err != redis.ErrNil {
 		return nil, err
 	}
 	if len(kvs) == 0 {


### PR DESCRIPTION
For example in the case of old log files, it is not always the user/group will process it. Sometimes others also need it, thus granting access of old log files to be readable for everyone.