### PR TITLE
Fixed logs.BeeLogger.SetLogger: open logs/info.log: permission denied

### DIFF
--- a/logs/file.go
+++ b/logs/file.go
@@ -193,7 +193,7 @@ func (w *fileLogWriter) createLogFile() (*os.File, error) {
 	}
 
 	filepath := path.Dir(w.Filename)
-	os.MkdirAll(filepath, os.FileMode(perm))
+	os.MkdirAll(filepath, os.FileMode(0755))
 
 	fd, err := os.OpenFile(w.Filename, os.O_WRONLY|os.O_APPEND|os.O_CREATE, os.FileMode(perm))
 	if err == nil {


### PR DESCRIPTION
* make missed directory in correct defalt permision(0755) when init logger that adaper is file.This patch can fix  ` logs.BeeLogger.SetLogger: open logs/info.log: permission denied`  problem