### PR TITLE
Repairing defects in downloading (golang.org/x/crypto/acme/autocert) …

### DIFF
--- a/app.go
+++ b/app.go
@@ -30,7 +30,6 @@ import (
 	"github.com/astaxie/beego/grace"
 	"github.com/astaxie/beego/logs"
 	"github.com/astaxie/beego/utils"
-	"golang.org/x/crypto/acme/autocert"
 )
 
 var (
@@ -134,12 +133,8 @@ func (app *App) Run(mws ...MiddleWare) {
 					}
 				} else {
 					if BConfig.Listen.AutoTLS {
-						m := autocert.Manager{
-							Prompt:     autocert.AcceptTOS,
-							HostPolicy: autocert.HostWhitelist(BConfig.Listen.Domains...),
-							Cache:      autocert.DirCache(BConfig.Listen.TLSCacheDir),
-						}
-						app.Server.TLSConfig = &tls.Config{GetCertificate: m.GetCertificate}
+						tlsConfig := utils.AutoTLS(BConfig.Listen.TLSCacheDir, BConfig.Listen.Domains...)
+						app.Server.TLSConfig = &tlsConfig
 						BConfig.Listen.HTTPSCertFile, BConfig.Listen.HTTPSKeyFile = "", ""
 					}
 					if err := server.ListenAndServeTLS(BConfig.Listen.HTTPSCertFile, BConfig.Listen.HTTPSKeyFile); err != nil {
@@ -181,12 +176,8 @@ func (app *App) Run(mws ...MiddleWare) {
 			}
 			logs.Info("https server Running on https://%s", app.Server.Addr)
 			if BConfig.Listen.AutoTLS {
-				m := autocert.Manager{
-					Prompt:     autocert.AcceptTOS,
-					HostPolicy: autocert.HostWhitelist(BConfig.Listen.Domains...),
-					Cache:      autocert.DirCache(BConfig.Listen.TLSCacheDir),
-				}
-				app.Server.TLSConfig = &tls.Config{GetCertificate: m.GetCertificate}
+				tlsConfig := utils.AutoTLS(BConfig.Listen.TLSCacheDir, BConfig.Listen.Domains...)
+				app.Server.TLSConfig = &tlsConfig
 				BConfig.Listen.HTTPSCertFile, BConfig.Listen.HTTPSKeyFile = "", ""
 			} else if BConfig.Listen.EnableMutualHTTPS {
 				pool := x509.NewCertPool()

--- a/utils/auto_tls.go
+++ b/utils/auto_tls.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"crypto/tls"
+	"golang.org/x/crypto/acme/autocert"
+)
+
+func AutoTLS(dirCache string, hosts ...string) tls.Config {
+	m := autocert.Manager{
+		Prompt:     autocert.AcceptTOS,
+		HostPolicy: autocert.HostWhitelist(hosts...),
+		Cache:      autocert.DirCache(dirCache),
+	}
+	return tls.Config{GetCertificate: m.GetCertificate}
+}


### PR DESCRIPTION
…and related operations when beego v1.10.0 and above are used in China and other places or countries without using auto TLS

#3308 
#3384 

修复在中国及其他地方或国家使用beego v1.10.0及以上时，在不使用auto tls情况下，还是需要翻墙下载(golang.org/x/crypto/acme/autocert)及其关联性操作无法使用缺陷