### PR TITLE
fix graceful bug

### DIFF
--- a/app.go
+++ b/app.go
@@ -130,7 +130,6 @@ func (app *App) Run(mws ...MiddleWare) {
 					if err := server.ListenAndServeMutualTLS(BConfig.Listen.HTTPSCertFile, BConfig.Listen.HTTPSKeyFile, BConfig.Listen.TrustCaFile); err != nil {
 						logs.Critical("ListenAndServeTLS: ", err, fmt.Sprintf("%d", os.Getpid()))
 						time.Sleep(100 * time.Microsecond)
-						endRunning <- true
 					}
 				} else {
 					if BConfig.Listen.AutoTLS {
@@ -145,9 +144,9 @@ func (app *App) Run(mws ...MiddleWare) {
 					if err := server.ListenAndServeTLS(BConfig.Listen.HTTPSCertFile, BConfig.Listen.HTTPSKeyFile); err != nil {
 						logs.Critical("ListenAndServeTLS: ", err, fmt.Sprintf("%d", os.Getpid()))
 						time.Sleep(100 * time.Microsecond)
-						endRunning <- true
 					}
 				}
+				endRunning <- true
 			}()
 		}
 		if BConfig.Listen.EnableHTTP {
@@ -161,8 +160,8 @@ func (app *App) Run(mws ...MiddleWare) {
 				if err := server.ListenAndServe(); err != nil {
 					logs.Critical("ListenAndServe: ", err, fmt.Sprintf("%d", os.Getpid()))
 					time.Sleep(100 * time.Microsecond)
-					endRunning <- true
 				}
+				endRunning <- true
 			}()
 		}
 		<-endRunning

--- a/grace/server.go
+++ b/grace/server.go
@@ -180,7 +180,7 @@ func (srv *Server) ListenAndServeMutualTLS(certFile, keyFile, trustFile string) 
 			log.Println(err)
 			return err
 		}
-		err = process.Kill()
+		err = process.Signal(syscall.SIGTERM)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
当打开graceful 开关时，应用无法ctl+c关闭，kill -HUP pid也无法正常退出旧进程
--

检查原因如下：

当ctrl+c 或是 kill -HUP pid 主进程会收到信号后调用 beego/grace/server.go 第279行的 shutdown()

此时会通过方法尾部的srv.Server.Shutdown(ctx)调用 官方库的net/http/server.go的Shutdown方法

然后进行关闭连接并返回，些时代码有可能会走到下面的代码块
```
if srv.closeIdleConns() {
			return lnerr
}
```
此时的lnerr 是来自srv.closeListenersLocked()  ，正常情况下是 nil 最终一层层向上返回则

beego/grace/server.go的ListenAndServe()的返回值也是nil

在beego/app.go的BConfig.Listen.Graceful 内容块中，只当server.ListenAndServe()返回是非nil时进行

endRunning 写入，导致当server.ListenAndServe() 返回nil时一直卡在 下面的<-endRunning 然后进

程无法退出
