### PR TITLE
Improve access log

### DIFF
--- a/admin_test.go
+++ b/admin_test.go
@@ -67,6 +67,7 @@ func oldMap() map[string]interface{} {
 	m["BConfig.WebConfig.Session.SessionDomain"] = BConfig.WebConfig.Session.SessionDomain
 	m["BConfig.WebConfig.Session.SessionDisableHTTPOnly"] = BConfig.WebConfig.Session.SessionDisableHTTPOnly
 	m["BConfig.Log.AccessLogs"] = BConfig.Log.AccessLogs
+	m["BConfig.Log.EnableStaticLogs"] = BConfig.Log.EnableStaticLogs
 	m["BConfig.Log.AccessLogsFormat"] = BConfig.Log.AccessLogsFormat
 	m["BConfig.Log.FileLineNum"] = BConfig.Log.FileLineNum
 	m["BConfig.Log.Outputs"] = BConfig.Log.Outputs

--- a/config.go
+++ b/config.go
@@ -106,6 +106,7 @@ type SessionConfig struct {
 // LogConfig holds Log related config
 type LogConfig struct {
 	AccessLogs       bool
+	EnableStaticLogs bool   //log static files requests default: false
 	AccessLogsFormat string //access log format: JSON_FORMAT, APACHE_FORMAT or empty string
 	FileLineNum      bool
 	Outputs          map[string]string // Store Adaptor : config
@@ -247,6 +248,7 @@ func newBConfig() *Config {
 		},
 		Log: LogConfig{
 			AccessLogs:       false,
+			EnableStaticLogs: false,
 			AccessLogsFormat: "APACHE_FORMAT",
 			FileLineNum:      true,
 			Outputs:          map[string]string{"console": ""},

--- a/controller.go
+++ b/controller.go
@@ -272,7 +272,9 @@ func (c *Controller) viewPath() string {
 
 // Redirect sends the redirection response to url with status code.
 func (c *Controller) Redirect(url string, code int) {
+	logAccess(c.Ctx, nil, code)
 	c.Ctx.Redirect(code, url)
+	panic(ErrAbort)
 }
 
 // Abort stops controller handler and show the error data if code is defined in ErrorMap or code string.

--- a/error.go
+++ b/error.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	errorTypeHandler = iota
+	errorTypeHandler    = iota
 	errorTypeController
 )
 
@@ -439,6 +439,9 @@ func exception(errCode string, ctx *context.Context) {
 }
 
 func executeError(err *errorInfo, ctx *context.Context, code int) {
+	//make sure to log the error in the access log
+	logAccess(ctx, nil, code)
+
 	if err.errorType == errorTypeHandler {
 		ctx.ResponseWriter.WriteHeader(code)
 		err.handler(ctx.ResponseWriter, ctx.Request)

--- a/logs/accesslog.go
+++ b/logs/accesslog.go
@@ -64,9 +64,7 @@ func disableEscapeHTML(i interface{}) {
 // AccessLog - Format and print access log.
 func AccessLog(r *AccessLogRecord, format string) {
 	var msg string
-
 	switch format {
-
 	case apacheFormat:
 		timeFormatted := r.RequestTime.Format("02/Jan/2006 03:04:05")
 		msg = fmt.Sprintf(apacheFormatPattern, r.RemoteAddr, timeFormatted, r.Request, r.Status, r.BodyBytesSent,

--- a/logs/accesslog.go
+++ b/logs/accesslog.go
@@ -16,9 +16,10 @@ package logs
 
 import (
 	"bytes"
+	"strings"
 	"encoding/json"
-	"time"
 	"fmt"
+	"time"
 )
 
 const (
@@ -53,10 +54,9 @@ func (r *AccessLogRecord) json() ([]byte, error) {
 }
 
 func disableEscapeHTML(i interface{}) {
-	e, ok := i.(interface {
+	if e, ok := i.(interface {
 		SetEscapeHTML(bool)
-	});
-	if ok {
+	}); ok {
 		e.SetEscapeHTML(false)
 	}
 }
@@ -81,6 +81,5 @@ func AccessLog(r *AccessLogRecord, format string) {
 			msg = string(jsonData)
 		}
 	}
-
-	beeLogger.Debug(msg)
+	beeLogger.writeMsg(levelLoggerImpl, strings.TrimSpace(msg))
 }

--- a/router.go
+++ b/router.go
@@ -201,9 +201,12 @@ func (p *ControllerRegister) addWithMethodParams(pattern string, c ControllerInt
 
 		numOfFields := elemVal.NumField()
 		for i := 0; i < numOfFields; i++ {
-			fieldVal := elemVal.Field(i)
 			fieldType := elemType.Field(i)
-			execElem.FieldByName(fieldType.Name).Set(fieldVal)
+
+			if execElem.FieldByName(fieldType.Name).CanSet() {
+				fieldVal := elemVal.Field(i)
+				execElem.FieldByName(fieldType.Name).Set(fieldVal)
+			}
 		}
 
 		return execController

--- a/router.go
+++ b/router.go
@@ -43,7 +43,7 @@ const (
 )
 
 const (
-	routerTypeBeego = iota
+	routerTypeBeego   = iota
 	routerTypeRESTFul
 	routerTypeHandler
 )
@@ -877,12 +877,14 @@ func (p *ControllerRegister) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 	}
 
 Admin:
-	//admin module record QPS
+//admin module record QPS
 
 	statusCode := context.ResponseWriter.Status
 	if statusCode == 0 {
 		statusCode = 200
 	}
+
+	logAccess(context, &startTime, statusCode)
 
 	if BConfig.Listen.EnableAdmin {
 		timeDur := time.Since(startTime)
@@ -900,49 +902,30 @@ Admin:
 		}
 	}
 
-	if BConfig.RunMode == DEV || BConfig.Log.AccessLogs {
-		timeDur := time.Since(startTime)
+	if BConfig.RunMode == DEV && !BConfig.Log.AccessLogs {
 		var devInfo string
-
+		timeDur := time.Since(startTime)
 		iswin := (runtime.GOOS == "windows")
 		statusColor := logs.ColorByStatus(iswin, statusCode)
 		methodColor := logs.ColorByMethod(iswin, r.Method)
 		resetColor := logs.ColorByMethod(iswin, "")
-		if BConfig.Log.AccessLogsFormat != "" {
-			record := &logs.AccessLogRecord{
-				RemoteAddr:     context.Input.IP(),
-				RequestTime:    startTime,
-				RequestMethod:  r.Method,
-				Request:        fmt.Sprintf("%s %s %s", r.Method, r.RequestURI, r.Proto),
-				ServerProtocol: r.Proto,
-				Host:           r.Host,
-				Status:         statusCode,
-				ElapsedTime:    timeDur,
-				HTTPReferrer:   r.Header.Get("Referer"),
-				HTTPUserAgent:  r.Header.Get("User-Agent"),
-				RemoteUser:     r.Header.Get("Remote-User"),
-				BodyBytesSent:  0, //@todo this one is missing!
-			}
-			logs.AccessLog(record, BConfig.Log.AccessLogsFormat)
-		} else {
-			if findRouter {
-				if routerInfo != nil {
-					devInfo = fmt.Sprintf("|%15s|%s %3d %s|%13s|%8s|%s %-7s %s %-3s   r:%s", context.Input.IP(), statusColor, statusCode,
-						resetColor, timeDur.String(), "match", methodColor, r.Method, resetColor, r.URL.Path,
-						routerInfo.pattern)
-				} else {
-					devInfo = fmt.Sprintf("|%15s|%s %3d %s|%13s|%8s|%s %-7s %s %-3s", context.Input.IP(), statusColor, statusCode, resetColor,
-						timeDur.String(), "match", methodColor, r.Method, resetColor, r.URL.Path)
-				}
+		if findRouter {
+			if routerInfo != nil {
+				devInfo = fmt.Sprintf("|%15s|%s %3d %s|%13s|%8s|%s %-7s %s %-3s   r:%s", context.Input.IP(), statusColor, statusCode,
+					resetColor, timeDur.String(), "match", methodColor, r.Method, resetColor, r.URL.Path,
+					routerInfo.pattern)
 			} else {
 				devInfo = fmt.Sprintf("|%15s|%s %3d %s|%13s|%8s|%s %-7s %s %-3s", context.Input.IP(), statusColor, statusCode, resetColor,
-					timeDur.String(), "nomatch", methodColor, r.Method, resetColor, r.URL.Path)
+					timeDur.String(), "match", methodColor, r.Method, resetColor, r.URL.Path)
 			}
-			if iswin {
-				logs.W32Debug(devInfo)
-			} else {
-				logs.Debug(devInfo)
-			}
+		} else {
+			devInfo = fmt.Sprintf("|%15s|%s %3d %s|%13s|%8s|%s %-7s %s %-3s", context.Input.IP(), statusColor, statusCode, resetColor,
+				timeDur.String(), "nomatch", methodColor, r.Method, resetColor, r.URL.Path)
+		}
+		if iswin {
+			logs.W32Debug(devInfo)
+		} else {
+			logs.Debug(devInfo)
 		}
 	}
 	// Call WriteHeader if status code has been set changed
@@ -990,4 +973,39 @@ func toURL(params map[string]string) string {
 		u += k + "=" + v + "&"
 	}
 	return strings.TrimRight(u, "&")
+}
+
+func logAccess(ctx *beecontext.Context, startTime *time.Time, statusCode int) {
+	//Skip logging if AccessLogs config is false
+	if !BConfig.Log.AccessLogs {
+		return
+	}
+	//Skip logging static requests unless EnableStaticLogs config is true
+	if !BConfig.Log.EnableStaticLogs && DefaultAccessLogFilter.Filter(ctx) {
+		return
+	}
+	var (
+		requestTime time.Time
+		elapsedTime time.Duration
+		r           = ctx.Request
+	)
+	if startTime != nil {
+		requestTime = *startTime
+		elapsedTime = time.Since(*startTime)
+	}
+	record := &logs.AccessLogRecord{
+		RemoteAddr:     ctx.Input.IP(),
+		RequestTime:    requestTime,
+		RequestMethod:  r.Method,
+		Request:        fmt.Sprintf("%s %s %s", r.Method, r.RequestURI, r.Proto),
+		ServerProtocol: r.Proto,
+		Host:           r.Host,
+		Status:         statusCode,
+		ElapsedTime:    elapsedTime,
+		HTTPReferrer:   r.Header.Get("Referer"),
+		HTTPUserAgent:  r.Header.Get("User-Agent"),
+		RemoteUser:     r.Header.Get("Remote-User"),
+		BodyBytesSent:  0, //@todo this one is missing!
+	}
+	logs.AccessLog(record, BConfig.Log.AccessLogsFormat)
 }


### PR DESCRIPTION
- Allow access log regardless of the log level.
- Log errors in access log (status: 404, 500, ...etc).
- Make static request logging optional "EnableStaticLogs" (default no logging).
- Log redirects (301, 302) and abort after redirect