### PR TITLE
Go by default initializes the type `string =""` (empty string).

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -116,8 +116,6 @@ type ControllerInterface interface {
 
 // Init generates default values of controller operations.
 func (c *Controller) Init(ctx *context.Context, controllerName, actionName string, app interface{}) {
-	c.Layout = ""
-	c.TplName = ""
 	c.controllerName = controllerName
 	c.actionName = actionName
 	c.Ctx = ctx


### PR DESCRIPTION
Go by default initializes the type `TplName=""` (empty string).
```
type Controller struct {
  ...
  // template data
  TplName        string // =""
  ...
}
```

These actions also nullify the result of the work:
```
// router.go
beego.Router("/foo", &controllers.BaseController{
	Controller: beego.Controller{
		TplName: "foo.html",
	},
})
```
Therefore, you must delete the rows
```
c.Layout = ""
c.TplName = ""
```