### PR TITLE
fix: data race on app.Server.Addr

### DIFF
--- a/app.go
+++ b/app.go
@@ -191,6 +191,10 @@ func (app *App) Run(mws ...MiddleWare) {
 			}
 		}()
 	}
+
+	// fix data race on app.Server.Addr
+	time.Sleep(1000 * time.Microsecond)
+
 	if BConfig.Listen.EnableHTTP {
 		go func() {
 			app.Server.Addr = addr


### PR DESCRIPTION
同时启用 https 和 http 的时候，在部分操作系统或环境下，很容易因为 app.Server.Addr 的原因产生条件竞争，触发 `address already in use` 的 panic。

关于 data race 的问题可以使用下面的代码复现，更多信息可以查看我给 golang 提的 [issue](https://github.com/golang/go/issues/24553)。golang 官方并不认为这是一个 bug, 但是在 beego 的代码里面确实会出现这个问题。简单来说，就是多个线程去引用同一个变量可能产生的问题。

```golang
package main

import (
	"log"
	"net"
	"net/http"
	"time"
)

func handler(w http.ResponseWriter, req *http.Request) {
	w.Header().Set("Content-Type", "text/plain")
	w.Write([]byte("This is an example server.\n"))
}

var Server *http.Server
var addr = ""

func runHTTPS() {
	addr = ":8083"
	http.HandleFunc("/", handler)
	log.Println("https://127.0.0.1:8083/")
	err := http.ListenAndServeTLS(addr, "cert.pem", "private.pem", nil)
	if err != nil {
		panic(err)
	}
}

func runHTTP() {
	addr = ":8082"
	log.Println("http://127.0.0.1:8082/")
	ln, err := net.Listen("tcp4", addr)
	if err != nil {
		panic(err)
	}
	log.Println(ln)
}

func main() {

	go runHTTPS()
	// time.Sleep(1000 * time.Microsecond)
	go runHTTP()

	for {
		time.Sleep(2 * time.Microsecond)
	}
}
```

golang 环境和系统环境可以参考链接上的内容，我们在MAC上能稳定复现，且在windows和linux上都有复现的经历。
当前的PR，可能不是最佳的修复方式，但是却是可以解决问题的。最好的方法还是不用使用同一个变量比较好，这样的话改动比较大，由你们来修改可能会好一点。