### PR TITLE
Update httplib.go

### DIFF
--- a/httplib/httplib.go
+++ b/httplib/httplib.go
@@ -332,7 +332,7 @@ func (b *BeegoHTTPRequest) XMLBody(obj interface{}) (*BeegoHTTPRequest, error) {
 }
 // JSONBody adds request raw body encoding by JSON.
 func (b *BeegoHTTPRequest) JSONBody(obj interface{}) (*BeegoHTTPRequest, error) {
-	if b.req.Body == nil && obj != nil {
+	if obj != nil {
 		byts, err := json.Marshal(obj)
 		if err != nil {
 			return b, err


### PR DESCRIPTION
#3081 
不判断b.req.Body == nil，这样每次重试都设置新的Body，避免出现 ContentLength和Body length 不一致的错误，导致重试发请求失败。
