### PR TITLE
add ignore auto_now_add field when update

### DIFF
--- a/orm/db.go
+++ b/orm/db.go
@@ -631,10 +631,10 @@ func (d *dbBase) Update(q dbQuerier, mi *modelInfo, ind reflect.Value, tz *time.
 	}
 
 	if find {
-		newSetNames := make([]string, 0, 0)
+		newSetNames := make([]string, 0, len(setNames)-1)
 		newSetNames = append(setNames[0:index], setNames[index+1:]...)
 		setNames = newSetNames
-		newSetValues := make([]interface{}, 0, 0)
+		newSetValues := make([]interface{}, 0, len(setNames)-1)
 		newSetValues = append(setValues[0:index], setValues[index+1:]...)
 		setValues = newSetValues
 

--- a/orm/db.go
+++ b/orm/db.go
@@ -621,6 +621,25 @@ func (d *dbBase) Update(q dbQuerier, mi *modelInfo, ind reflect.Value, tz *time.
 		return 0, err
 	}
 
+	var find bool
+	var index int
+	for i, col := range setNames {
+		if mi.fields.GetByColumn(col).autoNowAdd {
+			index = i
+			find = true
+		}
+	}
+
+	if find {
+		newSetNames := make([]string, 0, 0)
+		newSetNames = append(setNames[0:index], setNames[index+1:]...)
+		setNames = newSetNames
+		newSetValues := make([]interface{}, 0, 0)
+		newSetValues = append(setValues[0:index], setValues[index+1:]...)
+		setValues = newSetValues
+
+	}
+
 	setValues = append(setValues, pkValue)
 
 	Q := d.ins.TableQuote()


### PR DESCRIPTION
When I update database with ORM module to update a table which has a field with tag `auto_now_add`, I found that `o.Update(u)` will update the `create_time` field which has a tag `"auto_now_add;type(datetime)"`.
I think this is not correct.
So I create this pull request to fix it.
type` UserAbc struct {
 Id int
 Name string
 Age int 
UpdateTime time.Time `orm:"auto_now;type(datetime)"`
CreateTime time.Time`orm:"auto_now_add;type(datetime)"` 
}