### PR TITLE
Register .gohtml extension

### DIFF
--- a/template.go
+++ b/template.go
@@ -38,7 +38,7 @@ var (
 	beeViewPathTemplates = make(map[string]map[string]*template.Template)
 	templatesLock        sync.RWMutex
 	// beeTemplateExt stores the template extension which will build
-	beeTemplateExt = []string{"tpl", "html"}
+	beeTemplateExt = []string{"tpl", "html", "gohtml"}
 	// beeTemplatePreprocessors stores associations of extension -> preprocessor handler
 	beeTemplateEngines = map[string]templatePreProcessor{}
 	beeTemplateFS      = defaultFSFunc


### PR DESCRIPTION
Goland as of 2018.3 seems to support only '.tpl.gohtml" and ".gohtml" templates. The regular ".tpl" templates will be rendered as plain text files which is not acceptable.