### PR TITLE
beego日志格式化问题

### DIFF
--- a/logs/log.go
+++ b/logs/log.go
@@ -629,7 +629,7 @@ func formatLog(f interface{}, v ...interface{}) string {
 		if len(v) == 0 {
 			return msg
 		}
-		if strings.Contains(msg, "%") && !strings.Contains(msg, "%%") {
+		if strings.Contains(strings.Replace(msg, "%%", "", -1), "%") {
 			//format string
 		} else {
 			//do not contain format char


### PR DESCRIPTION
str := "good"
result := formatLog("%s dingai %%s", str)
fmt.Println(result)
结果如下：
good dingai %s %!v(MISSING)

修复该问题。。



