### PR TITLE
Remove panic from Redirect()

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -275,7 +275,6 @@ func (c *Controller) viewPath() string {
 func (c *Controller) Redirect(url string, code int) {
 	logAccess(c.Ctx, nil, code)
 	c.Ctx.Redirect(code, url)
-	panic(ErrAbort)
 }
 
 // Set the data depending on the accepted


### PR DESCRIPTION
This `panic(ErrAbort)` is unnecessary in `Redirect` function and causes problems in the production code.