### PR TITLE
[orm] add ignore auto_now_add field when update 

### DIFF
--- a/orm/db.go
+++ b/orm/db.go
@@ -632,10 +632,12 @@ func (d *dbBase) Update(q dbQuerier, mi *modelInfo, ind reflect.Value, tz *time.
 
 	if find {
 		newSetNames := make([]string, 0, len(setNames)-1)
-		newSetNames = append(setNames[0:index], setNames[index+1:]...)
+		newSetNames = append(newSetNames, setNames[0:index]...)
+		newSetNames = append(newSetNames, setNames[index+1:]...)
 		setNames = newSetNames
 		newSetValues := make([]interface{}, 0, len(setNames)-1)
-		newSetValues = append(setValues[0:index], setValues[index+1:]...)
+		newSetValues = append(newSetValues, setValues[0:index]...)
+		newSetValues = append(newSetValues, setValues[index+1:]...)
 		setValues = newSetValues
 
 	}

--- a/orm/db.go
+++ b/orm/db.go
@@ -631,10 +631,10 @@ func (d *dbBase) Update(q dbQuerier, mi *modelInfo, ind reflect.Value, tz *time.
 	}
 
 	if find {
-		newSetNames := make([]string, 0, 0)
+		newSetNames := make([]string, 0, len(setNames)-1)
 		newSetNames = append(setNames[0:index], setNames[index+1:]...)
 		setNames = newSetNames
-		newSetValues := make([]interface{}, 0, 0)
+		newSetValues := make([]interface{}, 0, len(setNames)-1)
 		newSetValues = append(setValues[0:index], setValues[index+1:]...)
 		setValues = newSetValues
 

--- a/orm/db.go
+++ b/orm/db.go
@@ -631,14 +631,8 @@ func (d *dbBase) Update(q dbQuerier, mi *modelInfo, ind reflect.Value, tz *time.
 	}
 
 	if find {
-		newSetNames := make([]string, 0, len(setNames)-1)
-		newSetNames = append(newSetNames, setNames[0:index]...)
-		newSetNames = append(newSetNames, setNames[index+1:]...)
-		setNames = newSetNames
-		newSetValues := make([]interface{}, 0, len(setNames)-1)
-		newSetValues = append(newSetValues, setValues[0:index]...)
-		newSetValues = append(newSetValues, setValues[index+1:]...)
-		setValues = newSetValues
+		setNames = append(setNames[0:index], setNames[index+1:]...)
+		setValues = append(setValues[0:index], setValues[index+1:]...)
 
 	}
 

--- a/orm/db.go
+++ b/orm/db.go
@@ -621,6 +621,25 @@ func (d *dbBase) Update(q dbQuerier, mi *modelInfo, ind reflect.Value, tz *time.
 		return 0, err
 	}
 
+	var find bool
+	var index int
+	for i, col := range setNames {
+		if mi.fields.GetByColumn(col).autoNowAdd {
+			index = i
+			find = true
+		}
+	}
+
+	if find {
+		newSetNames := make([]string, 0, 0)
+		newSetNames = append(setNames[0:index], setNames[index+1:]...)
+		setNames = newSetNames
+		newSetValues := make([]interface{}, 0, 0)
+		newSetValues = append(setValues[0:index], setValues[index+1:]...)
+		setValues = newSetValues
+
+	}
+
 	setValues = append(setValues, pkValue)
 
 	Q := d.ins.TableQuote()

--- a/orm/db.go
+++ b/orm/db.go
@@ -633,7 +633,6 @@ func (d *dbBase) Update(q dbQuerier, mi *modelInfo, ind reflect.Value, tz *time.
 	if find {
 		setNames = append(setNames[0:index], setNames[index+1:]...)
 		setValues = append(setValues[0:index], setValues[index+1:]...)
-
 	}
 
 	setValues = append(setValues, pkValue)


### PR DESCRIPTION
@astaxie 
1. My code is below:
package main

import (
	"fmt"
	"time"

	_ "github.com/go-sql-driver/mysql"

	"github.com/astaxie/beego/orm"
)

type UserAbc struct {
	Id         int
	Name       string
	Age        int
	UpdateTime time.Time `orm:"auto_now;type(datetime)"`
	CreateTime time.Time `orm:"auto_now_add;type(datetime)"`
}

func main() {
	orm.RegisterDriver("mysql", orm.DRMySQL)
	orm.RegisterDataBase("default", "mysql", "test:123456@tcp(127.0.0.1:3306)/testdb?charset=utf8")

	orm.RegisterModel(new(UserAbc))
	orm.RunSyncdb("default", true, true)
	orm.Debug = true
	o := orm.NewOrm()
	u := &UserAbc{
		Name: "aname",
		Age:  11,
	}
	id, err := o.Insert(u)
	if err != nil {
		fmt.Println(err.Error())
		return
	}
	fmt.Println(time.Now())
	time.Sleep(time.Second * 3)
	u.Id = int(id)
	u.Name = "updatename"
	o.Update(u) //which should only update field without tag auto_now_add
}

2. What did I expected ?
I expected the values of  fields name, update_time, age  will be updated
3. What did I get?
The values of fields name, update_time, age and create_time be updated

4. Why I create this pull request?

I add some code to skip the first field with tag "auto_now_add" in the ORM  Update operation.