### PR TITLE
Use regexp.Compile

### DIFF
--- a/template.go
+++ b/template.go
@@ -262,7 +262,7 @@ func getTplDeep(root string, fs http.FileSystem, file string, parent string, t *
 	}
 	reg, err := regexp.Compile(BConfig.WebConfig.TemplateLeft + "[ ]*template[ ]+\"([^\"]+)\"")
 	if err != nil {
-		logs.Trace("regex failed to compile", err)
+		return nil, [][]string{}, err
 	}
 	allSub := reg.FindAllStringSubmatch(string(data), -1)
 	for _, m := range allSub {
@@ -337,7 +337,7 @@ func _getTemplate(t0 *template.Template, root string, fs http.FileSystem, subMod
 				}
 				reg, err := regexp.Compile(BConfig.WebConfig.TemplateLeft + "[ ]*define[ ]+\"([^\"]+)\"")
 				if err != nil {
-					logs.Trace("regex failed to compile", err)
+					return nil, error
 				}
 				allSub := reg.FindAllStringSubmatch(string(data), -1)
 				for _, sub := range allSub {

--- a/template.go
+++ b/template.go
@@ -260,7 +260,10 @@ func getTplDeep(root string, fs http.FileSystem, file string, parent string, t *
 	if err != nil {
 		return nil, [][]string{}, err
 	}
-	reg := regexp.MustCompile(BConfig.WebConfig.TemplateLeft + "[ ]*template[ ]+\"([^\"]+)\"")
+	reg, err := regexp.Compile(BConfig.WebConfig.TemplateLeft + "[ ]*template[ ]+\"([^\"]+)\"")
+	if err != nil {
+		logs.Trace("regex failed to compile", err)
+	}
 	allSub := reg.FindAllStringSubmatch(string(data), -1)
 	for _, m := range allSub {
 		if len(m) == 2 {
@@ -332,7 +335,10 @@ func _getTemplate(t0 *template.Template, root string, fs http.FileSystem, subMod
 					logs.Trace("template file parse error, not success read file:", err)
 					continue
 				}
-				reg := regexp.MustCompile(BConfig.WebConfig.TemplateLeft + "[ ]*define[ ]+\"([^\"]+)\"")
+				reg, err := regexp.Compile(BConfig.WebConfig.TemplateLeft + "[ ]*define[ ]+\"([^\"]+)\"")
+				if err != nil {
+					logs.Trace("regex failed to compile", err)
+				}
 				allSub := reg.FindAllStringSubmatch(string(data), -1)
 				for _, sub := range allSub {
 					if len(sub) == 2 && sub[1] == m[1] {

--- a/templatefunc.go
+++ b/templatefunc.go
@@ -25,6 +25,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/astaxie/beego/logs"
 )
 
 const (
@@ -55,21 +57,36 @@ func Substr(s string, start, length int) string {
 // HTML2str returns escaping text convert from html.
 func HTML2str(html string) string {
 
-	re := regexp.MustCompile(`\<[\S\s]+?\>`)
+	re, err := regexp.Compile(`\<[\S\s]+?\>`)
+	if err != nil {
+		logs.Trace("Regex failed to compile", err)
+	}
 	html = re.ReplaceAllStringFunc(html, strings.ToLower)
 
 	//remove STYLE
-	re = regexp.MustCompile(`\<style[\S\s]+?\</style\>`)
+	re, err = regexp.Compile(`\<style[\S\s]+?\</style\>`)
+	if err != nil {
+		logs.Trace("Regex failed to compile", err)
+	}
 	html = re.ReplaceAllString(html, "")
 
 	//remove SCRIPT
-	re = regexp.MustCompile(`\<script[\S\s]+?\</script\>`)
+	re, err = regexp.Compile(`\<script[\S\s]+?\</script\>`)
+	if err != nil {
+		logs.Trace("Regex failed to compile", err)
+	}
 	html = re.ReplaceAllString(html, "")
 
-	re = regexp.MustCompile(`\<[\S\s]+?\>`)
+	re, err = regexp.Compile(`\<[\S\s]+?\>`)
+	if err != nil {
+		logs.Trace("Regex failed to compile", err)
+	}
 	html = re.ReplaceAllString(html, "\n")
 
-	re = regexp.MustCompile(`\s{2,}`)
+	re, err = regexp.Compile(`\s{2,}`)
+	if err != nil {
+		logs.Trace("Regex failed to compile", err)
+	}
 	html = re.ReplaceAllString(html, "\n")
 
 	return strings.TrimSpace(html)

--- a/templatefunc.go
+++ b/templatefunc.go
@@ -36,6 +36,12 @@ const (
 	formatDateTimeT = "2006-01-02T15:04:05"
 )
 
+var re1 = regexp.MustCompile(`\<[\S\s]+?\>`)
+var re2 = regexp.MustCompile(`\<style[\S\s]+?\</style\>`)
+var re3 = regexp.MustCompile(`\<script[\S\s]+?\</script\>`)
+var re4 = regexp.MustCompile(`\<[\S\s]+?\>`)
+var re5 = regexp.MustCompile(`\s{2,}`)
+
 // Substr returns the substr from start to length.
 func Substr(s string, start, length int) string {
 	bt := []rune(s)
@@ -57,37 +63,13 @@ func Substr(s string, start, length int) string {
 // HTML2str returns escaping text convert from html.
 func HTML2str(html string) string {
 
-	re, err := regexp.Compile(`\<[\S\s]+?\>`)
-	if err != nil {
-		logs.Trace("Regex failed to compile", err)
-	}
-	html = re.ReplaceAllStringFunc(html, strings.ToLower)
-
+	html = re1.ReplaceAllStringFunc(html, strings.ToLower)
 	//remove STYLE
-	re, err = regexp.Compile(`\<style[\S\s]+?\</style\>`)
-	if err != nil {
-		logs.Trace("Regex failed to compile", err)
-	}
-	html = re.ReplaceAllString(html, "")
-
+	html = re2.ReplaceAllString(html, "")
 	//remove SCRIPT
-	re, err = regexp.Compile(`\<script[\S\s]+?\</script\>`)
-	if err != nil {
-		logs.Trace("Regex failed to compile", err)
-	}
-	html = re.ReplaceAllString(html, "")
-
-	re, err = regexp.Compile(`\<[\S\s]+?\>`)
-	if err != nil {
-		logs.Trace("Regex failed to compile", err)
-	}
-	html = re.ReplaceAllString(html, "\n")
-
-	re, err = regexp.Compile(`\s{2,}`)
-	if err != nil {
-		logs.Trace("Regex failed to compile", err)
-	}
-	html = re.ReplaceAllString(html, "\n")
+	html = re3.ReplaceAllString(html, "")
+	html = re4.ReplaceAllString(html, "\n")
+	html = re5.ReplaceAllString(html, "\n")
 
 	return strings.TrimSpace(html)
 }

--- a/tree.go
+++ b/tree.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/astaxie/beego/context"
 	"github.com/astaxie/beego/utils"
+	"github.com/astaxie/beego/logs"
 )
 
 var (
@@ -171,7 +172,11 @@ func filterTreeWithPrefix(t *Tree, wildcards []string, reg string) {
 		if reg != "" {
 			if l.regexps != nil {
 				l.wildcards = append(wildcards, l.wildcards...)
-				l.regexps = regexp.MustCompile("^" + reg + "/" + strings.Trim(l.regexps.String(), "^$") + "$")
+				var err error
+				l.regexps, err = regexp.Compile("^" + reg + "/" + strings.Trim(l.regexps.String(), "^$") + "$")
+				if err != nil {
+					logs.Trace("Regex failed to compile", err)
+				}
 			} else {
 				for _, v := range l.wildcards {
 					if v == ":splat" {
@@ -180,7 +185,11 @@ func filterTreeWithPrefix(t *Tree, wildcards []string, reg string) {
 						reg = reg + "/([^/]+)"
 					}
 				}
-				l.regexps = regexp.MustCompile("^" + reg + "$")
+				var err error
+				l.regexps, err = regexp.Compile("^" + reg + "$")
+				if err != nil {
+					logs.Trace("Regex failed to compile", err)
+				}
 				l.wildcards = append(wildcards, l.wildcards...)
 			}
 		} else {
@@ -193,7 +202,11 @@ func filterTreeWithPrefix(t *Tree, wildcards []string, reg string) {
 						reg = "([^/]+)/" + reg
 					}
 				}
-				l.regexps = regexp.MustCompile("^" + reg + strings.Trim(l.regexps.String(), "^$") + "$")
+				var err error
+				l.regexps, err = regexp.Compile("^" + reg + strings.Trim(l.regexps.String(), "^$") + "$")
+				if err != nil {
+					logs.Trace("Regex failed to compile", err)
+				}
 			}
 		}
 	}
@@ -281,6 +294,7 @@ func (t *Tree) addseg(segments []string, route interface{}, wildcards []string, 
 		}
 	}
 }
+
 
 // Match router to runObject & params
 func (t *Tree) Match(pattern string, ctx *context.Context) (runObject interface{}) {
@@ -492,7 +506,10 @@ func splitSegment(key string) (bool, []string, string) {
 		var expt []rune
 		var skipnum int
 		params := []string{}
-		reg := regexp.MustCompile(`[a-zA-Z0-9_]+`)
+		reg, err := regexp.Compile(`[a-zA-Z0-9_]+`)
+		if err != nil {
+			logs.Trace("Regex failed to compile", err)
+		}
 		for i, v := range key {
 			if skipnum > 0 {
 				skipnum--

--- a/tree.go
+++ b/tree.go
@@ -26,6 +26,7 @@ import (
 
 var (
 	allowSuffixExt = []string{".json", ".xml", ".html"}
+	splitSegmentReg = regexp.MustCompile(`[a-zA-Z0-9_]+`)
 )
 
 // Tree has three elements: FixRouter/wildcard/leaves
@@ -176,6 +177,7 @@ func filterTreeWithPrefix(t *Tree, wildcards []string, reg string) {
 				l.regexps, err = regexp.Compile("^" + reg + "/" + strings.Trim(l.regexps.String(), "^$") + "$")
 				if err != nil {
 					logs.Trace("Regex failed to compile", err)
+					return
 				}
 			} else {
 				for _, v := range l.wildcards {
@@ -189,6 +191,7 @@ func filterTreeWithPrefix(t *Tree, wildcards []string, reg string) {
 				l.regexps, err = regexp.Compile("^" + reg + "$")
 				if err != nil {
 					logs.Trace("Regex failed to compile", err)
+					return
 				}
 				l.wildcards = append(wildcards, l.wildcards...)
 			}
@@ -206,6 +209,7 @@ func filterTreeWithPrefix(t *Tree, wildcards []string, reg string) {
 				l.regexps, err = regexp.Compile("^" + reg + strings.Trim(l.regexps.String(), "^$") + "$")
 				if err != nil {
 					logs.Trace("Regex failed to compile", err)
+					return
 				}
 			}
 		}
@@ -506,10 +510,6 @@ func splitSegment(key string) (bool, []string, string) {
 		var expt []rune
 		var skipnum int
 		params := []string{}
-		reg, err := regexp.Compile(`[a-zA-Z0-9_]+`)
-		if err != nil {
-			logs.Trace("Regex failed to compile", err)
-		}
 		for i, v := range key {
 			if skipnum > 0 {
 				skipnum--
@@ -544,7 +544,7 @@ func splitSegment(key string) (bool, []string, string) {
 					}
 				}
 				// params only support a-zA-Z0-9
-				if reg.MatchString(string(v)) {
+				if splitSegmentReg.MatchString(string(v)) {
 					param = append(param, v)
 					continue
 				}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -9,6 +9,12 @@ import (
 	"strings"
 )
 
+var reg *regexp.Regexp
+
+func init() {
+	reg = regexp.MustCompile("^\\d*")
+}
+
 // GetGOPATHs returns all paths in GOPATH variable.
 func GetGOPATHs() []string {
 	gopath := os.Getenv("GOPATH")
@@ -19,7 +25,6 @@ func GetGOPATHs() []string {
 }
 
 func compareGoVersion(a, b string) int {
-	reg := regexp.MustCompile("^\\d*")
 
 	a = strings.TrimPrefix(a, "go")
 	b = strings.TrimPrefix(b, "go")


### PR DESCRIPTION
The [regexp.MustCompile function](https://golang.org/pkg/regexp/#MustCompile) panics if the regex fails to compile and should only be used in globals or init functions. Instead use [regexp.Compile](https://golang.org/pkg/regexp/#Compile) and check `err` is nil.