### PR TITLE
avoid `panic: send on closed channel` after closing logger.

### DIFF
--- a/logs/console_test.go
+++ b/logs/console_test.go
@@ -16,6 +16,7 @@ package logs
 
 import (
 	"testing"
+	"time"
 )
 
 // Try each log level in decreasing order of priority.
@@ -48,4 +49,16 @@ func TestConsoleNoColor(t *testing.T) {
 	log := NewLogger(100)
 	log.SetLogger("console", `{"color":false}`)
 	testConsoleCalls(log)
+}
+
+// Test console async
+func TestConsoleAsync(t *testing.T) {
+	log := NewLogger(100)
+	log.SetLogger("console")
+	log.Async()
+	//log.Close()
+	testConsoleCalls(log)
+	for len(log.msgChan) != 0 {
+		time.Sleep(1 * time.Millisecond)
+	}
 }

--- a/logs/log.go
+++ b/logs/log.go
@@ -295,7 +295,11 @@ func (bl *BeeLogger) writeMsg(logLevel int, msg string, v ...interface{}) error 
 		lm.level = logLevel
 		lm.msg = msg
 		lm.when = when
-		bl.msgChan <- lm
+		if bl.outputs != nil {
+			bl.msgChan <- lm
+		} else {
+			logMsgPool.Put(lm)
+		}
 	} else {
 		bl.writeToLoggers(when, msg, logLevel)
 	}


### PR DESCRIPTION
In synchronous mode, writing log after closing logger doesn't cause panic.
In asynchronous mode, writing log after closing logger would cause panic.
Instead of causing panic, it's better to drop the msg. 