### PR TITLE
fix bugs of ParseForm about time in RFC3339 format

### DIFF
--- a/templatefunc.go
+++ b/templatefunc.go
@@ -361,6 +361,8 @@ func parseFormToStruct(form url.Values, objT reflect.Type, objV reflect.Value) e
 				if len(value) >= 25 {
 					value = value[:25]
 					t, err = time.ParseInLocation(time.RFC3339, value, time.Local)
+				} else if strings.HasSuffix(strings.ToUpper(value), "Z") {
+					t, err = time.ParseInLocation(time.RFC3339, value, time.Local)	
 				} else if len(value) >= 19 {
 					if strings.Contains(value, "T") {
 						value = value[:19]


### PR DESCRIPTION
https://tools.ietf.org/html/rfc3339#section-5  
```
5.8. Examples

   Here are some examples of Internet date/time format.

      1985-04-12T23:20:50.52Z

   This represents 20 minutes and 50.52 seconds after the 23rd hour of
   April 12th, 1985 in UTC.
```

"1985-04-12T23:20:50.52Z" is a valid RFC3339 format datetime, but it's length is 23.
