### PR TITLE
fix bug of tasks that only some but not all are executed

### DIFF
--- a/toolbox/task.go
+++ b/toolbox/task.go
@@ -428,6 +428,9 @@ func run() {
 			continue
 		case <-changed:
 			now = time.Now().Local()
+			for _, t := range AdminTaskList {
+				t.SetNext(now)
+			}
 			continue
 		case <-stop:
 			return


### PR DESCRIPTION
When tasks are in different files , I find some tasks are not executed in scheduled time. 

There are two solutions.

**No 1: Per task execute SetNext before AddTask**
task1 in task1.go
```
tk1 := toolbox.NewTask("tk1", "0/5 * * * * *", tk1func)
now := time.Now().Local()  
tk1.SetNext(now)    // per task execute SetNext before AddTask
toolbox.AddTask("tk1", tk1)
```
task 2 in task2.go
```
tk2 := toolbox.NewTask("tk1", "0/5 * * * * *", tk2func)
now := time.Now().Local()
tk2.SetNext(now)   // per task execute SetNext before AddTask
toolbox.AddTask("tk2", tk2)
```
**No 2: After AddTask ,  all tasks execute SetNext by Beego toolbox.**
```
                case <-changed:
                        now = time.Now().Local()
+                       for _, t := range AdminTaskList {
+                               t.SetNext(now)
+                       }
                        continue
                case <-stop:
                        return
```
