### PR TITLE
Add .Elapsed in context.ResponseWriter for monitor purpose

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -201,6 +201,7 @@ type Response struct {
 	http.ResponseWriter
 	Started bool
 	Status  int
+	Elapsed time.Duration
 }
 
 func (r *Response) reset(rw http.ResponseWriter) {

--- a/router.go
+++ b/router.go
@@ -890,8 +890,9 @@ Admin:
 
 	logAccess(context, &startTime, statusCode)
 
+	timeDur := time.Since(startTime)
+	context.ResponseWriter.Elapsed = timeDur
 	if BConfig.Listen.EnableAdmin {
-		timeDur := time.Since(startTime)
 		pattern := ""
 		if routerInfo != nil {
 			pattern = routerInfo.pattern
@@ -908,7 +909,6 @@ Admin:
 
 	if BConfig.RunMode == DEV && !BConfig.Log.AccessLogs {
 		var devInfo string
-		timeDur := time.Since(startTime)
 		iswin := (runtime.GOOS == "windows")
 		statusColor := logs.ColorByStatus(iswin, statusCode)
 		methodColor := logs.ColorByMethod(iswin, r.Method)


### PR DESCRIPTION
With this commit we can record per requests's elapsed time, so we can easy to monitor that by use a filter.