### PR TITLE
return template build error rather than log error

### DIFF
--- a/session/redis/sess_redis.go
+++ b/session/redis/sess_redis.go
@@ -160,10 +160,13 @@ func (rp *Provider) SessionInit(maxlifetime int64, savePath string) error {
 				return nil, err
 			}
 		}
-		_, err = c.Do("SELECT", rp.dbNum)
-		if err != nil {
-			c.Close()
-			return nil, err
+		//some redis proxy such as twemproxy is not support select command
+		if rp.dbNum > 0 {
+			_, err = c.Do("SELECT", rp.dbNum)
+			if err != nil {
+				c.Close()
+				return nil, err
+			}
 		}
 		return c, err
 	}, rp.poolsize)

--- a/template.go
+++ b/template.go
@@ -218,6 +218,7 @@ func BuildTemplate(dir string, files ...string) error {
 				}
 				if err != nil {
 					logs.Error("parse template err:", file, err)
+					return err
 				} else {
 					beeTemplates[file] = t
 				}


### PR DESCRIPTION
如果模板渲染遇到语法等错误，会渲染之前的缓存，不易察觉错误，最好能抛出处理