### PR TITLE
Get the real location of the log directory before using filepath.Walk function when remove old logs

### DIFF
--- a/logs/file.go
+++ b/logs/file.go
@@ -359,6 +359,10 @@ RESTART_LOGGER:
 
 func (w *fileLogWriter) deleteOldLog() {
 	dir := filepath.Dir(w.Filename)
+	absolutePath, err := filepath.EvalSymlinks(w.Filename)
+	if err == nil {
+		dir = filepath.Dir(absolutePath)
+	}
 	filepath.Walk(dir, func(path string, info os.FileInfo, err error) (returnErr error) {
 		defer func() {
 			if r := recover(); r != nil {
@@ -369,21 +373,21 @@ func (w *fileLogWriter) deleteOldLog() {
 		if info == nil {
 			return
 		}
-        if w.Hourly {
-            if !info.IsDir() && info.ModTime().Add(1 * time.Hour * time.Duration(w.MaxHours)).Before(time.Now()) {
-                if strings.HasPrefix(filepath.Base(path), filepath.Base(w.fileNameOnly)) &&
-                strings.HasSuffix(filepath.Base(path), w.suffix) {
-                    os.Remove(path)
-                }
-            }
-        } else if w.Daily {
-            if !info.IsDir() && info.ModTime().Add(24 * time.Hour * time.Duration(w.MaxDays)).Before(time.Now()) {
-                if strings.HasPrefix(filepath.Base(path), filepath.Base(w.fileNameOnly)) &&
-                strings.HasSuffix(filepath.Base(path), w.suffix) {
-                    os.Remove(path)
-                }
-            }
-        }
+		if w.Hourly {
+			if !info.IsDir() && info.ModTime().Add(1*time.Hour*time.Duration(w.MaxHours)).Before(time.Now()) {
+				if strings.HasPrefix(filepath.Base(path), filepath.Base(w.fileNameOnly)) &&
+					strings.HasSuffix(filepath.Base(path), w.suffix) {
+					os.Remove(path)
+				}
+			}
+		} else if w.Daily {
+			if !info.IsDir() && info.ModTime().Add(24*time.Hour*time.Duration(w.MaxDays)).Before(time.Now()) {
+				if strings.HasPrefix(filepath.Base(path), filepath.Base(w.fileNameOnly)) &&
+					strings.HasSuffix(filepath.Base(path), w.suffix) {
+					os.Remove(path)
+				}
+			}
+		}
 		return
 	})
 }

--- a/logs/file.go
+++ b/logs/file.go
@@ -373,21 +373,21 @@ func (w *fileLogWriter) deleteOldLog() {
 		if info == nil {
 			return
 		}
-		if w.Hourly {
-			if !info.IsDir() && info.ModTime().Add(1*time.Hour*time.Duration(w.MaxHours)).Before(time.Now()) {
-				if strings.HasPrefix(filepath.Base(path), filepath.Base(w.fileNameOnly)) &&
-					strings.HasSuffix(filepath.Base(path), w.suffix) {
-					os.Remove(path)
-				}
-			}
-		} else if w.Daily {
-			if !info.IsDir() && info.ModTime().Add(24*time.Hour*time.Duration(w.MaxDays)).Before(time.Now()) {
-				if strings.HasPrefix(filepath.Base(path), filepath.Base(w.fileNameOnly)) &&
-					strings.HasSuffix(filepath.Base(path), w.suffix) {
-					os.Remove(path)
-				}
-			}
-		}
+        if w.Hourly {
+            if !info.IsDir() && info.ModTime().Add(1 * time.Hour * time.Duration(w.MaxHours)).Before(time.Now()) {
+                if strings.HasPrefix(filepath.Base(path), filepath.Base(w.fileNameOnly)) &&
+                strings.HasSuffix(filepath.Base(path), w.suffix) {
+                    os.Remove(path)
+                }
+            }
+        } else if w.Daily {
+            if !info.IsDir() && info.ModTime().Add(24 * time.Hour * time.Duration(w.MaxDays)).Before(time.Now()) {
+                if strings.HasPrefix(filepath.Base(path), filepath.Base(w.fileNameOnly)) &&
+                strings.HasSuffix(filepath.Base(path), w.suffix) {
+                    os.Remove(path)
+                }
+            }
+        }
 		return
 	})
 }


### PR DESCRIPTION
According to issue#4759 (https://github.com/golang/go/issues/4759) filepath.Walk function in golang cannot handle symbolic path, meanwhile symbolic path for log directory is pretty common used. In such scenario this deleteOldLog function will fail without any error log. Get the real location of the log directory before using walk function can fix this.