### PR TITLE
Fix #2975

### DIFF
--- a/logs/accesslog.go
+++ b/logs/accesslog.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	apacheFormatPattern = "%s - - [%s] \"%s %d %d\" %f %s %s\n"
+	apacheFormatPattern = "%s - - [%s] \"%s %d %d\" %f %s %s"
 	apacheFormat        = "APACHE_FORMAT"
 	jsonFormat          = "JSON_FORMAT"
 )


### PR DESCRIPTION
Fix access log console unexpected '\n' at end of each log.