### PR TITLE
redis cache: make MaxIdle configurable

### DIFF
--- a/cache/redis/redis.go
+++ b/cache/redis/redis.go
@@ -171,7 +171,7 @@ func (rc *Cache) StartAndGC(config string) error {
 		cf["password"] = ""
 	}
 	if _, ok := cf["maxIdle"]; !ok {
-		cf["maxIdle"] = ""
+		cf["maxIdle"] = "3"
 	}
 	rc.key = cf["key"]
 	rc.conninfo = cf["conn"]

--- a/cache/redis/redis.go
+++ b/cache/redis/redis.go
@@ -53,6 +53,7 @@ type Cache struct {
 	dbNum    int
 	key      string
 	password string
+	maxIdle  int
 }
 
 // NewRedisCache create new redis cache with default collection name.
@@ -169,10 +170,14 @@ func (rc *Cache) StartAndGC(config string) error {
 	if _, ok := cf["password"]; !ok {
 		cf["password"] = ""
 	}
+	if _, ok := cf["maxIdle"]; !ok {
+		cf["maxIdle"] = ""
+	}
 	rc.key = cf["key"]
 	rc.conninfo = cf["conn"]
 	rc.dbNum, _ = strconv.Atoi(cf["dbNum"])
 	rc.password = cf["password"]
+	rc.maxIdle, _ = strconv.Atoi(cf["maxIdle"])
 
 	rc.connectInit()
 
@@ -206,7 +211,7 @@ func (rc *Cache) connectInit() {
 	}
 	// initialize a new pool
 	rc.p = &redis.Pool{
-		MaxIdle:     3,
+		MaxIdle:     rc.maxIdle,
 		IdleTimeout: 180 * time.Second,
 		Dial:        dialFunc,
 	}


### PR DESCRIPTION
Hi,

One of our applications has a very high req/s, and is hitting the redis cache for every request. In peak moments we were getting socket errors on the server. After investigation we noticed a lot of TIME_WAIT connections to the redis server. Increasing the MaxIdle to a higher value fixed this as connections are not closed as fast as before. In this PR we made the MaxIdle configuration of redigo configurable in the connection parameter of beego cache. The default stays the same.

Kind regards,
Pieter Callewaert