### PR TITLE
fix: session destory

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -270,7 +270,8 @@ func (manager *Manager) SessionDestroy(w http.ResponseWriter, r *http.Request) {
 			Path:     "/",
 			HttpOnly: !manager.config.DisableHTTPOnly,
 			Expires:  expiration,
-			MaxAge:   -1}
+			MaxAge:   -1,
+			Domain:   manager.config.Domain}
 
 		http.SetCookie(w, cookie)
 	}


### PR DESCRIPTION
如果设置cookied的domain是一个二级域名例如：beego.cn
此时调用Manager的SessionDestory，会set一个三级域名例如：test.beego.cn，该cookie是一个MaxAge=-1的cookie
如果用户再登陆，由于存在两个domain不同的cookie，且三级域名的cookie优先级高，会导致无法重新登录