### PR TITLE
Allow forked beego project to pass travis ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,19 @@ services:
   - postgresql
   - memcached
 env:
-  - ORM_DRIVER=sqlite3   ORM_SOURCE=$TRAVIS_BUILD_DIR/orm_test.db
-  - ORM_DRIVER=postgres ORM_SOURCE="user=postgres dbname=orm_test sslmode=disable"
+  global:
+    - GO_REPO_FULLNAME="github.com/astaxie/beego"
+  matrix:
+    - ORM_DRIVER=sqlite3   ORM_SOURCE=$TRAVIS_BUILD_DIR/orm_test.db
+    - ORM_DRIVER=postgres ORM_SOURCE="user=postgres dbname=orm_test sslmode=disable"
 before_install:
+   # link the local repo with ${GOPATH}/src/<namespace>/<repo>
+ - GO_REPO_NAMESPACE=${GO_REPO_FULLNAME%/*}
+   # relies on GOPATH to contain only one directory...
+ - mkdir -p ${GOPATH}/src/${GO_REPO_NAMESPACE}
+ - ln -sv ${TRAVIS_BUILD_DIR} ${GOPATH}/src/${GO_REPO_FULLNAME}
+ - cd ${GOPATH}/src/${GO_REPO_FULLNAME}
+   # get and build ssdb
  - git clone git://github.com/ideawu/ssdb.git
  - cd ssdb
  - make


### PR DESCRIPTION
A common problem with go is the fixed path required for the package.

When forking a project to a new namespace this fixed path is no longer valid and ci for the forked build fails.

By symlinking the cloned project into the correct location for the original project in the travis-ci.yml script the build and subsequent tests etc. will work whether this is the original or forked project.

The proposed changes in this mr use an environment variable to indicate the path of the original project:
```
GO_REPO_FULLNAME="github.com/astaxie/beego"
```
After making the changes proposed in this mr the project can be forked and the travis-ci build on the forked project will have the same status as the original branch.

The biggest advantage of this is that you can check whether any mrs are passing before accepting them.