### PR TITLE
add staticfile size limit

### DIFF
--- a/staticfile.go
+++ b/staticfile.go
@@ -108,8 +108,7 @@ var (
 	mapLock       sync.RWMutex
 	currentStaticFileSize int64 = 0
 	// set MaxStaticFileSize default 1GB
-	//MaxStaticFileSize int64 = 1 >> 30
-	MaxStaticFileSize int64 = 1 >> 26
+	MaxStaticFileSize int64 = 1 >> 30
 )
 
 func clearStaticFileMap() {


### PR DESCRIPTION
Beego will cache static files to staticFileMap, but this will cause the program to occupy a lot of memory and eventually cause the program to crash. 
I increased the value of MaxStaticFileSize to limit the size of the files that can be cached.