### PR TITLE
Fix Ormer#InsertOrUpdate modify "auto_now_add" fields when updating.

### DIFF
--- a/orm/db.go
+++ b/orm/db.go
@@ -533,7 +533,7 @@ func (d *dbBase) InsertOrUpdate(q dbQuerier, mi *modelInfo, ind reflect.Value, a
 
 	marks := make([]string, len(names))
 	updateValues := make([]interface{}, 0)
-	updates := make([]string, len(names))
+	updates := make([]string, 0)
 	var conflitValue interface{}
 	for i, v := range names {
 		// identifier in database may not be case-sensitive, so quote it
@@ -546,18 +546,18 @@ func (d *dbBase) InsertOrUpdate(q dbQuerier, mi *modelInfo, ind reflect.Value, a
 		if valueStr != "" {
 			switch a.Driver {
 			case DRMySQL:
-				updates[i] = v + "=" + valueStr
+				updates = append(updates, v+"="+valueStr)
 			case DRPostgres:
 				if conflitValue != nil {
 					//postgres ON CONFLICT DO UPDATE SET can`t use colu=colu+values
-					updates[i] = fmt.Sprintf("%s=(select %s from %s where %s = ? )", v, valueStr, mi.table, args0)
+					updates = append(updates, fmt.Sprintf("%s=(select %s from %s where %s = ? )", v, valueStr, mi.table, args0))
 					updateValues = append(updateValues, conflitValue)
 				} else {
 					return 0, fmt.Errorf("`%s` must be in front of `%s` in your struct", args0, v)
 				}
 			}
-		} else {
-			updates[i] = v + "=?"
+		} else if !mi.fields.GetByColumn(names[i]).autoNowAdd { // ignore auto_now_add when updating.
+			updates = append(updates, v+"=?")
 			updateValues = append(updateValues, values[i])
 		}
 	}

--- a/orm/db_mysql.go
+++ b/orm/db_mysql.go
@@ -128,15 +128,15 @@ func (d *dbBaseMysql) InsertOrUpdate(q dbQuerier, mi *modelInfo, ind reflect.Val
 
 	marks := make([]string, len(names))
 	updateValues := make([]interface{}, 0)
-	updates := make([]string, len(names))
+	updates := make([]string, 0)
 
 	for i, v := range names {
 		marks[i] = "?"
 		valueStr := argsMap[strings.ToLower(v)]
 		if valueStr != "" {
-			updates[i] = "`" + v + "`" + "=" + valueStr
-		} else {
-			updates[i] = "`" + v + "`" + "=?"
+			updates = append(updates, "`"+v+"`"+"="+valueStr)
+		} else if !mi.fields.GetByColumn(v).autoNowAdd { // ignore auto_now_add when updating.
+			updates = append(updates, "`"+v+"`"+"=?")
 			updateValues = append(updateValues, values[i])
 		}
 	}

--- a/orm/orm_test.go
+++ b/orm/orm_test.go
@@ -2403,8 +2403,10 @@ func TestIgnoreCaseTag(t *testing.T) {
 
 func TestInsertOrUpdate(t *testing.T) {
 	RegisterModel(new(User))
-	user := User{UserName: "unique_username133", Status: 1, Password: "o"}
-	user1 := User{UserName: "unique_username133", Status: 2, Password: "o"}
+	tnow := time.Now()
+	tcreated, _ := time.Parse(formatDate, formatDate)
+	user := User{UserName: "unique_username133", Status: 1, Password: "o", Created: tcreated}
+	user1 := User{UserName: "unique_username133", Status: 2, Password: "o", Created: tnow}
 	user2 := User{UserName: "unique_username133", Status: 3, Password: "oo"}
 	dORM.Insert(&user)
 	test := User{UserName: "unique_username133"}
@@ -2424,6 +2426,7 @@ func TestInsertOrUpdate(t *testing.T) {
 	} else {
 		dORM.Read(&test, "user_name")
 		throwFailNow(t, AssertIs(user1.Status, test.Status))
+		throwFailNow(t, AssertIs(test.Created.In(DefaultTimeLoc), user.Created.In(DefaultTimeLoc), testDate)) // Created should not be updated
 	}
 	//test2
 	_, err = dORM.InsertOrUpdate(&user2, "user_name")


### PR DESCRIPTION
When Ormer#InsertOrUpdate actually does update, "auto_now_add" field should be left untouched.
Fixes #3836