### PR TITLE
当模板错误的时候存在死锁

### DIFF
--- a/template.go
+++ b/template.go
@@ -217,6 +217,7 @@ func BuildTemplate(dir string, files ...string) error {
 					t, err = getTemplate(self.root, file, v...)
 				}
 				if err != nil {
+					templatesLock.Unlock()
 					logs.Error("parse template err:", file, err)
 					return err
 				}


### PR DESCRIPTION
当模板错误的时候存在死锁，虽然这钟情况会导致系统存在问题，但是不应该出现死锁吧！最好可以增加一个模板语法检查函数。