### PR TITLE
Add DetectTimeLoc option to orm

### DIFF
--- a/orm/db_alias.go
+++ b/orm/db_alias.go
@@ -212,6 +212,10 @@ func detectTZ(al *alias) {
 	// default use Local
 	al.TZ = DefaultTimeLoc
 
+	if !DetectTimeLoc {
+		return
+	}
+
 	if al.DriverName == "sphinx" {
 		return
 	}

--- a/orm/orm.go
+++ b/orm/orm.go
@@ -76,6 +76,7 @@ var (
 	DefaultRowsLimit = -1
 	DefaultRelsDepth = 2
 	DefaultTimeLoc   = time.Local
+	DetectTimeLoc    = true
 	ErrTxHasBegan    = errors.New("<Ormer.Begin> transaction already begin")
 	ErrTxDone        = errors.New("<Ormer.Commit/Rollback> transaction not begin")
 	ErrMultiRows     = errors.New("<QuerySeter> return multi rows")


### PR DESCRIPTION
这个侦测时区不能关掉的话, 我设置默认时区就没用, 然后就很烦, 没办法强制用我设置的时区.
我又不能改go-sql-driver连接的时区, 因为我写入数据库的要是UTC时间, 其他人要用