### PR TITLE
Refactor yaml config for support multilevel

### DIFF
--- a/config/yaml/yaml.go
+++ b/config/yaml/yaml.go
@@ -285,9 +285,23 @@ func (c *ConfigContainer) getData(key string) (interface{}, error) {
 	if len(key) == 0 {
 		return nil, errors.New("key is empty")
 	}
+	keys := strings.Split(key, ".")
+	tmpData := c.data
+	for _, k := range keys {
+		if v, ok := tmpData[k]; ok {
+			switch v.(type) {
 
-	if v, ok := c.data[key]; ok {
-		return v, nil
+			case map[string]interface{}:
+				{
+					tmpData = v.(map[string]interface{})
+				}
+			default:
+				{
+					return v, nil
+				}
+
+			}
+		}
 	}
 	return nil, fmt.Errorf("not exist key %q", key)
 }

--- a/config/yaml/yaml.go
+++ b/config/yaml/yaml.go
@@ -290,7 +290,6 @@ func (c *ConfigContainer) getData(key string) (interface{}, error) {
 	for _, k := range keys {
 		if v, ok := tmpData[k]; ok {
 			switch v.(type) {
-
 			case map[string]interface{}:
 				{
 					tmpData = v.(map[string]interface{})


### PR DESCRIPTION
Add support for multilevel yaml config
current yaml config only support single level config, not support config like:
```
a:
  b: this is value
```

refactor code to support this
