### PR TITLE
Fix the quick start section of the orm/README.md

### DIFF
--- a/orm/README.md
+++ b/orm/README.md
@@ -61,6 +61,9 @@ func init() {
 
 	// set default database
 	orm.RegisterDataBase("default", "mysql", "root:root@/my_db?charset=utf8", 30)
+	
+	// create table
+	orm.RunSyncdb("default", false, true)	
 }
 
 func main() {


### PR DESCRIPTION
Increase the init method by adding the `RunSyncdb` method to resolve the problem that the table is not created.