### PR TITLE
Amend a very minor typo in a variable name

### DIFF
--- a/context/output.go
+++ b/context/output.go
@@ -182,8 +182,8 @@ func errorRenderer(err error) Renderer {
 }
 
 // JSON writes json to response body.
-// if coding is true, it converts utf-8 to \u0000 type.
-func (output *BeegoOutput) JSON(data interface{}, hasIndent bool, coding bool) error {
+// if encoding is true, it converts utf-8 to \u0000 type.
+func (output *BeegoOutput) JSON(data interface{}, hasIndent bool, encoding bool) error {
 	output.Header("Content-Type", "application/json; charset=utf-8")
 	var content []byte
 	var err error
@@ -196,7 +196,7 @@ func (output *BeegoOutput) JSON(data interface{}, hasIndent bool, coding bool) e
 		http.Error(output.Context.ResponseWriter, err.Error(), http.StatusInternalServerError)
 		return err
 	}
-	if coding {
+	if encoding {
 		content = []byte(stringsToJSON(string(content)))
 	}
 	return output.Body(content)


### PR DESCRIPTION
It's just a minor typo on a variable that flags whether the output is transformed from utf-8 to the unicode value of each rune – which can be referred to as _encoding_ (the runes).