### PR TITLE
Changes to allow a model to implement a method to return true|flase d…

### DIFF
--- a/orm/cmd.go
+++ b/orm/cmd.go
@@ -135,6 +135,10 @@ func (d *commandSyncDb) Run() error {
 	}
 
 	for i, mi := range modelCache.allOrdered() {
+                if !isTableForDB(mi.addrField, d.al.Name) {
+                        fmt.Printf("table `%s` is not applicable to database '%s'\n", mi.table, d.al.Name)
+                        continue
+                }
 		if tables[mi.table] {
 			if !d.noInfo {
 				fmt.Printf("table `%s` already exists, skip\n", mi.table)

--- a/orm/models_utils.go
+++ b/orm/models_utils.go
@@ -106,6 +106,18 @@ func getTableUnique(val reflect.Value) [][]string {
 	return nil
 }
 
+// get whether the table needs to be created for the database alias
+func isTableForDB(val reflect.Value, db string) bool {
+        fun := val.MethodByName("IsTableForDB")
+        if fun.IsValid() {
+                vals := fun.Call([]reflect.Value{reflect.ValueOf(db)})
+                if len(vals) > 0 && vals[0].Kind() == reflect.Bool {
+                        return vals[0].Bool()
+                }
+        }
+        return true
+}
+
 // get snaked column name
 func getColumnName(ft int, addrField reflect.Value, sf reflect.StructField, col string) string {
 	column := col


### PR DESCRIPTION
For most practical cases we run into cases when we want to add some models only to some specific database. For example in a multi tenant scenario, there could be an admin database for administrative APIs and will have domain objects pertinent to administration, those models should not be sync'd to tenant databases.

✅ Allow for implementing a method `isTableForDB` for any model.
✅ isTableForDB will receive the database name and will be able to return whether or not this model should be added to that database

Example
```
type SomeModel struct {
  ---- some fields
}

func (this *SomeModel) IsTableForDB(dbname string) bool {
	if dbname == "AdminDB" {
		return true
	}
	return false
}

```