### PR TITLE
Add stmt

### DIFF
--- a/orm/db_alias.go
+++ b/orm/db_alias.go
@@ -110,6 +110,14 @@ type DB struct {
 	stmts map[string]*sql.Stmt
 }
 
+func (d *DB) Begin() (*sql.Tx, error) {
+	return d.DB.Begin()
+}
+
+func (d *DB) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	return d.DB.BeginTx(ctx, opts)
+}
+
 func (d *DB) getStmt(query string) (*sql.Stmt, error) {
 	d.RLock()
 	if stmt, ok := d.stmts[query]; ok {

--- a/orm/db_alias.go
+++ b/orm/db_alias.go
@@ -105,61 +105,17 @@ func (ac *_dbCache) getDefault() (al *alias) {
 }
 
 type DB struct {
-	inTx bool
-	tx   *sql.Tx
 	*sync.RWMutex
 	DB    *sql.DB
 	stmts map[string]*sql.Stmt
 }
 
 func (d *DB) Begin() (*sql.Tx, error) {
-	if d.inTx {
-		return nil, ErrTxHasBegan
-	}
-	tx, err := d.DB.Begin()
-	if err != nil {
-		return nil, err
-	}
-	d.inTx = true
-	d.tx = tx
-	return d.tx, nil
+	return d.DB.Begin()
 }
 
 func (d *DB) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
-	if d.inTx {
-		return nil, ErrTxHasBegan
-	}
-	tx, err := d.DB.BeginTx(ctx, opts)
-	if err != nil {
-		return nil, err
-	}
-	d.inTx = true
-	d.tx = tx
-	return d.tx, nil
-}
-
-func (d *DB) Commit() error {
-	if !d.inTx {
-		return ErrTxDone
-	}
-	err := d.tx.Commit()
-	if err != nil {
-		return err
-	}
-	d.inTx = false
-	return nil
-}
-
-func (d *DB) Rollback() error {
-	if !d.inTx {
-		return ErrTxDone
-	}
-	err := d.tx.Commit()
-	if err != nil {
-		return err
-	}
-	d.inTx = false
-	return nil
+	return d.DB.BeginTx(ctx, opts)
 }
 
 func (d *DB) getStmt(query string) (*sql.Stmt, error) {

--- a/orm/db_alias.go
+++ b/orm/db_alias.go
@@ -105,17 +105,61 @@ func (ac *_dbCache) getDefault() (al *alias) {
 }
 
 type DB struct {
+	inTx bool
+	tx   *sql.Tx
 	*sync.RWMutex
 	DB    *sql.DB
 	stmts map[string]*sql.Stmt
 }
 
 func (d *DB) Begin() (*sql.Tx, error) {
-	return d.DB.Begin()
+	if d.inTx {
+		return nil, ErrTxHasBegan
+	}
+	tx, err := d.DB.Begin()
+	if err != nil {
+		return nil, err
+	}
+	d.inTx = true
+	d.tx = tx
+	return d.tx, nil
 }
 
 func (d *DB) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
-	return d.DB.BeginTx(ctx, opts)
+	if d.inTx {
+		return nil, ErrTxHasBegan
+	}
+	tx, err := d.DB.BeginTx(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	d.inTx = true
+	d.tx = tx
+	return d.tx, nil
+}
+
+func (d *DB) Commit() error {
+	if !d.inTx {
+		return ErrTxDone
+	}
+	err := d.tx.Commit()
+	if err != nil {
+		return err
+	}
+	d.inTx = false
+	return nil
+}
+
+func (d *DB) Rollback() error {
+	if !d.inTx {
+		return ErrTxDone
+	}
+	err := d.tx.Commit()
+	if err != nil {
+		return err
+	}
+	d.inTx = false
+	return nil
 }
 
 func (d *DB) getStmt(query string) (*sql.Stmt, error) {

--- a/orm/db_alias.go
+++ b/orm/db_alias.go
@@ -15,6 +15,7 @@
 package orm
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"reflect"
@@ -103,6 +104,89 @@ func (ac *_dbCache) getDefault() (al *alias) {
 	return
 }
 
+type DB struct {
+	*sync.RWMutex
+	DB    *sql.DB
+	stmts map[string]*sql.Stmt
+}
+
+func (d *DB) getStmt(query string) (*sql.Stmt, error) {
+	d.RLock()
+	if stmt, ok := d.stmts[query]; ok {
+		d.RUnlock()
+		return stmt, nil
+	}
+
+	stmt, err := d.Prepare(query)
+	if err != nil {
+		return nil, err
+	}
+	d.Lock()
+	d.stmts[query] = stmt
+	d.Unlock()
+	return stmt, nil
+}
+
+func (d *DB) Prepare(query string) (*sql.Stmt, error) {
+	return d.DB.Prepare(query)
+}
+
+func (d *DB) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	return d.DB.PrepareContext(ctx, query)
+}
+
+func (d *DB) Exec(query string, args ...interface{}) (sql.Result, error) {
+	stmt, err := d.getStmt(query)
+	if err != nil {
+		return nil, err
+	}
+	return stmt.Exec(args)
+}
+
+func (d *DB) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	stmt, err := d.getStmt(query)
+	if err != nil {
+		return nil, err
+	}
+	return stmt.ExecContext(ctx, args)
+}
+
+func (d *DB) Query(query string, args ...interface{}) (*sql.Rows, error) {
+	stmt, err := d.getStmt(query)
+	if err != nil {
+		return nil, err
+	}
+	return stmt.Query(args)
+}
+
+func (d *DB) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	stmt, err := d.getStmt(query)
+	if err != nil {
+		return nil, err
+	}
+	return stmt.QueryContext(ctx, args)
+}
+
+func (d *DB) QueryRow(query string, args ...interface{}) *sql.Row {
+	stmt, err := d.getStmt(query)
+	if err != nil {
+		panic(err)
+		return nil
+	}
+	return stmt.QueryRow(args)
+
+}
+
+func (d *DB) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+
+	stmt, err := d.getStmt(query)
+	if err != nil {
+		panic(err)
+		return nil
+	}
+	return stmt.QueryRowContext(ctx, args)
+}
+
 type alias struct {
 	Name         string
 	Driver       DriverType
@@ -110,7 +194,7 @@ type alias struct {
 	DataSource   string
 	MaxIdleConns int
 	MaxOpenConns int
-	DB           *sql.DB
+	DB           *DB
 	DbBaser      dbBaser
 	TZ           *time.Location
 	Engine       string
@@ -176,7 +260,10 @@ func addAliasWthDB(aliasName, driverName string, db *sql.DB) (*alias, error) {
 	al := new(alias)
 	al.Name = aliasName
 	al.DriverName = driverName
-	al.DB = db
+	al.DB = &DB{
+		DB:    db,
+		stmts: make(map[string]*sql.Stmt),
+	}
 
 	if dr, ok := drivers[driverName]; ok {
 		al.DbBaser = dbBasers[dr]
@@ -272,7 +359,7 @@ func SetDataBaseTZ(aliasName string, tz *time.Location) error {
 func SetMaxIdleConns(aliasName string, maxIdleConns int) {
 	al := getDbAlias(aliasName)
 	al.MaxIdleConns = maxIdleConns
-	al.DB.SetMaxIdleConns(maxIdleConns)
+	al.DB.DB.SetMaxIdleConns(maxIdleConns)
 }
 
 // SetMaxOpenConns Change the max open conns for *sql.DB, use specify database alias name
@@ -296,7 +383,7 @@ func GetDB(aliasNames ...string) (*sql.DB, error) {
 	}
 	al, ok := dataBaseCache.get(name)
 	if ok {
-		return al.DB, nil
+		return al.DB.DB, nil
 	}
 	return nil, fmt.Errorf("DataBase of alias name `%s` not found", name)
 }

--- a/orm/db_alias.go
+++ b/orm/db_alias.go
@@ -172,7 +172,6 @@ func (d *DB) QueryRow(query string, args ...interface{}) *sql.Row {
 	stmt, err := d.getStmt(query)
 	if err != nil {
 		panic(err)
-		return nil
 	}
 	return stmt.QueryRow(args...)
 
@@ -183,7 +182,6 @@ func (d *DB) QueryRowContext(ctx context.Context, query string, args ...interfac
 	stmt, err := d.getStmt(query)
 	if err != nil {
 		panic(err)
-		return nil
 	}
 	return stmt.QueryRowContext(ctx, args)
 }

--- a/orm/orm.go
+++ b/orm/orm.go
@@ -529,7 +529,6 @@ func (o *orm) DBStats() *sql.DBStats {
 		stats := o.alias.DB.DB.Stats()
 		return &stats
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
I update the definition of struct orm->alias. I create new struct type orm.DB to replace the alias field DB. With the new type orm.DB, we can avoid redo prepare sql STMT. I believe this can improve the performance.