### PR TITLE
fix: negative WaitGroup counter has not been resolved yet.

### DIFF
--- a/grace/conn.go
+++ b/grace/conn.go
@@ -28,12 +28,11 @@ func (c *graceConn) Close() (err error) {
 	}()
 
 	c.m.Lock()
+	defer c.m.Unlock()
 	if c.closed {
-		c.m.Unlock()
 		return
 	}
 	c.server.wg.Done()
 	c.closed = true
-	c.m.Unlock()
 	return c.Conn.Close()
 }

--- a/grace/server.go
+++ b/grace/server.go
@@ -34,6 +34,11 @@ type Server struct {
 // creating a new service goroutine for each.
 // The service goroutines read requests and then call srv.Handler to reply to them.
 func (srv *Server) Serve() (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("wait group counter is negative", r)
+		}
+	}()
 	srv.state = StateRunning
 	err = srv.Server.Serve(srv.GraceListener)
 	log.Println(syscall.Getpid(), "Waiting for connections to finish...")


### PR DESCRIPTION
(https://github.com/astaxie/beego/pull/2717) this issue solved the waitgroup problem with a nice lock. 

However, in the `srv.serverTimeout(DefaultTimeout)` go routine, when wg.Done () occurs more than once in a for statement, it simply prints an error message. 
At that time, wg counter is already negative, so panic is generated again when `wg.Wait()` is called in the above `Serve()`.

I solved this problem by having a recover on `Serve()`.