### PR TITLE
Update for MySQL timezone detection bug

### DIFF
--- a/orm/db_alias.go
+++ b/orm/db_alias.go
@@ -119,7 +119,7 @@ type alias struct {
 func detectTZ(al *alias) {
 	// orm timezone system match database
 	// default use Local
-	al.TZ = time.Local
+	al.TZ = DefaultTimeLoc
 
 	if al.DriverName == "sphinx" {
 		return
@@ -136,7 +136,9 @@ func detectTZ(al *alias) {
 			}
 			t, err := time.Parse("-07:00:00", tz)
 			if err == nil {
-				al.TZ = t.Location()
+				if t.Location().String() != "" {
+					al.TZ = t.Location()
+				}
 			} else {
 				DebugLog.Printf("Detect DB timezone: %s %s\n", tz, err.Error())
 			}


### PR DESCRIPTION
Use "DefaultTimeLoc" for "al.TZ" default value
Don't set TZ on alias when t.Location() is empty

You can set your MySQL server timezone on main.go init function.
Example :
orm.DefaultTimeLoc, _ = time.LoadLocation("Europe/Paris")