### PR TITLE
[Fix] Fix the issue that genRouterCode results in @Import annotations getting overwritten

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -459,12 +459,16 @@ func genRouterCode(pkgRealpath string) {
 			imports := ""
 			if len(c.ImportComments) > 0 {
 				for _, i := range c.ImportComments {
+					var s string
 					if i.ImportAlias != "" {
-						imports += fmt.Sprintf(`
+						s = fmt.Sprintf(`
 	%s "%s"`, i.ImportAlias, i.ImportPath)
 					} else {
-						imports += fmt.Sprintf(`
+						s = fmt.Sprintf(`
 	"%s"`, i.ImportPath)
+					}
+					if !strings.Contains(globalimport, s) {
+						imports += s
 					}
 				}
 			}
@@ -490,7 +494,7 @@ func genRouterCode(pkgRealpath string) {
             }`, filters)
 			}
 
-			globalimport = imports
+			globalimport += imports
 
 			globalinfo = globalinfo + `
     beego.GlobalControllerRouter["` + k + `"] = append(beego.GlobalControllerRouter["` + k + `"],


### PR DESCRIPTION
Hi, Core maintainers 

I hit a issue on Beego framework with `@Import ` annotation getting overwritten while handled by `genRouterCode` block. I would like to contribute my fix to the main code stream. Please kindly review this submission. 

### Problem description:

When multiple `@Import` annotations are inserted, the `genRouterCode` can not handle correctly and  results only the annotation against very last annotated method of the last included controller instance could be added to generated router codes. From the code reading, it is handled according to alphabetic sorting sequence.

The issue is mainly caused by [this snippet of code](https://github.com/astaxie/beego/blob/develop/parser.go#L493)

Iterating over each parsed comment, the `globalimport` variable is overwritten by the later entry and then only the very last one take the position.

### Expected Behavior:

- `@Import` could be inserted to annotated controller codes at will and all will be processed by router code generator
- Multiple `@Import` annotations of the same package and alias could be handled correctly so that only one line generated

### Fix details:

Update the `genRouterCode` in [parser.go](https://github.com/astaxie/beego/blob/develop/parser.go)

While processing each parsed comment in iterations, each entry will be checked against processed ones stored in `globalimport` set by string comparison. Only the new one will be appended to `globalimport`. 

After the iterating processing, the final `globalimport` set will be put into the template as original logic.

I tested this fix locally with my own application. It works as expected.  @astaxie could you please review this fix ?

Thank YOU !