### PR TITLE
Foreign key enforcement added on database level

### DIFF
--- a/orm/cmd_utils.go
+++ b/orm/cmd_utils.go
@@ -189,6 +189,10 @@ func getDbCreateSQL(al *alias) (sqls []string, tableIndexes map[string][]dbIndex
 					column += " " + "UNIQUE"
 				}
 
+				if fi.rel {
+					column += " " + "REFERENCES "+fi.fkTable
+				}
+
 				if fi.index {
 					sqlIndexes = append(sqlIndexes, []string{fi.column})
 				}

--- a/orm/models_boot.go
+++ b/orm/models_boot.go
@@ -81,6 +81,18 @@ func registerModel(PrefixOrSuffix string, model interface{}, isPrefix bool) {
 
 	}
 
+	for _, fi := range mi.fields.fieldsDB {
+		if fi.rel {
+			if PrefixOrSuffix != "" {
+				if isPrefix {
+					fi.fkTable = PrefixOrSuffix + fi.fkTable
+				} else {
+					fi.fkTable = fi.fkTable + PrefixOrSuffix
+				}
+			}
+		}
+	}
+
 	mi.table = table
 	mi.pkg = typ.PkgPath()
 	mi.model = model

--- a/orm/models_info_f.go
+++ b/orm/models_info_f.go
@@ -132,6 +132,7 @@ type fieldInfo struct {
 	relThrough          string
 	relThroughModelInfo *modelInfo
 	relModelInfo        *modelInfo
+        fkTable             string
 	digits              int
 	decimals            int
 	isFielder           bool // implement Fielder interface

--- a/orm/models_info_m.go
+++ b/orm/models_info_m.go
@@ -74,6 +74,11 @@ func addModelFields(mi *modelInfo, ind reflect.Value, mName string, index []int)
 		} else if err != nil {
 			break
 		}
+
+                if fi.rel && field.Kind() == reflect.Ptr {
+                        fi.fkTable = snakeString(stripPrefixes(field.Type().String()))
+                }
+
 		//record current field index
 		fi.fieldIndex = append(fi.fieldIndex, index...)
 		fi.fieldIndex = append(fi.fieldIndex, i)

--- a/orm/orm_test.go
+++ b/orm/orm_test.go
@@ -2347,6 +2347,35 @@ func TestPtrPk(t *testing.T) {
 	throwFail(t, AssertIs(num, 1))
 }
 
+func TestFkRel(t *testing.T) {
+	RegisterModel(new(User))
+	RegisterModel(new(Post))
+
+	post := &Post{ID:100, Title: "post for unit test"}
+	post.Content = "some content for the unit test"
+
+	user := &User{ID:21, Email:"asif@gmail.com", UserName: "asif-fndr"}
+
+	post.User = user
+
+	cnt, err := dORM.Insert(user)
+	throwFail(t, err)
+	throwFail(t, AssertIs(cnt, 1))
+
+	cnt, err = dORM.Insert(post)
+	throwFail(t, err)
+	throwFail(t, AssertIs(cnt, 1))
+
+	cnt, err = dORM.Delete(user)
+	throwFail(t, AssertNot(err, nil))
+	throwFail(t, AssertIs(cnt, 0))
+
+	cnt, err = dORM.Delete(post)
+	throwFail(t, err)
+	throwFail(t, AssertIs(cnt, 1))
+}
+
+
 func TestSnake(t *testing.T) {
 	cases := map[string]string{
 		"i":           "i",

--- a/orm/utils.go
+++ b/orm/utils.go
@@ -257,6 +257,13 @@ func SetNameStrategy(s string) {
 	nameStrategy = s
 }
 
+// converst *pkg1.pkg2.StructName to StructName
+func stripPrefixes(in string) string  {
+	in = strings.Trim(in, "*")
+	toks := strings.Split(in, ".")
+	return toks[len(toks)-1]
+}
+
 // camel string, xx_yy to XxYy
 func camelString(s string) string {
 	data := make([]byte, 0, len(s))


### PR DESCRIPTION
Before this fix: there was no database level foreign key enforcement happening even if we create a reference using `orm:"rel(fk);null"`
After this fix: the `orm:"rel(fk);null"` adds the foreign key enforcement on database level.