### PR TITLE
add millisecond to timestamp in log output

### DIFF
--- a/logs/logger.go
+++ b/logs/logger.go
@@ -87,13 +87,15 @@ const (
 	mi2 = `012345678901234567890123456789012345678901234567890123456789`
 	s1  = `000000000011111111112222222222333333333344444444445555555555`
 	s2  = `012345678901234567890123456789012345678901234567890123456789`
+	ns1 = `0123456789`
 )
 
 func formatTimeHeader(when time.Time) ([]byte, int) {
 	y, mo, d := when.Date()
 	h, mi, s := when.Clock()
-	//len("2006/01/02 15:04:05 ")==20
-	var buf [20]byte
+	ns := when.Nanosecond()/1000000
+	//len("2006/01/02 15:04:05.123 ")==24
+	var buf [24]byte
 
 	buf[0] = y1[y/1000%10]
 	buf[1] = y2[y/100]
@@ -114,7 +116,12 @@ func formatTimeHeader(when time.Time) ([]byte, int) {
 	buf[16] = ':'
 	buf[17] = s1[s]
 	buf[18] = s2[s]
-	buf[19] = ' '
+	buf[19] = '.'
+	buf[20] = ns1[ns/100]
+	buf[21] = ns1[ns%100/10]
+	buf[22] = ns1[ns%10]
+
+	buf[23] = ' '
 
 	return buf[0:], d
 }

--- a/logs/logger_test.go
+++ b/logs/logger_test.go
@@ -31,7 +31,7 @@ func TestFormatHeader_0(t *testing.T) {
 			break
 		}
 		h, _ := formatTimeHeader(tm)
-		if tm.Format("2006/01/02 15:04:05 ") != string(h) {
+		if tm.Format("2006/01/02 15:04:05.999 ") != string(h) {
 			t.Log(tm)
 			t.FailNow()
 		}
@@ -49,7 +49,7 @@ func TestFormatHeader_1(t *testing.T) {
 			break
 		}
 		h, _ := formatTimeHeader(tm)
-		if tm.Format("2006/01/02 15:04:05 ") != string(h) {
+		if tm.Format("2006/01/02 15:04:05.999 ") != string(h) {
 			t.Log(tm)
 			t.FailNow()
 		}


### PR DESCRIPTION
As the current time stamp in log output is only to second, which is not so precise for analysis.