### PR TITLE
security question, fix arbitrary file read

### DIFF
--- a/session/sess_file.go
+++ b/session/sess_file.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
@@ -127,6 +128,9 @@ func (fp *FileProvider) SessionInit(maxlifetime int64, savePath string) error {
 // if file is not exist, create it.
 // the file path is generated from sid string.
 func (fp *FileProvider) SessionRead(sid string) (Store, error) {
+	if strings.ContainsAny(sid, "./") {
+		return nil, nil
+	}
 	filepder.lock.Lock()
 	defer filepder.lock.Unlock()
 


### PR DESCRIPTION
When use file type session in the beego framework，Hacker can use "../" modify the sessionID value，

Then directory crossing read any file , So I think beego should check the sessionID  before read it.

Some  example:

1，https://www.anquanke.com/post/id/163575

2，https://github.com/gogs/gogs/issues/5469