### PR TITLE
task超出errlog上限时，滚动记录日志

### DIFF
--- a/toolbox/task.go
+++ b/toolbox/task.go
@@ -138,7 +138,7 @@ func (t *Task) GetStatus() string {
 	return str
 }
 
-// Run run all tasks
+// Run run all tasks, append error list
 func (t *Task) Run() error {
 	err := t.DoFunc()
 	if err != nil {

--- a/toolbox/task.go
+++ b/toolbox/task.go
@@ -142,7 +142,10 @@ func (t *Task) GetStatus() string {
 func (t *Task) Run() error {
 	err := t.DoFunc()
 	if err != nil {
-		if t.ErrLimit > 0 && t.ErrLimit > len(t.Errlist) {
+		if t.ErrLimit > 0 {
+			if t.ErrLimit <= len(t.Errlist) {
+				t.Errlist = t.Errlist[1:]
+			}
 			t.Errlist = append(t.Errlist, &taskerr{t: t.Next, errinfo: err.Error()})
 		}
 	}


### PR DESCRIPTION
### 问题
task设置了ErrLimit，在超出其上限时，会不再记录日志。

### 解决方案
优化为：超出上线时，清除最早记录，滚动记录日志

展示最近的N条日志才是业务需求，而不是最开始的。