### PR TITLE
[Fix-Issue-3991] Fix Read with SQLite not supporting SELECT FOR UPDAT…

### DIFF
--- a/orm/db_sqlite.go
+++ b/orm/db_sqlite.go
@@ -17,6 +17,8 @@ package orm
 import (
 	"database/sql"
 	"fmt"
+	"reflect"
+	"time"
 )
 
 // sqlite operators.
@@ -65,6 +67,11 @@ type dbBaseSqlite struct {
 }
 
 var _ dbBaser = new(dbBaseSqlite)
+
+// override base db read for update behavior as SQlite does not support syntax
+func (d *dbBaseSqlite) Read(q dbQuerier, mi *modelInfo, ind reflect.Value, tz *time.Location, cols []string, isForUpdate bool) error {
+	return d.dbBase.Read(q, mi, ind, tz, cols, false)
+}
 
 // get sqlite operator.
 func (d *dbBaseSqlite) OperatorSQL(operator string) string {

--- a/orm/db_sqlite.go
+++ b/orm/db_sqlite.go
@@ -70,6 +70,9 @@ var _ dbBaser = new(dbBaseSqlite)
 
 // override base db read for update behavior as SQlite does not support syntax
 func (d *dbBaseSqlite) Read(q dbQuerier, mi *modelInfo, ind reflect.Value, tz *time.Location, cols []string, isForUpdate bool) error {
+	if isForUpdate {
+		DebugLog.Println("[WARN] SQLite does not support SELECT FOR UPDATE query, isForUpdate param is ignored and always as false to do the work")
+	}
 	return d.dbBase.Read(q, mi, ind, tz, cols, false)
 }
 


### PR DESCRIPTION
Hi

This is to fix #3991 . As stated in this issue, SQLite does not support `SELECT FOR UPDATE`

The fix is simple that **SQLite** dbBaser instance could just override the `Read` from base. The override should ignores the `isForUpdate` param and constantly use `false` to invoke base call instead.

Please kindly review this MR. 

Thanks.