### PR TITLE
Update parser.go

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -500,7 +500,7 @@ func genRouterCode(pkgRealpath string) {
     beego.GlobalControllerRouter["` + k + `"] = append(beego.GlobalControllerRouter["` + k + `"],
         beego.ControllerComments{
             Method: "` + strings.TrimSpace(c.Method) + `",
-            ` + "Router: `" + c.Router + "`" + `,
+            ` + `Router: "` + c.Router + `"` + `,
             AllowHTTPMethods: ` + allmethod + `,
             MethodParams: ` + methodParams + `,
             Filters: ` + filters + `,


### PR DESCRIPTION
修复genRouterCode方法解析  router 注释（// @router） 单双引号引起的bug