### PR TITLE
修复Prepared_stmt_count 资源未释放，导致线上环境MYSQL报错

### DIFF
--- a/orm/db_alias.go
+++ b/orm/db_alias.go
@@ -119,20 +119,20 @@ func (d *DB) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) 
 }
 
 func (d *DB) getStmt(query string) (*sql.Stmt, error) {
-	d.RLock()
-	if stmt, ok := d.stmts[query]; ok {
-		d.RUnlock()
-		return stmt, nil
-	}
-	d.RUnlock()
+	//d.RLock()
+	//if stmt, ok := d.stmts[query]; ok {
+	//	d.RUnlock()
+	//	return stmt, nil
+	//}
+	//d.RUnlock()
 
 	stmt, err := d.Prepare(query)
 	if err != nil {
 		return nil, err
 	}
-	d.Lock()
-	d.stmts[query] = stmt
-	d.Unlock()
+	//d.Lock()
+	//d.stmts[query] = stmt
+	//d.Unlock()
 	return stmt, nil
 }
 

--- a/orm/db_alias.go
+++ b/orm/db_alias.go
@@ -149,6 +149,9 @@ func (d *DB) Exec(query string, args ...interface{}) (sql.Result, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	defer stmt.Close()
+
 	return stmt.Exec(args...)
 }
 
@@ -157,6 +160,9 @@ func (d *DB) ExecContext(ctx context.Context, query string, args ...interface{})
 	if err != nil {
 		return nil, err
 	}
+
+	defer stmt.Close()
+
 	return stmt.ExecContext(ctx, args...)
 }
 
@@ -165,6 +171,9 @@ func (d *DB) Query(query string, args ...interface{}) (*sql.Rows, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	defer stmt.Close()
+
 	return stmt.Query(args...)
 }
 
@@ -173,6 +182,9 @@ func (d *DB) QueryContext(ctx context.Context, query string, args ...interface{}
 	if err != nil {
 		return nil, err
 	}
+
+	defer stmt.Close()
+
 	return stmt.QueryContext(ctx, args...)
 }
 


### PR DESCRIPTION
修复Prepared_stmt_count 资源未释放，导致线上环境MYSQL报错：
FATAL: MySQL error: 1461 "Can't create more than max_prepared_stmt_count statements (current value: 16382)"