### PR TITLE
Handle pointer validation

### DIFF
--- a/validation/validation.go
+++ b/validation/validation.go
@@ -245,7 +245,17 @@ func (v *Validation) ZipCode(obj interface{}, key string) *Result {
 }
 
 func (v *Validation) apply(chk Validator, obj interface{}) *Result {
-	if chk.IsSatisfied(obj) {
+	if reflect.TypeOf(obj).Kind() == reflect.Ptr {
+		if reflect.ValueOf(obj).IsNil() {
+			if "Required" != chk.GetKey() {
+				return &Result{Ok: true}
+			}
+		} else {
+			if chk.IsSatisfied(reflect.ValueOf(obj).Elem().Interface()) {
+				return &Result{Ok: true}
+			}
+		}
+	} else if chk.IsSatisfied(obj) {
 		return &Result{Ok: true}
 	}
 

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -245,9 +245,14 @@ func (v *Validation) ZipCode(obj interface{}, key string) *Result {
 }
 
 func (v *Validation) apply(chk Validator, obj interface{}) *Result {
-	if reflect.TypeOf(obj).Kind() == reflect.Ptr {
+	validatorName := reflect.TypeOf(chk).Name()
+	if nil == obj {
+		if chk.IsSatisfied(obj) {
+			return &Result{Ok: true}
+		}
+	} else if reflect.TypeOf(obj).Kind() == reflect.Ptr {
 		if reflect.ValueOf(obj).IsNil() {
-			if "Required" != chk.GetKey() {
+			if "Required" != validatorName {
 				return &Result{Ok: true}
 			}
 		} else {

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -480,7 +480,35 @@ func TestPointer(t *testing.T) {
 		t.Fatal("validation should be passed")
 	}
 
+	u = User{
+		ReqEmail: &validEmail,
+		Email:	  nil,
+	}
+
+	valid = Validation{}
+	b, err = valid.Valid(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !b {
+		t.Fatal("validation should be passed")
+	}
+
 	invalidEmail := "a@a"
+	u = User{
+		ReqEmail: &validEmail,
+		Email:	  &invalidEmail,
+	}
+
+	valid = Validation{RequiredFirst: true}
+	b, err = valid.Valid(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b {
+		t.Fatal("validation should not be passed")
+	}
+
 	u = User{
 		ReqEmail: &validEmail,
 		Email:	  &invalidEmail,

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -490,8 +490,8 @@ func TestPointer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !b {
-		t.Fatal("validation should be passed")
+	if b {
+		t.Fatal("validation should not be passed")
 	}
 
 	invalidEmail := "a@a"
@@ -523,3 +523,41 @@ func TestPointer(t *testing.T) {
 		t.Fatal("validation should not be passed")
 	}
 }
+
+
+func TestCanSkipAlso(t *testing.T) {
+	type User struct {
+		ID int
+
+		Email    	string `valid:"Email"`
+		ReqEmail 	string `valid:"Required;Email"`
+		MatchRange	int 	`valid:"Range(10, 20)"`
+	}
+
+	u := User{
+		ReqEmail: 	"a@a.com",
+		Email:    	"",
+		MatchRange: 0,
+	}
+
+	valid := Validation{RequiredFirst: true}
+	b, err := valid.Valid(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b {
+		t.Fatal("validation should not be passed")
+	}
+
+	valid = Validation{RequiredFirst: true}
+	valid.CanSkipAlso("Range")
+	b, err = valid.Valid(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !b {
+		t.Fatal("validation should be passed")
+	}
+
+}
+

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -442,3 +442,56 @@ func TestSkipValid(t *testing.T) {
 		t.Fatal("validation should be passed")
 	}
 }
+
+func TestPointer(t *testing.T) {
+	type User struct {
+		ID int
+
+		Email    *string `valid:"Email"`
+		ReqEmail *string `valid:"Required;Email"`
+	}
+
+	u := User{
+		ReqEmail: nil,
+		Email:	  nil,
+	}
+
+	valid := Validation{}
+	b, err := valid.Valid(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b {
+		t.Fatal("validation should not be passed")
+	}
+
+	validEmail := "a@a.com"
+	u = User{
+		ReqEmail: &validEmail,
+		Email:	  nil,
+	}
+
+	valid = Validation{RequiredFirst: true}
+	b, err = valid.Valid(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !b {
+		t.Fatal("validation should be passed")
+	}
+
+	invalidEmail := "a@a"
+	u = User{
+		ReqEmail: &validEmail,
+		Email:	  &invalidEmail,
+	}
+
+	valid = Validation{}
+	b, err = valid.Valid(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b {
+		t.Fatal("validation should not be passed")
+	}
+}


### PR DESCRIPTION
I have a struct like the following that I populate from json unmarshaling:
```
type Entity struct {
	ID                  int     `json:"-" db:"rowid"`
	Status            *string `json:"status" db:"status" valid:"Match(/^(active|inactive|deleted)$/)"`
}
```
I rely to the fact that `Status` is set to `nil` when the tag is not present in the json (that's a different behaviour from using `omitempty` since I want to differ between the field not being set at all or sent as an empty string)
beego validation doesn't have any support for pointer in the struct, my PR take care of it (I will add tests)
Please, note that this may change expected behaviour: since beego provides a `Required` validator I supposed that all the other validators allow nil values and `Required` was a kind of a flag that overrides this behaviour, while it seems that `Required` is just a standard validator for multi types "not empty" logic other validators don't accept nil values.
My PR changes this behaviour, so that if the value is nil and the element has no `Required` it will pass validation

PS: I will close https://github.com/astaxie/beego/pull/3043 and continue here instead