### PR TITLE
Add docker-compose to support running unit test locally

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+docker-compose -f test_docker_compose.yaml up -d
+
+export ORM_DRIVER=mysql
+export TZ=UTC
+export ORM_SOURCE="beego:test@tcp(localhost:13306)/orm_test?charset=utf8"
+
+go test ./...
+
+# clear all container
+docker-compose -f test_docker_compose.yaml down
+
+

--- a/test_docker_compose.yaml
+++ b/test_docker_compose.yaml
@@ -1,0 +1,39 @@
+version: "3.8"
+services:
+  redis:
+    container_name: "beego-redis"
+    image: redis
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+    ports:
+      - "6379:6379"
+
+  mysql:
+    container_name: "beego-mysql"
+    image: mysql:5.7.30
+    ports:
+    - "13306:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=1q2w3e
+      - MYSQL_DATABASE=orm_test
+      - MYSQL_USER=beego
+      - MYSQL_PASSWORD=test
+
+  postgresql:
+    container_name: "beego-postgresql"
+    image: bitnami/postgresql:latest
+    ports:
+    - "5432:5432"
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+  ssdb:
+    container_name: "beego-ssdb"
+    image: wendal/ssdb
+    ports:
+    - "8888:8888"
+  memcache:
+    container_name: "beego-memcache"
+    image: memcached
+    ports:
+    - "11211:11211"
+


### PR DESCRIPTION
Now it's hard to start all components, like mysql, to run unit tests locally. 

I write a docker-compose file and test.sh script to reduce the difficulties for developers to run unit tests locally