### PR TITLE
Fix concurrent issue of context/input Query method

### DIFF
--- a/context/input.go
+++ b/context/input.go
@@ -334,11 +334,13 @@ func (input *BeegoInput) Query(key string) string {
 	}
 	if input.Context.Request.Form == nil {
 		input.dataLock.Lock()
-		defer input.dataLock.Unlock()
 		if input.Context.Request.Form == nil {
 			input.Context.Request.ParseForm()
 		}
+		input.dataLock.Unlock()
 	}
+	input.dataLock.RLock()
+	defer input.dataLock.RUnlock()
 	return input.Context.Request.Form.Get(key)
 }
 

--- a/context/input.go
+++ b/context/input.go
@@ -333,7 +333,11 @@ func (input *BeegoInput) Query(key string) string {
 		return val
 	}
 	if input.Context.Request.Form == nil {
-		input.Context.Request.ParseForm()
+		input.dataLock.Lock()
+		defer input.dataLock.Unlock()
+		if input.Context.Request.Form == nil {
+			input.Context.Request.ParseForm()
+		}
 	}
 	return input.Context.Request.Form.Get(key)
 }

--- a/context/input_test.go
+++ b/context/input_test.go
@@ -205,3 +205,13 @@ func TestParams(t *testing.T) {
 	}
 
 }
+func BenchmarkQuery(b *testing.B) {
+	beegoInput := NewInput()
+	beegoInput.Context = NewContext()
+	beegoInput.Context.Request, _ = http.NewRequest("POST", "http://www.example.com/?q=foo", nil)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			beegoInput.Query("q")
+		}
+	})
+}


### PR DESCRIPTION
Fix https://github.com/astaxie/beego/issues/3686

context/input的Query方法有类似单线程建singleton的问题，
在并发下可能出现同时间不同单线调用`ParseForm()`和`Get()`，
引致issue中的 concurrent map read and map write / concurrent map writes。

Before:
```
$ go test -v -bench=.
goos: darwin
goarch: amd64
pkg: github.com/astaxie/beego/context
BenchmarkQuery
fatal error: concurrent map read and map write
fatal error: concurrent map read and map write
fatal error: concurrent map read and map write
fatal error: concurrent map read and map write
fatal error: concurrent map read and map write
...
goroutine 82 [running]:
runtime.throw(0x14c741d, 0x21)
        /usr/local/go/src/runtime/panic.go:1116 +0x72 fp=0xc00005ce98 sp=0xc00005ce68 pc=0x1035e52
runtime.mapaccess1_faststr(0x1480b00, 0xc00009d1a0, 0x14ba0d2, 0x1, 0x0)
        /usr/local/go/src/runtime/map_faststr.go:21 +0x43c fp=0xc00005cf08 sp=0xc00005ce98 pc=0x1014adc
net/url.Values.Get(...)
        /usr/local/go/src/net/url/url.go:838
github.com/astaxie/beego/context.(*BeegoInput).Query(0xc0000ca280, 0x14ba0d2, 0x1, 0x14c528e, 0x3)
        /Users/playhing/Documents/beego/context/input.go:338 +0xc0 fp=0xc00005cf40 sp=0xc00005cf08 pc=0x13d8750
github.com/astaxie/beego/context.BenchmarkQuery.func1(0xc00000e040)
        /Users/playhing/Documents/beego/context/input_test.go:214 +0x4f fp=0xc00005cf80 sp=0xc00005cf40 pc=0x13e3fdf
testing.(*B).RunParallel.func1(0xc0000260b0, 0xc0000260a8, 0xc0000260a0, 0xc00010a380, 0xc000098200)
        /usr/local/go/src/testing/benchmark.go:763 +0x99 fp=0xc00005cfb8 sp=0xc00005cf80 pc=0x1103e69
runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:1373 +0x1 fp=0xc00005cfc0 sp=0xc00005cfb8 pc=0x1067cf1
created by testing.(*B).RunParallel
        /usr/local/go/src/testing/benchmark.go:756 +0x192
```
After the fix:
```
$ go test -v -bench=.
BenchmarkQuery
BenchmarkQuery-8        342745783                3.47 ns/op
PASS
```