### PR TITLE
fix httplib PostFile method

### DIFF
--- a/httplib/httplib.go
+++ b/httplib/httplib.go
@@ -407,6 +407,7 @@ func (b *BeegoHTTPRequest) buildURL(paramBody string) {
 			}()
 			b.Header("Content-Type", bodyWriter.FormDataContentType())
 			b.req.Body = ioutil.NopCloser(pr)
+			b.Header("Transfer-Encoding", "chunked")
 			return
 		}
 


### PR DESCRIPTION
PostFile method don't send Content-Length in the head.

It may cause some error  on  other  server.

Use Transfer-Encoding":"chunked" to fixed it ,  or specific the content length.



