### PR TITLE
Update: Fix migration generate SQL

### DIFF
--- a/migration/ddl.go
+++ b/migration/ddl.go
@@ -322,7 +322,7 @@ func (m *Migration) GetSQL() (sql string) {
 					sql += fmt.Sprintf("\n DROP COLUMN `%s`", column.Name)
 				}
 
-				if len(m.Columns) > index {
+				if len(m.Columns) > index+1 {
 					sql += ","
 				}
 			}
@@ -355,7 +355,7 @@ func (m *Migration) GetSQL() (sql string) {
 				} else {
 					sql += fmt.Sprintf("\n DROP COLUMN `%s`", column.Name)
 				}
-				if len(m.Columns) > index {
+				if len(m.Columns) > index+1 {
 					sql += ","
 				}
 			}
@@ -366,14 +366,14 @@ func (m *Migration) GetSQL() (sql string) {
 
 			for index, unique := range m.Uniques {
 				sql += fmt.Sprintf("\n DROP KEY `%s`", unique.Definition)
-				if len(m.Uniques) > index {
+				if len(m.Uniques) > index+1 {
 					sql += ","
 				}
 
 			}
 			for index, column := range m.Renames {
 				sql += fmt.Sprintf("\n CHANGE COLUMN `%s` `%s` %s %s %s %s", column.NewName, column.OldName, column.OldDataType, column.OldUnsign, column.OldNull, column.OldDefault)
-				if len(m.Renames) > index {
+				if len(m.Renames) > index+1 {
 					sql += ","
 				}
 			}


### PR DESCRIPTION
When you delete a field in a table, the generated statement adds extra commas, resulting in a syntax error.

The migration code like this:

```
package main

import (
	"github.com/astaxie/beego/migration"
)

// DO NOT MODIFY
type User_20180103_183316 struct {
	migration.Migration
}

// DO NOT MODIFY
func init() {
	m := &User_20180103_183316{}
	m.Created = "20180103_183316"
        m.ddlSpec()
	migration.Register("User_20180103_183316", m)
}

/*
   refer beego/migration/doc.go
*/
func (m *User_20180103_183316) ddlSpec() {
    m.AlterTable("user")    
}

func (m *User_20180103_183316) Up() {
	m.NewCol("name").Remove()
	m.SQL(m.GetSQL())
}
```

  