### PR TITLE
config/yaml: s/bytes.NewBuffer/bytes.NewReader/

### DIFF
--- a/config/yaml/yaml.go
+++ b/config/yaml/yaml.go
@@ -97,7 +97,7 @@ func parseYML(buf []byte) (cnf map[string]interface{}, err error) {
 		}
 	}
 
-	data, err := goyaml2.Read(bytes.NewBuffer(buf))
+	data, err := goyaml2.Read(bytes.NewReader(buf))
 	if err != nil {
 		log.Println("Goyaml2 ERR>", string(buf), err)
 		return


### PR DESCRIPTION
When io.Reader is required out of []byte,
it's better to use bytes.NewReader than bytes.NewBuffer.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>