### PR TITLE
Return error when wrong filtering field

### DIFF
--- a/orm/db.go
+++ b/orm/db.go
@@ -928,7 +928,7 @@ func (d *dbBase) ReadBatch(q dbQuerier, qs *querySet, mi *modelInfo, cond *Condi
 					maps[fi.column] = true
 				}
 			} else {
-				panic(fmt.Errorf("wrong field/column name `%s`", col))
+				return -1, fmt.Errorf("wrong field/column name `%s`", col)
 			}
 		}
 		if hasRel {


### PR DESCRIPTION
When end user put wrong filtering field ORM should return error instead of Panic()
so developers can handle this error.

This should fix #3332 