### PR TITLE
validation: support required option for some struct tag valids

### DIFF
--- a/validation/README.md
+++ b/validation/README.md
@@ -64,6 +64,9 @@ Struct Tag Use:
 
 	func main() {
 		valid := validation.Validation{}
+		// ignore empty field valid
+		// see CanSkipFuncs
+		// valid := validation.Validation{RequiredFirst:true}
 		u := user{Name: "test", Age: 40}
 		b, err := valid.Valid(u)
 		if err != nil {

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -391,3 +391,54 @@ func TestRecursiveValid(t *testing.T) {
 		t.Error("validation should not be passed")
 	}
 }
+
+func TestSkipValid(t *testing.T) {
+	type User struct {
+		ID int
+
+		Email    string `valid:"Email"`
+		ReqEmail string `valid:"Required;Email"`
+
+		IP    string `valid:"IP"`
+		ReqIP string `valid:"Required;IP"`
+
+		Mobile    string `valid:"Mobile"`
+		ReqMobile string `valid:"Required;Mobile"`
+
+		Tel    string `valid:"Tel"`
+		ReqTel string `valid:"Required;Tel"`
+
+		Phone    string `valid:"Phone"`
+		ReqPhone string `valid:"Required;Phone"`
+
+		ZipCode    string `valid:"ZipCode"`
+		ReqZipCode string `valid:"Required;ZipCode"`
+	}
+
+	u := User{
+		ReqEmail:   "a@a.com",
+		ReqIP:      "127.0.0.1",
+		ReqMobile:  "18888888888",
+		ReqTel:     "02088888888",
+		ReqPhone:   "02088888888",
+		ReqZipCode: "510000",
+	}
+
+	valid := Validation{}
+	b, err := valid.Valid(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b {
+		t.Fatal("validation should not be passed")
+	}
+
+	valid = Validation{RequiredFirst: true}
+	b, err = valid.Valid(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !b {
+		t.Fatal("validation should be passed")
+	}
+}

--- a/validation/validators.go
+++ b/validation/validators.go
@@ -23,6 +23,16 @@ import (
 	"unicode/utf8"
 )
 
+// CanSkipFuncs will skip valid if RequiredFirst is true and the struct field's value is empty
+var CanSkipFuncs = map[string]struct{}{
+	"Email":   struct{}{},
+	"IP":      struct{}{},
+	"Mobile":  struct{}{},
+	"Tel":     struct{}{},
+	"Phone":   struct{}{},
+	"ZipCode": struct{}{},
+}
+
 // MessageTmpls store commond validate template
 var MessageTmpls = map[string]string{
 	"Required":     "Can not be empty",


### PR DESCRIPTION
Ignore empty field valid with `RequiredFirst` option.

#2713 
#2522 

```
func TestSkipValid(t *testing.T) {
	type User struct {
		ID int

		Email    string `valid:"Email"`
		ReqEmail string `valid:"Required;Email"`

		IP    string `valid:"IP"`
		ReqIP string `valid:"Required;IP"`

		Mobile    string `valid:"Mobile"`
		ReqMobile string `valid:"Required;Mobile"`

		Tel    string `valid:"Tel"`
		ReqTel string `valid:"Required;Tel"`

		Phone    string `valid:"Phone"`
		ReqPhone string `valid:"Required;Phone"`

		ZipCode    string `valid:"ZipCode"`
		ReqZipCode string `valid:"Required;ZipCode"`
	}

	u := User{
		ReqEmail:   "a@a.com",
		ReqIP:      "127.0.0.1",
		ReqMobile:  "18888888888",
		ReqTel:     "02088888888",
		ReqPhone:   "02088888888",
		ReqZipCode: "510000",
	}

	valid := Validation{}
	b, err := valid.Valid(u)
	if err != nil {
		t.Fatal(err)
	}
	if b {
		t.Fatal("validation should not be passed")
	}

	valid = Validation{RequiredFirst: true}
	b, err = valid.Valid(u)
	if err != nil {
		t.Fatal(err)
	}
	if !b {
		t.Fatal("validation should be passed")
	}
}
```