### PR TITLE
test: Improve test case for utils/safemap, make it 100% cover

### DIFF
--- a/utils/safemap_test.go
+++ b/utils/safemap_test.go
@@ -31,6 +31,22 @@ func TestSet(t *testing.T) {
 	}
 }
 
+func TestReSet(t *testing.T) {
+	safeMap := NewBeeMap()
+	if ok := safeMap.Set("astaxie", 1); !ok {
+		t.Error("expected", true, "got", false)
+	}
+	// set diff value
+	if ok := safeMap.Set("astaxie", -1); !ok {
+		t.Error("expected", true, "got", false)
+	}
+
+	// set same value
+	if ok := safeMap.Set("astaxie", -1); ok {
+		t.Error("expected", false, "got", true)
+	}
+}
+
 func TestCheck(t *testing.T) {
 	if exists := safeMap.Check("astaxie"); !exists {
 		t.Error("expected", true, "got", false)
@@ -47,6 +63,21 @@ func TestDelete(t *testing.T) {
 	safeMap.Delete("astaxie")
 	if exists := safeMap.Check("astaxie"); exists {
 		t.Error("expected element to be deleted")
+	}
+}
+
+func TestItems(t *testing.T) {
+	safeMap := NewBeeMap()
+	safeMap.Set("astaxie", "hello")
+	for k, v := range safeMap.Items() {
+		key := k.(string)
+		value := v.(string)
+		if key != "astaxie" {
+			t.Error("expected the key should be astaxie")
+		}
+		if value != "hello" {
+			t.Error("expected the value should be hello")
+		}
 	}
 }
 


### PR DESCRIPTION
**Before:**

```bash
$ go test --cover
2017/12/01 01:05:21 [Debug] at com/astaxie/beego/utils.TestPrint() [C:/Users/axetroy/go/src/github.com/astaxie/beego/utils/debug_test.go:27]

[Variables]
v1 = 1
v2 = 2
v3 = 3
2017/12/01 01:05:21 [Debug] at com/astaxie/beego/utils.TestPrintPoint() [C:/Users/axetroy/go/src/github.com/astaxie/beego/utils/debug_test.go:40]

[Variables]
v1 = &utils.mytype{
    next: &utils.mytype{
        next: nil,
        prev: 0xC0420466C0,
    },
    prev: nil,
}
v2 = &utils.mytype{
    next: nil,
    prev: &utils.mytype{
        next: 0xC0420466D0,
        prev: nil,
    },
}
[Debug] at com/astaxie/beego/utils.TestPrintString() [C:/Users/axetroy/go/src/github.com/astaxie/beego/utils/debug_test.go:44]

[Variables]
v1 = 1
v2 = 2

PASS
coverage: 39.4% of statements
ok      github.com/astaxie/beego/utils  42.057s
```

**After:**

```bash
$ go test --cover
2017/12/01 01:04:28 [Debug] at com/axetroy/beego/utils.TestPrint() [C:/Users/axetroy/go/src/github.com/axetroy/beego/utils/debug_test.go:27]

[Variables]
v1 = 1
v2 = 2
v3 = 3
2017/12/01 01:04:28 [Debug] at com/axetroy/beego/utils.TestPrintPoint() [C:/Users/axetroy/go/src/github.com/axetroy/beego/utils/debug_test.go:40]

[Variables]
v1 = &utils.mytype{
    next: &utils.mytype{
        next: nil,
        prev: 0xC0420386D0,
    },
    prev: nil,
}
v2 = &utils.mytype{
    next: nil,
    prev: &utils.mytype{
        next: 0xC0420386E0,
        prev: nil,
    },
}
[Debug] at com/axetroy/beego/utils.TestPrintString() [C:/Users/axetroy/go/src/github.com/axetroy/beego/utils/debug_test.go:44]

[Variables]
v1 = 1
v2 = 2

PASS
coverage: 41.0% of statements
ok      github.com/axetroy/beego/utils  23.299s
```

coverage: **39.4%** of statements > coverage: **41.0%** of statements

and safemap have been cover all code