### PR TITLE
Add IPV6 compatibility

### DIFF
--- a/context/input.go
+++ b/context/input.go
@@ -115,9 +115,8 @@ func (input *BeegoInput) Domain() string {
 // if no host info in request, return localhost.
 func (input *BeegoInput) Host() string {
 	if input.Context.Request.Host != "" {
-		hostParts := strings.Split(input.Context.Request.Host, ":")
-		if len(hostParts) > 0 {
-			return hostParts[0]
+		if hostPart, _, err := net.SplitHostPort(input.Context.Request.Host); err == nil {
+			return hostPart
 		}
 		return input.Context.Request.Host
 	}
@@ -206,20 +205,20 @@ func (input *BeegoInput) AcceptsJSON() bool {
 
 // IP returns request client ip.
 // if in proxy, return first proxy id.
-// if error, return 127.0.0.1.
+// if error, return RemoteAddr.
 func (input *BeegoInput) IP() string {
 	ips := input.Proxy()
 	if len(ips) > 0 && ips[0] != "" {
-		rip := strings.Split(ips[0], ":")
-		return rip[0]
-	}
-	ip := strings.Split(input.Context.Request.RemoteAddr, ":")
-	if len(ip) > 0 {
-		if ip[0] != "[" {
-			return ip[0]
+		rip, _, err := net.SplitHostPort(ips[0])
+		if err != nil {
+			rip = ips[0]
 		}
+		return rip
 	}
-	return "127.0.0.1"
+	if ip, _, err := net.SplitHostPort(input.Context.Request.RemoteAddr); err == nil {
+		return ip
+	}
+	return input.Context.Request.RemoteAddr
 }
 
 // Proxy returns proxy client ips slice.
@@ -253,9 +252,8 @@ func (input *BeegoInput) SubDomains() string {
 // Port returns request client port.
 // when error or empty, return 80.
 func (input *BeegoInput) Port() int {
-	parts := strings.Split(input.Context.Request.Host, ":")
-	if len(parts) == 2 {
-		port, _ := strconv.Atoi(parts[1])
+	if _, portPart, err := net.SplitHostPort(input.Context.Request.Host); err == nil {
+		port, _ := strconv.Atoi(portPart)
 		return port
 	}
 	return 80


### PR DESCRIPTION
Uses net.SplitHostPort() instead of strings.Split() to get host and port from IPV4 and IPV6 remote address