### PR TITLE
fix: generating router file in go module environment and filename gen…

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -77,9 +77,7 @@ func init() {
 }
 
 func parserPkg(pkgRealpath, pkgpath string) error {
-	rep := strings.NewReplacer("\\", "_", "/", "_", ".", "_")
-	commentFilename, _ = filepath.Rel(AppPath, pkgRealpath)
-	commentFilename = commentPrefix + rep.Replace(commentFilename) + ".go"
+	commentFilename = commentPrefix + strings.Join(strings.Split(pkgpath, "/")[1:], "_") + ".go"
 	if !compareFile(pkgRealpath) {
 		logs.Info(pkgRealpath + " no changed")
 		return nil

--- a/router.go
+++ b/router.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"path"
 	"path/filepath"
 	"reflect"
@@ -257,11 +258,21 @@ func (p *ControllerRegister) Include(cList ...ControllerInterface) {
 				panic("you are in dev mode. So please set gopath")
 			}
 			pkgpath := ""
-			for _, wg := range wgopath {
-				wg, _ = filepath.EvalSymlinks(filepath.Join(wg, "src", t.PkgPath()))
-				if utils.FileExists(wg) {
-					pkgpath = wg
-					break
+			goModOn := os.Getenv("GO111MODULE") == "on"
+			if goModOn {
+				pl := strings.Split(t.PkgPath(), "/")
+				var err error
+				pkgpath, err = filepath.Abs(strings.Join(pl[1:], "/"))
+				if err != nil {
+					logs.Error("failed to get controllers real path, Error: ", err)
+				}
+			} else {
+				for _, wg := range wgopath {
+					wg, _ = filepath.EvalSymlinks(filepath.Join(wg, "src", t.PkgPath()))
+					if utils.FileExists(wg) {
+						pkgpath = wg
+						break
+					}
 				}
 			}
 			if pkgpath != "" {


### PR DESCRIPTION
fix: generating router file in go module environment and filename generated incorrctly in some situation.
I've test on my project, and it works on Windows10 with go version 1.13.  In general, what I did are two things:
1. Detect whether the the go mod flag is set and treat differently.
2. Using runtime path maybe improper when the application running inside the IDE like goland, because it doesn't put the target in the project directory. Using the package name will avoid this problem.