### PR TITLE
Adds the evaluated object to the validator struct

### DIFF
--- a/validation/validation.go
+++ b/validation/validation.go
@@ -111,6 +111,9 @@ type Validation struct {
 	// it will skip those valid functions, see CanSkipFuncs
 	RequiredFirst bool
 
+	// The object being evaluated (set in Valid())
+	FormObj interface{}
+
 	Errors    []*Error
 	ErrorsMap map[string][]*Error
 }
@@ -345,19 +348,22 @@ func (v *Validation) Valid(obj interface{}) (b bool, err error) {
 		return
 	}
 
+	// Tie the object to the validator.
+	v.FormObj = obj
+
 	for i := 0; i < objT.NumField(); i++ {
 		var vfs []ValidFunc
 		if vfs, err = getValidFuncs(objT.Field(i)); err != nil {
 			return
 		}
 
-		var hasReuired bool
+		var hasRequired bool
 		for _, vf := range vfs {
 			if vf.Name == "Required" {
-				hasReuired = true
+				hasRequired = true
 			}
 
-			if !hasReuired && v.RequiredFirst && len(objV.Field(i).String()) == 0 {
+			if !hasRequired && v.RequiredFirst && len(objV.Field(i).String()) == 0 {
 				if _, ok := CanSkipFuncs[vf.Name]; ok {
 					continue
 				}


### PR DESCRIPTION
This addition allows users to create custom validation between multiple data fields (example provided below). If this feature is already available, please let me know!

Example:
```
// MatchPassword will test to see if the confirm password field matches the "password" field.
func MatchPassword(v *validation.Validation, obj interface{}, key string) {
	fieldName := strings.Split(key, ".")[0]
	confirmPassword, ok := obj.(string)
	if !ok {
		v.SetError(fieldName, "Password is not a valid string!")
		return
	}

	valueOfObj := reflect.ValueOf(v.FormObj)
	if valueOfObj.Type().Kind() != reflect.Ptr {
		valueOfObj = reflect.New(reflect.TypeOf(v.FormObj))
	}
	password := valueOfObj.Elem().FieldByName("Password")

	if !password.IsValid() || confirmPassword != password.String() {
		v.SetError(fieldName, "Password confirmation does not match!")
	}
}
```