### PR TITLE
fix orm datarace

### DIFF
--- a/orm/models_boot.go
+++ b/orm/models_boot.go
@@ -335,11 +335,11 @@ func RegisterModelWithSuffix(suffix string, models ...interface{}) {
 // BootStrap bootstrap models.
 // make all model parsed and can not add more models
 func BootStrap() {
+	modelCache.Lock()
+	defer modelCache.Unlock()
 	if modelCache.done {
 		return
 	}
-	modelCache.Lock()
-	defer modelCache.Unlock()
 	bootStrap()
 	modelCache.done = true
 }


### PR DESCRIPTION
Code here may crash in concurrent way

```golang
// beego/orm/models_boot.go
func BootStrap() {	
        //if there are multiple goroutines run orm.NewOrm(), the runtime may crash
	if modelCache.done {
		return
	}
        modelCache.Lock() 
	defer modelCache.Unlock()
	bootStrap()
	modelCache.done = true
}
```

```shell
➜  demo git:(demo) go run -race main.go
2019/06/14 14:44:53 15843 :8080
==================
WARNING: DATA RACE
Read at 0x00000196f160 by goroutine 17:
  vendor/github.com/astaxie/beego/orm.BootStrap()
      /data/workspace/src/vendor/github.com/astaxie/beego/orm/models_boot.go:338 +0x59
  vendor/github.com/astaxie/beego/orm.NewOrm()
      /data/workspace/src/vendor/github.com/astaxie/beego/orm/orm.go:520 +0x33
  ad-adapter/models/dp.Loaddk()
      /data/workspace/src/demo/models/dp/dp.go:31 +0x44
  vendor/base/lib/util.StartTicker()
      /data/workspace/src/vendor/base/lib/util/util.go:121 +0x42

Previous write at 0x00000196f160 by main goroutine:
  [failed to restore the stack]
...
```