### PR TITLE
Handle pointer validation

### DIFF
--- a/validation/validation.go
+++ b/validation/validation.go
@@ -245,7 +245,17 @@ func (v *Validation) ZipCode(obj interface{}, key string) *Result {
 }
 
 func (v *Validation) apply(chk Validator, obj interface{}) *Result {
-	if chk.IsSatisfied(obj) {
+	if reflect.TypeOf(obj).Kind() == reflect.Ptr {
+		if reflect.ValueOf(obj).IsNil() {
+			if "Required" != chk.GetKey() {
+				return &Result{Ok: true}
+			}
+		} else {
+			if chk.IsSatisfied(reflect.ValueOf(obj).Elem().Interface()) {
+				return &Result{Ok: true}
+			}
+		}
+	} else if chk.IsSatisfied(obj) {
 		return &Result{Ok: true}
 	}
 


### PR DESCRIPTION
I have a struct like the following that I populate from json unmarshaling:
```
type Entity struct {
	ID                  int     `json:"-" db:"rowid"`
	Status            *string `json:"status" db:"status" valid:"Match(/^(active|inactive|deleted)$/)"`
}
```

I rely to the fact that `Status` is set to `nil` when the tag is not present in the json (that's a different behaviour from using `omitempty` since I want to differ between the field not being set at all or sent as an empty string)
beego validation doesn't have any support for pointer in the struct, my PR take care of it (I will add test)
Please, note that this may change expected behaviour: since beego provides a `Required` validator I supposed that all the other validators allow nil values and `Required` was a kind of a flag that overrides this behaviour, while it seems that `Required` is just a standard validator for multi types "not empty" logic  other validators don't accept nil values.
My PR changes this behaviour, so that if the value is nil and the element has no `Required` it will pass validation