### PR TITLE
Set default Beego RunMode to production

### DIFF
--- a/config.go
+++ b/config.go
@@ -188,7 +188,7 @@ func recoverPanic(ctx *context.Context) {
 func newBConfig() *Config {
 	return &Config{
 		AppName:             "beego",
-		RunMode:             DEV,
+		RunMode:             PROD,
 		RouterCaseSensitive: true,
 		ServerName:          "beegoServer:" + VERSION,
 		RecoverPanic:        true,


### PR DESCRIPTION
Development mode should only be available if it was explicitly configured otherwise it is a security risk.