### PR TITLE
Fix BatchUpdate not update the auto_now field

### DIFF
--- a/orm/db.go
+++ b/orm/db.go
@@ -621,18 +621,29 @@ func (d *dbBase) Update(q dbQuerier, mi *modelInfo, ind reflect.Value, tz *time.
 		return 0, err
 	}
 
-	var find bool
+	var findAutoNowAdd, findAutoNow bool
 	var index int
 	for i, col := range setNames {
 		if mi.fields.GetByColumn(col).autoNowAdd {
 			index = i
-			find = true
+			findAutoNowAdd = true
+		}
+		if mi.fields.GetByColumn(col).autoNow {
+			findAutoNow = true
 		}
 	}
-
-	if find {
+	if findAutoNowAdd {
 		setNames = append(setNames[0:index], setNames[index+1:]...)
 		setValues = append(setValues[0:index], setValues[index+1:]...)
+	}
+
+	if !findAutoNow {
+		for col, info := range mi.fields.columns {
+			if info.autoNow {
+				setNames = append(setNames, col)
+				setValues = append(setValues, time.Now())
+			}
+		}
 	}
 
 	setValues = append(setValues, pkValue)


### PR DESCRIPTION
when we do batch update by the code below, it will not update the field with tag `auto_now`.
`
num, err := o.QueryTable("user").Filter("name", "slene").Update(orm.Params{
    "name": "astaxie",
})
fmt.Printf("Affected Num: %s, %s", num, err)
// SET name = "astaixe" WHERE name = "slene"
`
I create this pull request to fix this.