### PR TITLE
fix cache/memory fatal error: concurrent map iteration and map write

### DIFF
--- a/cache/memory.go
+++ b/cache/memory.go
@@ -223,6 +223,7 @@ func (bc *MemoryCache) vaccuum() {
 	}
 }
 
+// expiredKeys returns key list which are expired.
 func (bc *MemoryCache) expiredKeys() (keys []string) {
 	bc.RLock()
 	defer bc.RUnlock()
@@ -234,6 +235,7 @@ func (bc *MemoryCache) expiredKeys() (keys []string) {
 	return
 }
 
+// clearItems removes all the items which key in keys.
 func (bc *MemoryCache) clearItems(keys []string) {
 	bc.Lock()
 	defer bc.Unlock()

--- a/cache/memory.go
+++ b/cache/memory.go
@@ -217,26 +217,29 @@ func (bc *MemoryCache) vaccuum() {
 		if bc.items == nil {
 			return
 		}
-		for name := range bc.items {
-			bc.itemExpired(name)
+		if keys := bc.expiredKeys(); len(keys) != 0 {
+			bc.clearItems(keys)
 		}
 	}
 }
 
-// itemExpired returns true if an item is expired.
-func (bc *MemoryCache) itemExpired(name string) bool {
+func (bc *MemoryCache) expiredKeys() (keys []string) {
+	bc.RLock()
+	defer bc.RUnlock()
+	for key, itm := range bc.items {
+		if itm.isExpire() {
+			keys = append(keys, key)
+		}
+	}
+	return
+}
+
+func (bc *MemoryCache) clearItems(keys []string) {
 	bc.Lock()
 	defer bc.Unlock()
-
-	itm, ok := bc.items[name]
-	if !ok {
-		return true
+	for _, key := range keys {
+		delete(bc.items, key)
 	}
-	if itm.isExpire() {
-		delete(bc.items, name)
-		return true
-	}
-	return false
 }
 
 func init() {


### PR DESCRIPTION
Fix cache/memory fatal error: concurrent map iteration and map write.
For use the beego/cache/memory, maybe cause the application crash with error message:
"fatal error: concurrent map iteration and map write.", when insert many items(over 1000 items). 
It's random, but I meet this at least 3 times.. 
