### PR TITLE
avoid unnecessary read of large log file

### DIFF
--- a/logs/file.go
+++ b/logs/file.go
@@ -182,7 +182,7 @@ func (w *fileLogWriter) initFd() error {
 	if w.Daily {
 		go w.dailyRotate(w.dailyOpenTime)
 	}
-	if fInfo.Size() > 0 {
+	if fInfo.Size() > 0 && w.MaxLines > 0 {
 		count, err := w.lines()
 		if err != nil {
 			return err


### PR DESCRIPTION
If w.MaxLines is not set, there is no need to calc large log file’s lines. It may takes more than 10mins to calc a 10G file.
When we restart beego app, "strace -p" show reading log file for several minutes.