### PR TITLE
validation: fix ErrorMap, added AddError(key, message)

### DIFF
--- a/validation/validation.go
+++ b/validation/validation.go
@@ -112,7 +112,7 @@ type Validation struct {
 	RequiredFirst bool
 
 	Errors    []*Error
-	ErrorsMap map[string]*Error
+	ErrorsMap map[string][]*Error
 }
 
 // Clear Clean all ValidationError.
@@ -129,7 +129,7 @@ func (v *Validation) HasErrors() bool {
 // ErrorMap Return the errors mapped by key.
 // If there are multiple validation errors associated with a single key, the
 // first one "wins".  (Typically the first validation will be the more basic).
-func (v *Validation) ErrorMap() map[string]*Error {
+func (v *Validation) ErrorMap() map[string][]*Error {
 	return v.ErrorsMap
 }
 
@@ -278,14 +278,35 @@ func (v *Validation) apply(chk Validator, obj interface{}) *Result {
 	}
 }
 
+// Add independent error message for key
+func (v *Validation) AddError(key, message string) {
+	Name := key
+	Field := ""
+
+	parts := strings.Split(key, ".")
+	if len(parts) == 2 {
+		Field = parts[0]
+		Name = parts[1]
+	}
+
+	err := &Error{
+		Message: message,
+		Key:     key,
+		Name:    Name,
+		Field:   Field,
+	}
+	v.setError(err)
+}
+
 func (v *Validation) setError(err *Error) {
 	v.Errors = append(v.Errors, err)
 	if v.ErrorsMap == nil {
-		v.ErrorsMap = make(map[string]*Error)
+		v.ErrorsMap = make(map[string][]*Error)
 	}
 	if _, ok := v.ErrorsMap[err.Field]; !ok {
-		v.ErrorsMap[err.Field] = err
+		v.ErrorsMap[err.Field] = []*Error{}
 	}
+	v.ErrorsMap[err.Field] = append(v.ErrorsMap[err.Field], err)
 }
 
 // SetError Set error message for one field in ValidationError


### PR DESCRIPTION
AddError func we can use like this:
```
valid := validation.Validation{}
if emailAlreadyExist {
     valid.AddError("email.email", `This email already exist!`)
}
c.Data["Errors"] = valid.ErrorMap()
```
I did'n understand difference between Name and Field, may be, we can use like:  valid.AddError("email",..)

In template:
```
{{ if .Errors.email }}
  <div class="alert alert-danger" role="alert">
    {{ range .Errors.email }}
        {{ . }}<br/>
    {{ end }}
  </div>
{{ end }}
```