### PR TITLE
fix beego log print wrong trace function bug

### DIFF
--- a/logs/log.go
+++ b/logs/log.go
@@ -144,7 +144,7 @@ var logMsgPool *sync.Pool
 func NewLogger(channelLens ...int64) *BeeLogger {
 	bl := new(BeeLogger)
 	bl.level = LevelDebug
-	bl.loggerFuncCallDepth = 2
+	bl.loggerFuncCallDepth = 3
 	bl.msgChanLen = append(channelLens, 0)[0]
 	if bl.msgChanLen <= 0 {
 		bl.msgChanLen = defaultAsyncMsgLen
@@ -552,7 +552,6 @@ func EnableFuncCallDepth(b bool) {
 // SetLogFuncCall set the CallDepth, default is 4
 func SetLogFuncCall(b bool) {
 	beeLogger.EnableFuncCallDepth(b)
-	beeLogger.SetLogFuncCallDepth(4)
 }
 
 // SetLogFuncCallDepth set log funcCallDepth


### PR DESCRIPTION
when using beego `logs` with `enableFuncCallDepth` enbled,
the function is always not the one calling the `logs.xxx`,
after checking beego's source code, it comes to beego's bug,
which can see from the call trace below.

So just fix this bug which seems there quite some time.

``` beego log call trace
0  0x00000000012fdb52 in github.com/astaxie/beego/logs.(*BeeLogger).writeMsg
   at /Users/zhoutao/goprj_root/src/github.com/astaxie/beego/logs/log.go:272
1  0x00000000012fe70d in github.com/astaxie/beego/logs.(*BeeLogger).Info
   at /Users/zhoutao/goprj_root/src/github.com/astaxie/beego/logs/log.go:429
2  0x00000000012ff3b6 in github.com/astaxie/beego/logs.Info
   at /Users/zhoutao/goprj_root/src/github.com/astaxie/beego/logs/log.go:609
3  0x000000000140dc02 in zhoutao/beego_prjs/hostsapi/controllers.(*MainController).Get
   at ./controllers/default.go:16
4  0x00000000013f627c in github.com/astaxie/beego.(*ControllerRegister).ServeHTTP
   at /Users/zhoutao/goprj_root/src/github.com/astaxie/beego/router.go:798
5  0x000000000129c564 in net/http.serverHandler.ServeHTTP
   at /usr/local/go/src/net/http/server.go:2619
6  0x000000000129887d in net/http.(*conn).serve
   at /usr/local/go/src/net/http/server.go:1801
7  0x000000000105bf41 in runtime.goexit
   at /usr/local/go/src/runtime/asm_amd64.s:2337
```