### PR TITLE
fix file daily rotate question

### DIFF
--- a/logs/file.go
+++ b/logs/file.go
@@ -176,7 +176,7 @@ func (w *fileLogWriter) initFd() error {
 		return fmt.Errorf("get stat err: %s", err)
 	}
 	w.maxSizeCurSize = int(fInfo.Size())
-	w.dailyOpenTime = time.Now()
+	w.dailyOpenTime = fInfo.ModTime()
 	w.dailyOpenDate = w.dailyOpenTime.Day()
 	w.maxLinesCurLines = 0
 	if w.Daily {


### PR DESCRIPTION
以前用time.Now()记录打开时间，仅适用于服务端一直运行，隔天开始新建一个文件。对于要经常启动停止的客户端应用无法每日创建新文件。修改为文件最终修改的时间，既能适用服务端，也能适用客户端。