### PR TITLE
Update app.go

### DIFF
--- a/app.go
+++ b/app.go
@@ -130,7 +130,6 @@ func (app *App) Run(mws ...MiddleWare) {
 					if err := server.ListenAndServeMutualTLS(BConfig.Listen.HTTPSCertFile, BConfig.Listen.HTTPSKeyFile, BConfig.Listen.TrustCaFile); err != nil {
 						logs.Critical("ListenAndServeTLS: ", err, fmt.Sprintf("%d", os.Getpid()))
 						time.Sleep(100 * time.Microsecond)
-						endRunning <- true
 					}
 				} else {
 					if BConfig.Listen.AutoTLS {
@@ -145,9 +144,9 @@ func (app *App) Run(mws ...MiddleWare) {
 					if err := server.ListenAndServeTLS(BConfig.Listen.HTTPSCertFile, BConfig.Listen.HTTPSKeyFile); err != nil {
 						logs.Critical("ListenAndServeTLS: ", err, fmt.Sprintf("%d", os.Getpid()))
 						time.Sleep(100 * time.Microsecond)
-						endRunning <- true
 					}
 				}
+				endRunning <- true
 			}()
 		}
 		if BConfig.Listen.EnableHTTP {
@@ -161,8 +160,8 @@ func (app *App) Run(mws ...MiddleWare) {
 				if err := server.ListenAndServe(); err != nil {
 					logs.Critical("ListenAndServe: ", err, fmt.Sprintf("%d", os.Getpid()))
 					time.Sleep(100 * time.Microsecond)
-					endRunning <- true
 				}
+				endRunning <- true
 			}()
 		}
 		<-endRunning


### PR DESCRIPTION
In case of graceful shutdown , beego server never exit. graceful shutdown return nil and endRunning will never become true.