### PR TITLE
Add lock while releasing session

### DIFF
--- a/session/sess_file.go
+++ b/session/sess_file.go
@@ -78,6 +78,8 @@ func (fs *FileSessionStore) SessionID() string {
 
 // SessionRelease Write file session to local file with Gob string
 func (fs *FileSessionStore) SessionRelease(w http.ResponseWriter) {
+	filepder.lock.Lock()
+	defer filepder.lock.Unlock()
 	b, err := EncodeGob(fs.values)
 	if err != nil {
 		SLogger.Println(err)


### PR DESCRIPTION
### Solve the problem of SessionRead failure while ReleaseSession is in progress
Session data cannot be read successfully sometimes while performing concurrent request stress test. I found it is caused by file reading while releasing session after doing some research,  the session release procedure must be locked as well.
