### PR TITLE
Added orm.DefaultDeletePolicy, which can be one of values we can use …

### DIFF
--- a/orm/models_info_f.go
+++ b/orm/models_info_f.go
@@ -349,7 +349,7 @@ checkType:
 			}
 		default:
 			if onDelete == "" {
-				onDelete = DefaultDeletePolicy
+				onDelete = DefaultOdPolicy
 			} else {
 				err = fmt.Errorf("on_delete value expected choice in `cascade,set_null,set_default,do_nothing`, unknown `%s`", onDelete)
 				goto end

--- a/orm/models_info_f.go
+++ b/orm/models_info_f.go
@@ -349,7 +349,7 @@ checkType:
 			}
 		default:
 			if onDelete == "" {
-				onDelete = odCascade
+				onDelete = DefaultDeletePolicy
 			} else {
 				err = fmt.Errorf("on_delete value expected choice in `cascade,set_null,set_default,do_nothing`, unknown `%s`", onDelete)
 				goto end

--- a/orm/orm.go
+++ b/orm/orm.go
@@ -71,19 +71,19 @@ const (
 
 // Define common vars
 var (
-	Debug               = false
-	DebugLog            = NewLog(os.Stdout)
-	DefaultRowsLimit    = -1
-	DefaultRelsDepth    = 2
-	DefaultTimeLoc      = time.Local
-	DefaultDeletePolicy = odDoNothing
-	ErrTxHasBegan       = errors.New("<Ormer.Begin> transaction already begin")
-	ErrTxDone           = errors.New("<Ormer.Commit/Rollback> transaction not begin")
-	ErrMultiRows        = errors.New("<QuerySeter> return multi rows")
-	ErrNoRows           = errors.New("<QuerySeter> no row found")
-	ErrStmtClosed       = errors.New("<QuerySeter> stmt already closed")
-	ErrArgs             = errors.New("<Ormer> args error may be empty")
-	ErrNotImplement     = errors.New("have not implement")
+	Debug            = false
+	DebugLog         = NewLog(os.Stdout)
+	DefaultRowsLimit = -1
+	DefaultRelsDepth = 2
+	DefaultTimeLoc   = time.Local
+	DefaultOdPolicy  = odDoNothing
+	ErrTxHasBegan    = errors.New("<Ormer.Begin> transaction already begin")
+	ErrTxDone        = errors.New("<Ormer.Commit/Rollback> transaction not begin")
+	ErrMultiRows     = errors.New("<QuerySeter> return multi rows")
+	ErrNoRows        = errors.New("<QuerySeter> no row found")
+	ErrStmtClosed    = errors.New("<QuerySeter> stmt already closed")
+	ErrArgs          = errors.New("<Ormer> args error may be empty")
+	ErrNotImplement  = errors.New("have not implement")
 )
 
 // Params stores the Params

--- a/orm/orm.go
+++ b/orm/orm.go
@@ -71,18 +71,19 @@ const (
 
 // Define common vars
 var (
-	Debug            = false
-	DebugLog         = NewLog(os.Stdout)
-	DefaultRowsLimit = -1
-	DefaultRelsDepth = 2
-	DefaultTimeLoc   = time.Local
-	ErrTxHasBegan    = errors.New("<Ormer.Begin> transaction already begin")
-	ErrTxDone        = errors.New("<Ormer.Commit/Rollback> transaction not begin")
-	ErrMultiRows     = errors.New("<QuerySeter> return multi rows")
-	ErrNoRows        = errors.New("<QuerySeter> no row found")
-	ErrStmtClosed    = errors.New("<QuerySeter> stmt already closed")
-	ErrArgs          = errors.New("<Ormer> args error may be empty")
-	ErrNotImplement  = errors.New("have not implement")
+	Debug               = false
+	DebugLog            = NewLog(os.Stdout)
+	DefaultRowsLimit    = -1
+	DefaultRelsDepth    = 2
+	DefaultTimeLoc      = time.Local
+	DefaultDeletePolicy = odDoNothing
+	ErrTxHasBegan       = errors.New("<Ormer.Begin> transaction already begin")
+	ErrTxDone           = errors.New("<Ormer.Commit/Rollback> transaction not begin")
+	ErrMultiRows        = errors.New("<QuerySeter> return multi rows")
+	ErrNoRows           = errors.New("<QuerySeter> no row found")
+	ErrStmtClosed       = errors.New("<QuerySeter> stmt already closed")
+	ErrArgs             = errors.New("<Ormer> args error may be empty")
+	ErrNotImplement     = errors.New("have not implement")
 )
 
 // Params stores the Params


### PR DESCRIPTION
There is quite a chance that the row having foreign key can be unexpectedly deleted in current code.

For example,

type Job struct {
    ...
}

type Profile struct {
    Job *Job `orm:"column(job_id);rel(fk);"`
}

If we don't have relationship config in the `profiles` table, Beego will automatically delete the `profile` if the `job` is deleted, which doesn't make sense for above case.
(Should deleting `job` cause deleting the `profile` of user...?)

And nowadays many devs don't put real relation config for foreign keys in the table actually, due to performance issue.

So I suggest below:
1. Let's have
orm.DefaultDeletePolicy: ["cascade", "set_null", "set_default", "do_nothing"]
2. Let's set it's default as "do_nothing" instead of "cascade"