### PR TITLE
In dev mode, template parse error cause program lock

### DIFF
--- a/template.go
+++ b/template.go
@@ -218,6 +218,7 @@ func BuildTemplate(dir string, files ...string) error {
 				}
 				if err != nil {
 					logs.Error("parse template err:", file, err)
+					templatesLock.Unlock()
 					return err
 				}
 				beeTemplates[file] = t


### PR DESCRIPTION
To avoid the title's story, unlock a mutex when template error occured.