### PR TITLE
Fix JSON log formatting

### DIFF
--- a/logs/accesslog.go
+++ b/logs/accesslog.go
@@ -16,9 +16,9 @@ package logs
 
 import (
 	"bytes"
-	"strings"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -42,6 +42,7 @@ type AccessLogRecord struct {
 	HTTPReferrer   string        `json:"http_referrer"`
 	HTTPUserAgent  string        `json:"http_user_agent"`
 	RemoteUser     string        `json:"remote_user"`
+	LineReference  string        `json:"line_reference"`
 }
 
 func (r *AccessLogRecord) json() ([]byte, error) {

--- a/logs/logger.go
+++ b/logs/logger.go
@@ -32,10 +32,18 @@ func newLogWriter(wr io.Writer) *logWriter {
 
 func (lg *logWriter) writeln(when time.Time, msg string) (int, error) {
 	lg.Lock()
-	h, _, _ := formatTimeHeader(when)
-	n, err := lg.writer.Write(append(append(h, msg...), '\n'))
-	lg.Unlock()
-	return n, err
+	if when.IsZero() {
+		// When the time is Zero it means it should be printed in JSON
+		// format e.g without time printed before the JSON formatted msg
+		n, err := lg.writer.Write(append([]byte(msg), '\n'))
+		lg.Unlock()
+		return n, err
+	} else {
+		h, _, _ := formatTimeHeader(when)
+		n, err := lg.writer.Write(append(append(h, msg...), '\n'))
+		lg.Unlock()
+		return n, err
+	}
 }
 
 const (


### PR DESCRIPTION
Fixed https://github.com/astaxie/beego/issues/3769

Now when the `AccessLogsFormat` is set to `JSON_FORMAT` is prints the logs in proper JSON format without time and line number before inplain text.

A full test for this would involve spinning up a new api so I'm not sure it would be the best idea. To test you can run `bee api testapi` and the `main.go` would be 
```go
package main

import (
	_ "testapi/routers"

	"github.com/astaxie/beego"
)

func main() {
	if beego.BConfig.RunMode == "dev" {
		beego.BConfig.WebConfig.DirectoryIndex = true
		beego.BConfig.WebConfig.StaticDir["/swagger"] = "swagger"
	}
	beego.BConfig.Log.AccessLogs = true
	beego.BConfig.Log.AccessLogsFormat = "JSON_FORMAT"
	beego.SetLogger("file", `{"filename":"test.json"}`)

	beego.Run()
}

```

which gives the desired output for requests (this is formatted just to look nice): 
```
{
    "remote_addr": "::1",
    "request_time": "2020-07-08T18:14:03.305436912+01:00",
    "request_method": "GET",
    "request": "GET / HTTP/1.1",
    "server_protocol": "HTTP/1.1",
    "host": "localhost:8080",
    "status": 404,
    "body_bytes_sent": 0,
    "elapsed_time": 243366,
    "http_referrer": "",
    "http_user_agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36",
    "remote_user": "",
    "line_reference": "server.go:2807"
}
```

I initially tried to add a `logFormat` parameter to the functions to differentiate between the two formats but it wasn't going to work due to complications. Instead what it does it it tries to decode the message into a JSON struct. If it can then it means it is in `JSON_FORMAT` and it goes on as it should. If it cannot decode into a JSON struct then it is in `APACHE_FORMAT`

```go
tempStruct := &AccessLogRecord{}
	jsonDecodeError := json.Unmarshal([]byte(msg), tempStruct)
	if jsonDecodeError == nil {
		logFormat = "JSON_FORMAT"
	}
```

Also to distinguish the two it sets the `when` parameter for `JSON_FORMAT` to an empty time struct (`time.Time{}`). Later before printing to the console it's checked. If [when.isZero()](https://golang.org/pkg/time/#Time.IsZero) it knows it's in `JSON_FORMAT` and it therefore does not print it before.