### PR TITLE
Send the request from context rather than the original one to handlers

### DIFF
--- a/router.go
+++ b/router.go
@@ -773,7 +773,7 @@ func (p *ControllerRegister) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 			}
 		} else if routerInfo.routerType == routerTypeHandler {
 			isRunnable = true
-			routerInfo.handler.ServeHTTP(rw, r)
+			routerInfo.handler.ServeHTTP(context.ResponseWriter, context.Request)
 		} else {
 			runRouter = routerInfo.controllerType
 			methodParams = routerInfo.methodParams


### PR DESCRIPTION
The filters may do some changes to the request, such as putting values in the request's context

Signed-off-by: Wenkai Yin <yinw@vmware.com>