### PR TITLE
fixed automatically creat table bug

### DIFF
--- a/orm/models_boot.go
+++ b/orm/models_boot.go
@@ -41,6 +41,7 @@ func registerModel(PrefixOrSuffix string, model interface{}, isPrefix bool) {
 	table := getTableName(val)
 
 	if PrefixOrSuffix != "" {
+		PrefixOrSuffix = nameStrategyMap[nameStrategy](PrefixOrSuffix)
 		if isPrefix {
 			table = PrefixOrSuffix + table
 		} else {


### PR DESCRIPTION
creating table using uppercase prefix, orm.RegisterModelWithPrefix("T_", new(User)) , it is a little problem when I use func o.QueryTable("T_user") , it tell me this table doesn't exist. actually it is in database.