### PR TITLE
add custom middleware options for beego.Run()

### DIFF
--- a/app.go
+++ b/app.go
@@ -51,8 +51,10 @@ func NewApp() *App {
 	return app
 }
 
+type MiddleWare func(http.Handler) http.Handler
+
 // Run beego application.
-func (app *App) Run() {
+func (app *App) Run(mws ...MiddleWare) {
 	addr := BConfig.Listen.HTTPAddr
 
 	if BConfig.Listen.HTTPPort != 0 {
@@ -94,6 +96,12 @@ func (app *App) Run() {
 	}
 
 	app.Server.Handler = app.Handlers
+	for i:=len(mws)-1;i>=0;i-- {
+		if mws[i] == nil {
+			continue
+		}
+		app.Server.Handler = mws[i](app.Server.Handler)
+	}
 	app.Server.ReadTimeout = time.Duration(BConfig.Listen.ServerTimeOut) * time.Second
 	app.Server.WriteTimeout = time.Duration(BConfig.Listen.ServerTimeOut) * time.Second
 	app.Server.ErrorLog = logs.GetLogger("HTTP")

--- a/beego.go
+++ b/beego.go
@@ -67,6 +67,20 @@ func Run(params ...string) {
 	BeeApp.Run()
 }
 
+func RunWithMiddleWares(addr string, mws ...MiddleWare) {
+	initBeforeHTTPRun()
+
+	strs := strings.Split(addr, ":")
+	if len(strs) > 0 && strs[0] != "" {
+		BConfig.Listen.HTTPAddr = strs[0]
+	}
+	if len(strs) > 1 && strs[1] != "" {
+		BConfig.Listen.HTTPPort, _ = strconv.Atoi(strs[1])
+	}
+
+	BeeApp.Run(mws...)
+}
+
 func initBeforeHTTPRun() {
 	//init hooks
 	AddAPPStartHook(


### PR DESCRIPTION
增加了beego.RunWithMiddleWares方法，同时给beego.App.Run增加了参数，可以用来出入用户自定义的一些中间件，
用来实现类似于如下的写法：
	http.ListenAndServe(addr, reqidMiddleware(dlogMiddleware(mux)))

现有的beego，应该只能在beego内部添加中间件。
这里是希望能够提供一种选择，可以在beego的外层添加上用户的中间件。

beego.RunWithMiddleWares(addr, mws ...MiddleWare) 
用这种方式进行启动beego的话，参数mws的中间件列表，在处理http request的时候会按照从前往后的顺序执行。