### PR TITLE
Allow Healthcheck endpoint return JSON for Kubernetes

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -326,8 +326,8 @@ func healthcheck(rw http.ResponseWriter, r *http.Request) {
 	shouldReturnJSON, _ := strconv.ParseBool(jsonFlag)
 
 	if shouldReturnJSON {
-		responseMap := buildHealthCheckResponseMap(resultList)
-		jsonResponse, err := json.Marshal(responseMap)
+		response := buildHealthCheckResponseList(resultList)
+		jsonResponse, err := json.Marshal(response)
 
 		if err != nil {
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
@@ -344,15 +344,15 @@ func healthcheck(rw http.ResponseWriter, r *http.Request) {
 	writeTemplate(rw, data, healthCheckTpl, defaultScriptsTpl)
 }
 
-func buildHealthCheckResponseMap(resultList *[][]string) []map[string]interface{} {
-	response := make([]map[string]interface{}, len(*resultList))
+func buildHealthCheckResponseList(healthCheckResults *[][]string) []map[string]interface{} {
+	response := make([]map[string]interface{}, len(*healthCheckResults))
 
-	for i, currentResult := range *resultList {
+	for i, healthCheckResult := range *healthCheckResults {
 		currentResultMap := make(map[string]interface{})
 
-		currentResultMap["name"] = currentResult[0]
-		currentResultMap["message"] = currentResult[1]
-		currentResultMap["status"] = currentResult[2]
+		currentResultMap["name"] = healthCheckResult[0]
+		currentResultMap["message"] = healthCheckResult[1]
+		currentResultMap["status"] = healthCheckResult[2]
 
 		response[i] = currentResultMap
 	}

--- a/admin.go
+++ b/admin.go
@@ -71,7 +71,7 @@ func init() {
 // AdminIndex is the default http.Handler for admin module.
 // it matches url pattern "/".
 func adminIndex(rw http.ResponseWriter, _ *http.Request) {
-	execTpl(rw, map[interface{}]interface{}{}, indexTpl, defaultScriptsTpl)
+	writeTemplate(rw, map[interface{}]interface{}{}, indexTpl, defaultScriptsTpl)
 }
 
 // QpsIndex is the http.Handler for writing qps statistics map result info in http.ResponseWriter.
@@ -91,7 +91,7 @@ func qpsIndex(rw http.ResponseWriter, _ *http.Request) {
 		}
 	}
 
-	execTpl(rw, data, qpsTpl, defaultScriptsTpl)
+	writeTemplate(rw, data, qpsTpl, defaultScriptsTpl)
 }
 
 // ListConf is the http.Handler of displaying all beego configuration values as key/value pair.
@@ -128,7 +128,7 @@ func listConf(rw http.ResponseWriter, r *http.Request) {
 		}
 		data["Content"] = content
 		data["Title"] = "Routers"
-		execTpl(rw, data, routerAndFilterTpl, defaultScriptsTpl)
+		writeTemplate(rw, data, routerAndFilterTpl, defaultScriptsTpl)
 	case "filter":
 		var (
 			content = M{
@@ -171,7 +171,7 @@ func listConf(rw http.ResponseWriter, r *http.Request) {
 
 		data["Content"] = content
 		data["Title"] = "Filters"
-		execTpl(rw, data, routerAndFilterTpl, defaultScriptsTpl)
+		writeTemplate(rw, data, routerAndFilterTpl, defaultScriptsTpl)
 	default:
 		rw.Write([]byte("command not support"))
 	}
@@ -279,7 +279,7 @@ func profIndex(rw http.ResponseWriter, r *http.Request) {
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		execJSON(rw, dataJSON)
+		writeJSON(rw, dataJSON)
 		return
 	}
 
@@ -288,7 +288,7 @@ func profIndex(rw http.ResponseWriter, r *http.Request) {
 	if command == "gc summary" {
 		defaultTpl = gcAjaxTpl
 	}
-	execTpl(rw, data, profillingTpl, defaultTpl)
+	writeTemplate(rw, data, profillingTpl, defaultTpl)
 }
 
 // Healthcheck is a http.Handler calling health checking and showing the result.
@@ -340,7 +340,7 @@ func healthcheck(rw http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 		} else {
-			execJSON(rw, JSONResponse)
+			writeJSON(rw, JSONResponse)
 		}
 
 		return
@@ -350,10 +350,10 @@ func healthcheck(rw http.ResponseWriter, r *http.Request) {
 	data["Content"] = content
 	data["Title"] = "Health Check"
 
-	execTpl(rw, data, healthCheckTpl, defaultScriptsTpl)
+	writeTemplate(rw, data, healthCheckTpl, defaultScriptsTpl)
 }
 
-func execJSON(rw http.ResponseWriter, jsonData []byte) {
+func writeJSON(rw http.ResponseWriter, jsonData []byte) {
 	rw.Header().Set("Content-Type", "application/json")
 	rw.Write(jsonData)
 }
@@ -401,10 +401,10 @@ func taskStatus(rw http.ResponseWriter, req *http.Request) {
 	content["Data"] = resultList
 	data["Content"] = content
 	data["Title"] = "Tasks"
-	execTpl(rw, data, tasksTpl, defaultScriptsTpl)
+	writeTemplate(rw, data, tasksTpl, defaultScriptsTpl)
 }
 
-func execTpl(rw http.ResponseWriter, data map[interface{}]interface{}, tpls ...string) {
+func writeTemplate(rw http.ResponseWriter, data map[interface{}]interface{}, tpls ...string) {
 	tmpl := template.Must(template.New("dashboard").Parse(dashboardTpl))
 	for _, tpl := range tpls {
 		tmpl = template.Must(tmpl.Parse(tpl))

--- a/admin_test.go
+++ b/admin_test.go
@@ -97,7 +97,7 @@ func oldMap() M {
 	return m
 }
 
-func TestExecJSON(t *testing.T) {
+func TestWriteJSON(t *testing.T) {
 	t.Log("Testing the adding of JSON to the response")
 
 	w := httptest.NewRecorder()
@@ -105,7 +105,7 @@ func TestExecJSON(t *testing.T) {
 
 	res, _ := json.Marshal(originalBody)
 
-	execJSON(w, res)
+	writeJSON(w, res)
 
 	decodedBody := []int{}
 	err := json.NewDecoder(w.Body).Decode(&decodedBody)

--- a/admin_test.go
+++ b/admin_test.go
@@ -149,6 +149,41 @@ func TestHealthCheckHandlerDefault(t *testing.T) {
 
 }
 
+func TestBuildHealthCheckResponseList(t *testing.T) {
+	healthCheckResults := [][]string{
+		[]string{
+			"error",
+			"Database",
+			"Error occured whie starting the db",
+		},
+		[]string{
+			"success",
+			"Cache",
+			"Cache started successfully",
+		},
+	}
+
+	responseList := buildHealthCheckResponseList(&healthCheckResults)
+
+	if len(responseList) != len(healthCheckResults) {
+		t.Errorf("invalid response map length: got %d want %d",
+			len(responseList), len(healthCheckResults))
+	}
+
+	responseFields := []string{"name", "message", "status"}
+
+	for _, response := range responseList {
+		for _, field := range responseFields {
+			_, ok := response[field]
+			if !ok {
+				t.Errorf("expected %s to be in the response %v", field, response)
+			}
+		}
+
+	}
+
+}
+
 func TestHealthCheckHandlerReturnsJSON(t *testing.T) {
 
 	toolbox.AddHealthCheck("database", &SampleDatabaseCheck{})

--- a/admin_test.go
+++ b/admin_test.go
@@ -187,7 +187,6 @@ func TestBuildHealthCheckResponseList(t *testing.T) {
 func TestHealthCheckHandlerReturnsJSON(t *testing.T) {
 
 	toolbox.AddHealthCheck("database", &SampleDatabaseCheck{})
-	toolbox.AddHealthCheck("cache", &SampleCacheCheck{})
 
 	req, err := http.NewRequest("GET", "/healthcheck?json=true", nil)
 	if err != nil {
@@ -213,11 +212,6 @@ func TestHealthCheckHandlerReturnsJSON(t *testing.T) {
 				"message":"database",
 				"name":"success",
 				"status":"OK"
-			},
-			{
-				"message":"cache",
-				"name":"error",
-				"status":"no cache detected"
 			}
 		]
 	`)

--- a/admin_test.go
+++ b/admin_test.go
@@ -1,7 +1,9 @@
 package beego
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -74,4 +76,28 @@ func oldMap() M {
 	m["BConfig.Log.FileLineNum"] = BConfig.Log.FileLineNum
 	m["BConfig.Log.Outputs"] = BConfig.Log.Outputs
 	return m
+}
+
+func TestExecJSON(t *testing.T) {
+	t.Log("Testing the adding of JSON to the response")
+
+	w := httptest.NewRecorder()
+	originalBody := []int{1, 2, 3}
+
+	res, _ := json.Marshal(originalBody)
+
+	execJSON(w, res)
+
+	decodedBody := []int{}
+	err := json.NewDecoder(w.Body).Decode(&decodedBody)
+
+	if err != nil {
+		t.Fatal("Should be able to decode response body into decodedBody slice")
+	}
+
+	for i := range decodedBody {
+		if decodedBody[i] != originalBody[i] {
+			t.Fatalf("Expected %d but got %d in decoded body slice", originalBody[i], decodedBody[i])
+		}
+	}
 }

--- a/admin_test.go
+++ b/admin_test.go
@@ -187,6 +187,7 @@ func TestBuildHealthCheckResponseList(t *testing.T) {
 func TestHealthCheckHandlerReturnsJSON(t *testing.T) {
 
 	toolbox.AddHealthCheck("database", &SampleDatabaseCheck{})
+	toolbox.AddHealthCheck("cache", &SampleCacheCheck{})
 
 	req, err := http.NewRequest("GET", "/healthcheck?json=true", nil)
 	if err != nil {
@@ -212,6 +213,11 @@ func TestHealthCheckHandlerReturnsJSON(t *testing.T) {
 				"message":"database",
 				"name":"success",
 				"status":"OK"
+			},
+			{
+				"message":"cache",
+				"name":"error",
+				"status":"no cache detected"
 			}
 		]
 	`)
@@ -219,6 +225,11 @@ func TestHealthCheckHandlerReturnsJSON(t *testing.T) {
 	json.Unmarshal(expectedJSONString, &expectedResponseBody)
 
 	json.Unmarshal(w.Body.Bytes(), &decodedResponseBody)
+
+	if len(expectedResponseBody) != len(decodedResponseBody) {
+		t.Errorf("invalid response map length: got %d want %d",
+			len(decodedResponseBody), len(expectedResponseBody))
+	}
 
 	if !reflect.DeepEqual(decodedResponseBody, expectedResponseBody) {
 		t.Errorf("handler returned unexpected body: got %v want %v",

--- a/admin_test.go
+++ b/admin_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -111,7 +112,7 @@ func TestWriteJSON(t *testing.T) {
 	err := json.NewDecoder(w.Body).Decode(&decodedBody)
 
 	if err != nil {
-		t.Fatal("Should be able to decode response body into decodedBody slice")
+		t.Fatal("Could not decode response body into slice.")
 	}
 
 	for i := range decodedBody {
@@ -168,9 +169,31 @@ func TestHealthCheckHandlerReturnsJSON(t *testing.T) {
 			status, http.StatusOK)
 	}
 
-	expectedResponseBody := `[{"message":"database","name":"success","status":"OK"},{"message":"cache","name":"error","status":"no cache detected"}]`
-	if w.Body.String() != expectedResponseBody {
+	decodedResponseBody := []map[string]interface{}{}
+	expectedResponseBody := []map[string]interface{}{}
+
+	expectedJSONString := []byte(`
+		[
+			{
+				"message":"database",
+				"name":"success",
+				"status":"OK"
+			},
+			{
+				"message":"cache",
+				"name":"error",
+				"status":"no cache detected"
+			}
+		]
+	`)
+
+	json.Unmarshal(expectedJSONString, &expectedResponseBody)
+
+	json.Unmarshal(w.Body.Bytes(), &decodedResponseBody)
+
+	if !reflect.DeepEqual(decodedResponseBody, expectedResponseBody) {
 		t.Errorf("handler returned unexpected body: got %v want %v",
-			w.Body.String(), expectedResponseBody)
+			decodedResponseBody, expectedResponseBody)
 	}
+
 }


### PR DESCRIPTION
This pull request allows the `/healthcheck` endpoint to be able to return JSON if a JSON flag is specified as a query string `/healthcheck?json=true`. It also includes unit tests for the changes.

The tests which check the regular healthcheck endpoint without the `json` query string could definitely be improved by more powerful introspection of the template which is generated. Perhaps checking against the classes generated in the HTML template?






