### PR TITLE
结构体字段和orm:column()字段定义相同时出现的bug,

### DIFF
--- a/orm/models_info_f.go
+++ b/orm/models_info_f.go
@@ -80,12 +80,16 @@ func (f *fields) GetByAny(name string) (*fieldInfo, bool) {
 	if fi, ok := f.fields[name]; ok {
 		return fi, ok
 	}
-	if fi, ok := f.fieldsLow[strings.ToLower(name)]; ok {
-		return fi, ok
-	}
+
+	//优先使用orm:column()定义的字段
 	if fi, ok := f.columns[name]; ok {
 		return fi, ok
 	}
+
+	if fi, ok := f.fieldsLow[strings.ToLower(name)]; ok {
+		return fi, ok
+	}
+
 	return nil, false
 }
 


### PR DESCRIPTION
解决orm定义中，结构体字段和orm:column()字段定义相同时出现的bug,当出现以下定义的时候，orm在进行Insert的时候会出现错误

ConfigID1           uint32 `field:"默认镜像配置" orm:"column(configid0)" json:"configid0"`
ConfigID2           uint32 `field:"第二镜像配置" orm:"column(configid1)" json:"configid1"`
构出的sql的字段都是configid0，