### PR TITLE
Closes #2515 Autodetect timezone in NewOrmWithDB()

### DIFF
--- a/orm/orm.go
+++ b/orm/orm.go
@@ -548,6 +548,9 @@ func NewOrmWithDB(driverName, aliasName string, db *sql.DB) (Ormer, error) {
 
 	al.Name = aliasName
 	al.DriverName = driverName
+	al.DB = db
+	
+	detectTZ(al)
 
 	o := new(orm)
 	o.alias = al


### PR DESCRIPTION
Hey @astaxie,
As mentioned in #2515 I added the two lines into a pull request

This PR adds a call to `detectTZ` into `NewOrmWithDB()` to ensure `alias.TZ` is populated and can not cause panics
