### PR TITLE
When log maxSize set big int，FileWrite Init fail

### DIFF
--- a/logs/multifile.go
+++ b/logs/multifile.go
@@ -67,7 +67,10 @@ func (f *multiFileLogWriter) Init(config string) error {
 				jsonMap["level"] = i
 				bs, _ := json.Marshal(jsonMap)
 				writer = newFileWriter().(*fileLogWriter)
-				writer.Init(string(bs))
+				err := writer.Init(string(bs))
+				if err != nil {
+					return err
+				}
 				f.writers[i] = writer
 			}
 		}


### PR DESCRIPTION
example:
beego.SetLogger("multifile", {"filename":"logs/liverelay.log","separate":[ "emergency", "error", "info", "debug"],"maxsize":250000000}).

json: cannot unmarshal number 2.5e+08 into Go value of type int

The err should return and show the developer.