### PR TITLE
create log file when not exist before write

### DIFF
--- a/logs/file.go
+++ b/logs/file.go
@@ -146,6 +146,9 @@ func (w *fileLogWriter) WriteMsg(when time.Time, msg string, level int) error {
 	}
 
 	w.Lock()
+	if _, err := os.Stat(w.fileWriter.Name()); os.IsNotExist(err) {
+		w.startLogger()
+	}
 	_, err := w.fileWriter.Write([]byte(msg))
 	if err == nil {
 		w.maxLinesCurLines++


### PR DESCRIPTION
由于beego自带的log rotate功能需要beego程序运行才行，所以在服务升级期间，故障期间等服务会停止服务，log日志就无法自动rotate, 所以我使用的是一个单独的进程进行log rotate, 期间会对文件重命名，这时候beego写日志的时候就会无法写入，所以在每次写入前做了一个判断，如果文件不存在就会重新建一个文件，希望采纳。