### PR TITLE
upgrade validators mobile rule

### DIFF
--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -253,8 +253,8 @@ func TestBase64(t *testing.T) {
 func TestMobile(t *testing.T) {
 	valid := Validation{}
 
-	if valid.Mobile("19800008888", "mobile").Ok {
-		t.Error("\"19800008888\" is a valid mobile phone number should be false")
+	if !valid.Mobile("19800008888", "mobile").Ok {
+		t.Error("\"19800008888\" is a valid mobile phone number should be true")
 	}
 	if !valid.Mobile("18800008888", "mobile").Ok {
 		t.Error("\"18800008888\" is a valid mobile phone number should be true")

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -256,6 +256,9 @@ func TestMobile(t *testing.T) {
 	if !valid.Mobile("19800008888", "mobile").Ok {
 		t.Error("\"19800008888\" is a valid mobile phone number should be true")
 	}
+	if !valid.Mobile("19900008888", "mobile").Ok {
+		t.Error("\"19900008888\" is a valid mobile phone number should be true")
+	}
 	if !valid.Mobile("18800008888", "mobile").Ok {
 		t.Error("\"18800008888\" is a valid mobile phone number should be true")
 	}

--- a/validation/validators.go
+++ b/validation/validators.go
@@ -632,7 +632,7 @@ func (b Base64) GetLimitValue() interface{} {
 }
 
 // just for chinese mobile phone number
-var mobilePattern = regexp.MustCompile(`^((\+86)|(86))?(1(([35][0-9])|[8][0-9]|[7][01356789]|[4][579]))\d{8}$`)
+var mobilePattern = regexp.MustCompile(`^((\+|00)?86)?1([358][0-9]|4[579]|6[67]|7[0135678]|9[189])[0-9]{8}$`)
 
 // Mobile check struct
 type Mobile struct {


### PR DESCRIPTION
#3746 resolve this issue

**The Latest China Number Section**

- CDMA
133、149、153、173、177、180、181、189、191、199、193
- CUCC
130、131、132、145、155、156、166、171、175、176、185、186
- CMCC
134(0-8)、135、136、137、138、139、147、150、151、152、157、158、159、172、178、182、183、184、187、188、198

**Reference** :  [MobileValidator](https://github.com/validatorjs/validator.js/blob/47f3492976f3a24c52d337db2e0dc59b46ca7e90/lib/isMobilePhone.js#L94)