### PR TITLE
add 'FOR UPDATE' support for querySet

### DIFF
--- a/orm/db.go
+++ b/orm/db.go
@@ -969,6 +969,10 @@ func (d *dbBase) ReadBatch(q dbQuerier, qs *querySet, mi *modelInfo, cond *Condi
 	}
 	query := fmt.Sprintf("%s %s FROM %s%s%s T0 %s%s%s%s%s", sqlSelect, sels, Q, mi.table, Q, join, where, groupBy, orderBy, limit)
 
+	if qs.forupdate {
+		query += " FOR UPDATE"
+	}
+
 	d.ins.ReplaceMarks(&query)
 
 	var rs *sql.Rows

--- a/orm/orm_queryset.go
+++ b/orm/orm_queryset.go
@@ -55,16 +55,17 @@ func ColValue(opt operator, value interface{}) interface{} {
 
 // real query struct
 type querySet struct {
-	mi       *modelInfo
-	cond     *Condition
-	related  []string
-	relDepth int
-	limit    int64
-	offset   int64
-	groups   []string
-	orders   []string
-	distinct bool
-	orm      *orm
+	mi        *modelInfo
+	cond      *Condition
+	related   []string
+	relDepth  int
+	limit     int64
+	offset    int64
+	groups    []string
+	orders    []string
+	distinct  bool
+	forupdate bool
+	orm       *orm
 }
 
 var _ QuerySeter = new(querySet)
@@ -124,6 +125,12 @@ func (o querySet) OrderBy(exprs ...string) QuerySeter {
 // add DISTINCT to SELECT
 func (o querySet) Distinct() QuerySeter {
 	o.distinct = true
+	return &o
+}
+
+// add FOR UPDATE to SELECT
+func (o querySet) ForUpdate() QuerySeter {
+	o.forupdate = true
 	return &o
 }
 

--- a/orm/types.go
+++ b/orm/types.go
@@ -190,6 +190,10 @@ type QuerySeter interface {
 	//    Distinct().
 	//    All(&permissions)
 	Distinct() QuerySeter
+	// set FOR UPDATE to query.
+	// for example:
+	//  o.QueryTable("user").Filter("uid", uid).ForUpdate().All(&users)
+	ForUpdate() QuerySeter
 	// return QuerySeter execution result number
 	// for example:
 	//	num, err = qs.Filter("profile__age__gt", 28).Count()


### PR DESCRIPTION
Currently, only orm.ReadForUpdate() supports locking on one row. If we want to batch update with locks on multiple rows, we have to write raw sql which is inconvenient.
So I tried to add 'FOR UPDATE' support to querySet, so that users can add `FOR UPDATE` with batch rows.