### PR TITLE
avoid a handler crash situation

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,8 +31,8 @@ import (
 
 // Config is the main struct for BConfig
 type Config struct {
-	AppName             string //Application name
-	RunMode             string //Running Mode: dev | prod
+	AppName             string // Application name
+	RunMode             string // Running Mode: dev | prod
 	RouterCaseSensitive bool
 	ServerName          string
 	RecoverPanic        bool
@@ -109,8 +109,8 @@ type SessionConfig struct {
 // LogConfig holds Log related config
 type LogConfig struct {
 	AccessLogs       bool
-	EnableStaticLogs bool   //log static files requests default: false
-	AccessLogsFormat string //access log format: JSON_FORMAT, APACHE_FORMAT or empty string
+	EnableStaticLogs bool   // log static files requests default: false
+	AccessLogsFormat string // access log format: JSON_FORMAT, APACHE_FORMAT or empty string
 	FileLineNum      bool
 	Outputs          map[string]string // Store Adaptor : config
 }
@@ -166,6 +166,10 @@ func recoverPanic(ctx *context.Context) {
 		if !BConfig.RecoverPanic {
 			panic(err)
 		}
+		if s, ok := err.(string); ok && ctx.Output.Status > 0 && len(s) > 0 {
+			ctx.Output.Body([]byte(s))
+			return
+		}
 		if BConfig.EnableErrorsShow {
 			if _, ok := ErrorMaps[fmt.Sprint(err)]; ok {
 				exception(fmt.Sprint(err), ctx)
@@ -204,7 +208,7 @@ func newBConfig() *Config {
 		RecoverFunc:         recoverPanic,
 		CopyRequestBody:     false,
 		EnableGzip:          false,
-		MaxMemory:           1 << 26, //64MB
+		MaxMemory:           1 << 26, // 64MB
 		EnableErrorsShow:    true,
 		EnableErrorsRender:  true,
 		Listen: Listen{
@@ -249,7 +253,7 @@ func newBConfig() *Config {
 				SessionGCMaxLifetime:         3600,
 				SessionProviderConfig:        "",
 				SessionDisableHTTPOnly:       false,
-				SessionCookieLifeTime:        0, //set cookie default is the browser life
+				SessionCookieLifeTime:        0, // set cookie default is the browser life
 				SessionAutoSetCookie:         true,
 				SessionDomain:                "",
 				SessionEnableSidInHTTPHeader: false, // enable store/get the sessionId into/from http headers
@@ -332,7 +336,7 @@ func assignConfig(ac config.Configer) error {
 		}
 	}
 
-	//init log
+	// init log
 	logs.Reset()
 	for adaptor, config := range BConfig.Log.Outputs {
 		err := logs.SetLogger(adaptor, config)
@@ -371,7 +375,7 @@ func assignSingleConfig(p interface{}, ac config.Configer) {
 			pf.SetBool(ac.DefaultBool(name, pf.Bool()))
 		case reflect.Struct:
 		default:
-			//do nothing here
+			// do nothing here
 		}
 	}
 


### PR DESCRIPTION
When automatic-parameter-routing is triggered, handler would crush if a required param is not present.

But according to the [docs](https://beego.me/docs/mvc/controller/params.md#automatic-parameter-routing), it should return `400 Bad Request`.

update: when run in prod mode, the client would receive `400 Bad Request` as expected.