### PR TITLE
sort ControllerComments

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -55,6 +55,12 @@ type ControllerComments struct {
 	MethodParams     []*param.MethodParam
 }
 
+type ControllerCommentsSlice []ControllerComments
+
+func (p ControllerCommentsSlice) Len() int           { return len(p) }
+func (p ControllerCommentsSlice) Less(i, j int) bool { return p[i].Router < p[j].Router }
+func (p ControllerCommentsSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
 // Controller defines some basic http request handler operations, such as
 // http context, template and view, session and xsrf.
 type Controller struct {

--- a/parser.go
+++ b/parser.go
@@ -274,6 +274,7 @@ func genRouterCode(pkgRealpath string) {
 	sort.Strings(sortKey)
 	for _, k := range sortKey {
 		cList := genInfoList[k]
+		sort.Sort(ControllerCommentsSlice(cList))
 		for _, c := range cList {
 			allmethod := "nil"
 			if len(c.AllowHTTPMethods) > 0 {


### PR DESCRIPTION
当一个 Controller 里的 Method 分布在多个文件里时，即使没有增删改 Method，commentsRouter_*.go 文件也会经常变动。

原因时解析器遍历包里文件时用的系统库的返回是个 map 结构，然后直接根据 map 元素的顺序来遍历生成每个 Controller 的 []ControllerComments，而 map 的元素次数是随机的。

修改方式是：在使用时，对这个路由切片做次排序。