### PR TITLE
do html escape before display path, avoid xss

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -76,6 +76,18 @@ func adminIndex(rw http.ResponseWriter, r *http.Request) {
 func qpsIndex(rw http.ResponseWriter, r *http.Request) {
 	data := make(map[interface{}]interface{})
 	data["Content"] = toolbox.StatisticsMap.GetMap()
+
+	// do html escape before display path, avoid xss
+	if content, ok := (data["Content"]).(map[string]interface{}); ok {
+		if resultLists, ok := (content["Data"]).([][]string); ok {
+			for i := range resultLists {
+				if len(resultLists[i]) > 0 {
+					resultLists[i][0] = template.HTMLEscapeString(resultLists[i][0])
+				}
+			}
+		}
+	}
+
 	execTpl(rw, data, qpsTpl, defaultScriptsTpl)
 }
 


### PR DESCRIPTION
We will get XSS if we do not escape before display on admin page. 
If we
`curl "http://127.0.0.1:8080/search=<script>alert('XSS')</script>"`
We will get XSS alert on
`http://127.0.0.1:8088/qps`