### PR TITLE
fix:utils.GetGOPATHs() when go version equal or after go1.10

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,17 +3,76 @@ package utils
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
 // GetGOPATHs returns all paths in GOPATH variable.
 func GetGOPATHs() []string {
 	gopath := os.Getenv("GOPATH")
-	if gopath == "" && strings.Compare(runtime.Version(), "go1.8") >= 0 {
+	if gopath == "" && compareGoVersion(runtime.Version(), "go1.8") >= 0 {
 		gopath = defaultGOPATH()
 	}
 	return filepath.SplitList(gopath)
+}
+
+func compareGoVersion(a, b string) int {
+	reg := regexp.MustCompile("^\\d*")
+
+	a = strings.TrimPrefix(a, "go")
+	b = strings.TrimPrefix(b, "go")
+
+	versionsA := strings.Split(a, ".")
+	versionsB := strings.Split(b, ".")
+
+	for i := 0; i < len(versionsA) && i < len(versionsB); i++ {
+		versionA := versionsA[i]
+		versionB := versionsB[i]
+
+		vA, err := strconv.Atoi(versionA)
+		if err != nil {
+			str := reg.FindString(versionA)
+			if str != "" {
+				vA, _ = strconv.Atoi(str)
+			} else {
+				vA = -1
+			}
+		}
+
+		vB, err := strconv.Atoi(versionB)
+		if err != nil {
+			str := reg.FindString(versionB)
+			if str != "" {
+				vB, _ = strconv.Atoi(str)
+			} else {
+				vB = -1
+			}
+		}
+
+		if vA > vB {
+			// vA = 12, vB = 8
+			return 1
+		} else if vA < vB {
+			// vA = 6, vB = 8
+			return -1
+		} else if vA == -1 {
+			// vA = rc1, vB = rc3
+			return strings.Compare(versionA, versionB)
+		}
+
+		// vA = vB = 8
+		continue
+	}
+
+	if len(versionsA) > len(versionsB) {
+		return 1
+	} else if len(versionsA) == len(versionsB) {
+		return 0
+	}
+
+	return -1
 }
 
 func defaultGOPATH() string {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestCompareGoVersion(t *testing.T) {
+	targetVersion := "go1.8"
+	if compareGoVersion("go1.12.4", targetVersion) != 1 {
+		t.Error("should be 1")
+	}
+
+	if compareGoVersion("go1.8.7", targetVersion) != 1 {
+		t.Error("should be 1")
+	}
+
+	if compareGoVersion("go1.8", targetVersion) != 0 {
+		t.Error("should be 0")
+	}
+
+	if compareGoVersion("go1.7.6", targetVersion) != -1 {
+		t.Error("should be -1")
+	}
+
+	if compareGoVersion("go1.12.1rc1", targetVersion) != 1 {
+		t.Error("should be 1")
+	}
+
+	if compareGoVersion("go1.8rc1", targetVersion) != 0 {
+		t.Error("should be 0")
+	}
+
+	if compareGoVersion("go1.7rc1", targetVersion) != -1 {
+		t.Error("should be -1")
+	}
+}


### PR DESCRIPTION
fix:utils.GetGOPATHs() when go version equal or after go1.10 func does not return defaultGoPATH()