### PR TITLE
解决使用grace功能时，主进程不退出的问题、开启https服务时程序崩溃的问题

### DIFF
--- a/app.go
+++ b/app.go
@@ -131,6 +131,9 @@ func (app *App) Run(mws ...MiddleWare) {
 						logs.Critical("ListenAndServeTLS: ", err, fmt.Sprintf("%d", os.Getpid()))
 						time.Sleep(100 * time.Microsecond)
 						endRunning <- true
+					} else {
+						time.Sleep(100 * time.Microsecond)
+						endRunning <- true
 					}
 				} else {
 					if BConfig.Listen.AutoTLS {
@@ -144,6 +147,9 @@ func (app *App) Run(mws ...MiddleWare) {
 					}
 					if err := server.ListenAndServeTLS(BConfig.Listen.HTTPSCertFile, BConfig.Listen.HTTPSKeyFile); err != nil {
 						logs.Critical("ListenAndServeTLS: ", err, fmt.Sprintf("%d", os.Getpid()))
+						time.Sleep(100 * time.Microsecond)
+						endRunning <- true
+					} else {
 						time.Sleep(100 * time.Microsecond)
 						endRunning <- true
 					}
@@ -160,6 +166,9 @@ func (app *App) Run(mws ...MiddleWare) {
 				}
 				if err := server.ListenAndServe(); err != nil {
 					logs.Critical("ListenAndServe: ", err, fmt.Sprintf("%d", os.Getpid()))
+					time.Sleep(100 * time.Microsecond)
+					endRunning <- true
+				} else {
 					time.Sleep(100 * time.Microsecond)
 					endRunning <- true
 				}

--- a/grace/server.go
+++ b/grace/server.go
@@ -308,7 +308,7 @@ func (srv *Server) fork() (err error) {
 	var files = make([]*os.File, len(runningServers))
 	var orderArgs = make([]string, len(runningServers))
 	for _, srvPtr := range runningServers {
-		files[socketPtrOffsetMap[srvPtr.Server.Addr]] = srv.File
+		files[socketPtrOffsetMap[srvPtr.Server.Addr]] = srvPtr.File
 		orderArgs[socketPtrOffsetMap[srvPtr.Server.Addr]] = srvPtr.Server.Addr
 	}
 	log.Println(files)


### PR DESCRIPTION
使用 kill -HUP 发出信号，旧程序处理完剩余的请求不会自动退出。开启https服务时，进行热更新时产生 panic: interface conversion: net.Listener is *tls.listener, not *net.TCPListener, 引发错误的位置在 github.com/astaxie/beego@v1.12.1/grace/server.go:306。