### PR TITLE
Modify m2m.Add to allow multiple pointer in the rel_through table

### DIFF
--- a/orm/orm_querym2m.go
+++ b/orm/orm_querym2m.go
@@ -79,6 +79,7 @@ func (o *queryM2M) Add(mds ...interface{}) (int64, error) {
 	names := []string{mfi.column, rfi.column}
 
 	values := make([]interface{}, 0, len(models)*2)
+	values = append(values, v1)
 	for _, md := range models {
 
 		ind := reflect.Indirect(reflect.ValueOf(md))
@@ -91,8 +92,7 @@ func (o *queryM2M) Add(mds ...interface{}) (int64, error) {
 				panic(ErrMissPK)
 			}
 		}
-		values = append(values, v1, v2)
-
+		values = append(values, v2)
 	}
 	names = append(names, otherNames...)
 	values = append(values, otherValues...)

--- a/orm/orm_querym2m.go
+++ b/orm/orm_querym2m.go
@@ -42,6 +42,7 @@ func (o *queryM2M) Add(mds ...interface{}) (int64, error) {
 	dbase := orm.alias.DbBaser
 
 	var models []interface{}
+	var tempMds []interface{}
 	var otherValues []interface{}
 	var otherNames []string
 
@@ -54,9 +55,11 @@ func (o *queryM2M) Add(mds ...interface{}) (int64, error) {
 	for i, md := range mds {
 		if reflect.Indirect(reflect.ValueOf(md)).Kind() != reflect.Struct && i > 0 {
 			otherValues = append(otherValues, md)
-			mds = append(mds[:i], mds[i+1:]...)
+		} else {
+			tempMds = append(tempMds, md)
 		}
 	}
+	mds = tempMds
 	for _, md := range mds {
 		val := reflect.ValueOf(md)
 		if val.Kind() == reflect.Slice || val.Kind() == reflect.Array {


### PR DESCRIPTION
In the design of beego's M2M table, we allow programmers to use rel_through tag to use a customized table for the intermedia table. For instance, we have Book  Tag, User, and a BookTagReaderRel to connect those three tables. And the Definition of the PostTagReaderRel is as following:  
```
type Book struct {
        ID        int         
        Tags
        Tags   []*Tag     `orm:”rel(m2m);rel_through(project/models.BookTagRel)"`
}

type Tag struct {
        ID        int       
        // tag info
        Books  []*Book  `orm:”reverse(many);rel_through(project/models. BookTagReaderRel)"`   
}

type User struct {
        ID        int         
        // user info
}

type BookTagRel struct {
        ID         int              `orm:”ok;auto"`
        Book    *Book         `orm:”rel(fk)"`
        Tag       *Tag          `orm:”rel(fk)"`
        User     *User        `orm:”rel(fk)”` // NOTE: The key is that we want to use pointer here
}
```
Then if a user add a new tag for a book, we willl typically do the following:

        m2mTable := o.QueryM2M(book, “Tags”)
        m2mTable.Add(newTag, tagUser)

However, this will give us an error saying something like:

[ORM]2018/06/08 11:24:56  -[Queries/default] - [FAIL /     db.Exec /     1.1ms] - [INSERT INTO `book_tag_rel` (`book_id`, `tag_id`, `user_id`) VALUES (?, ?, ?)] - `2`, `4`, `2`, `2` - sql: expected 3 arguments, got 4

The reason of this is in the orm_querym2m.go file, we perform
``` values = append(values, v1, v2) ```
inside the loop where v1 is the id value use to to anchor the m2mTable and v2 is the current key of the struct we are dealing with. 

So the `2`, `4`, `2`, `2` part in the sql statement is from 
`2`,  -> book_id
`4`,  -> tag_id
`2`,  -> book_id
`2`   -> user_id
And we have duplicate value for the 0 and 3 position. 

To fix this issue, we can simply add the v1 value outside the loop and only add the v2 value inside the loop. This will allow us to use the rel_through table to store multiple pointers.

---------------------------------------------------------------------------------------------

The second commit fix a more bug in the code. In a more general case, where we don't use pointer in the rel_through table, the original code will break when we have more than one non-struct field in the table because
        mds = append(mds[:i], mds[i+1:]...)
will modify mds itself and the next loop iteration will use the old index on the new mds list. 