### PR TITLE
fix: when parse post form it didnt parse fields correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/astaxie/beego
 
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible // indirect
+	github.com/OwnLocal/goes v1.0.0
 	github.com/beego/goyaml2 v0.0.0-20130207012346-5545475820dd
 	github.com/beego/x2j v0.0.0-20131220205130-a0352aadc542
-	github.com/OwnLocal/goes v1.0.0	
 	github.com/bradfitz/gomemcache v0.0.0-20180710155616-bc664df96737
 	github.com/casbin/casbin v1.7.0
 	github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/Knetic/govaluate v3.0.0+incompatible h1:7o6+MAPhYTCF0+fdvoz1xDedhRb4f6s9Tn1Tt7/WTEg=
 github.com/Knetic/govaluate v3.0.0+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
+github.com/OwnLocal/goes v1.0.0/go.mod h1:8rIFjBGTue3lCU0wplczcUgt9Gxgrkkrw7etMIcn8TM=
 github.com/beego/goyaml2 v0.0.0-20130207012346-5545475820dd h1:jZtX5jh5IOMu0fpOTC3ayh6QGSPJ/KWOv1lgPvbRw1M=
 github.com/beego/goyaml2 v0.0.0-20130207012346-5545475820dd/go.mod h1:1b+Y/CofkYwXMUU0OhQqGvsY2Bvgr4j6jfT699wyZKQ=
 github.com/beego/x2j v0.0.0-20131220205130-a0352aadc542 h1:nYXb+3jF6Oq/j8R/y90XrKpreCxIalBWfeyeKymgOPk=

--- a/templatefunc.go
+++ b/templatefunc.go
@@ -85,24 +85,24 @@ func DateFormat(t time.Time, layout string) (datestring string) {
 var datePatterns = []string{
 	// year
 	"Y", "2006", // A full numeric representation of a year, 4 digits   Examples: 1999 or 2003
-	"y", "06",   //A two digit representation of a year   Examples: 99 or 03
+	"y", "06", //A two digit representation of a year   Examples: 99 or 03
 
 	// month
-	"m", "01",      // Numeric representation of a month, with leading zeros 01 through 12
-	"n", "1",       // Numeric representation of a month, without leading zeros   1 through 12
-	"M", "Jan",     // A short textual representation of a month, three letters Jan through Dec
+	"m", "01", // Numeric representation of a month, with leading zeros 01 through 12
+	"n", "1", // Numeric representation of a month, without leading zeros   1 through 12
+	"M", "Jan", // A short textual representation of a month, three letters Jan through Dec
 	"F", "January", // A full textual representation of a month, such as January or March   January through December
 
 	// day
 	"d", "02", // Day of the month, 2 digits with leading zeros 01 to 31
-	"j", "2",  // Day of the month without leading zeros 1 to 31
+	"j", "2", // Day of the month without leading zeros 1 to 31
 
 	// week
-	"D", "Mon",    // A textual representation of a day, three letters Mon through Sun
+	"D", "Mon", // A textual representation of a day, three letters Mon through Sun
 	"l", "Monday", // A full textual representation of the day of the week  Sunday through Saturday
 
 	// time
-	"g", "3",  // 12-hour format of an hour without leading zeros    1 through 12
+	"g", "3", // 12-hour format of an hour without leading zeros    1 through 12
 	"G", "15", // 24-hour format of an hour without leading zeros   0 through 23
 	"h", "03", // 12-hour format of an hour with leading zeros  01 through 12
 	"H", "15", // 24-hour format of an hour with leading zeros  00 through 23
@@ -297,8 +297,21 @@ func parseFormToStruct(form url.Values, objT reflect.Type, objV reflect.Value) e
 			tag = tags[0]
 		}
 
+		if fieldT.Type.Kind() == reflect.Slice {
+			found := false
+			for _, v := range form[tag] {
+				if len(v) != 0 {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+
 		value := form.Get(tag)
-		if len(value) == 0 {
+		if (fieldT.Type.Kind() != reflect.Slice) && len(value) == 0 {
 			continue
 		}
 


### PR DESCRIPTION
When multiple fields which have same name is sent from browser but the first index is empty,
When parse form, Currently It only checked whether the first index is empty, 
Unfortunately the first index is empty but the rest is not (["", "second", "third"])
so this PR fixed this issue by adding logic for a slice checking.