### PR TITLE
cache, context, session: add lock to fix inconsistent field protection

### DIFF
--- a/cache/memory.go
+++ b/cache/memory.go
@@ -218,9 +218,12 @@ func (bc *MemoryCache) vacuum() {
 	}
 	for {
 		<-time.After(bc.dur)
+		bc.RLock()
 		if bc.items == nil {
+			bc.RUnlock()
 			return
 		}
+		bc.RUnlock()
 		if keys := bc.expiredKeys(); len(keys) != 0 {
 			bc.clearItems(keys)
 		}

--- a/context/input.go
+++ b/context/input.go
@@ -71,7 +71,9 @@ func (input *BeegoInput) Reset(ctx *Context) {
 	input.CruSession = nil
 	input.pnames = input.pnames[:0]
 	input.pvalues = input.pvalues[:0]
+	input.dataLock.Lock()
 	input.data = nil
+	input.dataLock.Unlock()
 	input.RequestBody = []byte{}
 }
 

--- a/session/sess_cookie.go
+++ b/session/sess_cookie.go
@@ -74,7 +74,9 @@ func (st *CookieSessionStore) SessionID() string {
 
 // SessionRelease Write cookie session to http response cookie
 func (st *CookieSessionStore) SessionRelease(w http.ResponseWriter) {
+	st.lock.Lock()
 	encodedCookie, err := encodeCookie(cookiepder.block, cookiepder.config.SecurityKey, cookiepder.config.SecurityName, st.values)
+	st.lock.Unlock()
 	if err == nil {
 		cookie := &http.Cookie{Name: cookiepder.config.CookieName,
 			Value:    url.QueryEscape(encodedCookie),


### PR DESCRIPTION
Inconsistent Field Protection: A field in a structure is sometimes protected by Mutex, but sometimes unprotected. Developers may forget to protect the field with Mutex, leading to data race.
In cache/memory.go, bc.items is protected by bc.RLock() except for L221.
In contex/input.go, input.data is protected by input.dataLock() except for L74.
In session/sess_cookie.go, st.values is protected by st.lock.Lock() except for L77. 