### PR TITLE
add support for pointer fields of structs to method QueryRows()

### DIFF
--- a/orm/orm_raw.go
+++ b/orm/orm_raw.go
@@ -191,6 +191,14 @@ func (o *rawSet) setFieldValue(ind reflect.Value, value interface{}) {
 				ind.Set(reflect.Indirect(reflect.ValueOf(sc)))
 			}
 		}
+
+	case reflect.Ptr:
+		if value == nil {
+			ind.Set(reflect.Zero(ind.Type()))
+			break
+		}
+		ind.Set(reflect.New(ind.Type().Elem()))
+		o.setFieldValue(reflect.Indirect(ind), value)
 	}
 }
 

--- a/orm/orm_test.go
+++ b/orm/orm_test.go
@@ -464,6 +464,7 @@ func TestNullDataTypes(t *testing.T) {
 	Q := dDbBaser.TableQuote()
 	num, err = dORM.Raw(fmt.Sprintf("SELECT * FROM %sdata_null%s where id=?", Q, Q), 3).QueryRows(&dnList)
 	throwFailNow(t, err)
+	throwFailNow(t, AssertIs(num, 1))
 	equal := reflect.DeepEqual(*dnList[0], d)
 	throwFailNow(t, AssertIs(equal, true))
 }

--- a/orm/orm_test.go
+++ b/orm/orm_test.go
@@ -458,6 +458,14 @@ func TestNullDataTypes(t *testing.T) {
 	throwFail(t, AssertIs((*d.TimePtr).UTC().Format(testTime), timePtr.UTC().Format(testTime)))
 	throwFail(t, AssertIs((*d.DatePtr).UTC().Format(testDate), datePtr.UTC().Format(testDate)))
 	throwFail(t, AssertIs((*d.DateTimePtr).UTC().Format(testDateTime), dateTimePtr.UTC().Format(testDateTime)))
+
+	// test support for pointer fields using RawSeter.QueryRows()
+	var dnList []*DataNull
+	Q := dDbBaser.TableQuote()
+	num, err = dORM.Raw(fmt.Sprintf("SELECT * FROM %sdata_null%s where id=?", Q, Q), 3).QueryRows(&dnList)
+	throwFailNow(t, err)
+	equal := reflect.DeepEqual(*dnList[0], d)
+	throwFailNow(t, AssertIs(equal, true))
 }
 
 func TestDataCustomTypes(t *testing.T) {


### PR DESCRIPTION
When querying data using raw sql, the method `QueryRows(&container)` ignores pointer fields of container's element type if that type is a struct. This time I add support to this method to deal with this fields.