### PR TITLE
fix graceful bug: old process didn't exist when graceful restart

### DIFF
--- a/grace/server.go
+++ b/grace/server.go
@@ -46,7 +46,10 @@ func (srv *Server) Serve() (err error) {
 
 	log.Println(syscall.Getpid(), srv.ln.Addr(), "Listener closed.")
 	// wait for Shutdown to return
-	return <-srv.terminalChan
+	if shutdownErr := <-srv.terminalChan; shutdownErr != nil {
+		return shutdownErr
+	}
+	return
 }
 
 // ListenAndServe listens on the TCP network address srv.Addr and then calls Serve


### PR DESCRIPTION
fix bug of issue #3717 
In beego 1.12.0, process will call  ShutDown and send ShutDown error to [terminalChan](https://github.com/astaxie/beego/blob/develop/grace/server.go#L292) when received SIGHUP signal, and [serve funtion](https://github.com/astaxie/beego/blob/develop/grace/server.go#L35) will return this error, but in normal scene, Shutdown just return nil. It means [serve funtion](https://github.com/astaxie/beego/blob/develop/grace/server.go#L35) will return nil when received SIGHUP signal, and [app.go(line161)](https://github.com/astaxie/beego/blob/develop/app.go#L161) will not send data to endRunning channel, so process will HANGUP in [line68](https://github.com/astaxie/beego/blob/develop/app.go#L168)