### PR TITLE
Refactor RegisterDatabase

### DIFF
--- a/orm/orm_alias_adapt_test.go
+++ b/orm/orm_alias_adapt_test.go
@@ -1,0 +1,46 @@
+// Copyright 2020 beego-dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orm
+
+import (
+	"os"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/lib/pq"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+)
+
+var DBARGS = struct {
+	Driver string
+	Source string
+	Debug  string
+}{
+	os.Getenv("ORM_DRIVER"),
+	os.Getenv("ORM_SOURCE"),
+	os.Getenv("ORM_DEBUG"),
+}
+
+func TestRegisterDataBase(t *testing.T) {
+	err := RegisterDataBase("test-adapt1", DBARGS.Driver, DBARGS.Source)
+	assert.Nil(t, err)
+	err = RegisterDataBase("test-adapt2", DBARGS.Driver, DBARGS.Source, 20)
+	assert.Nil(t, err)
+	err = RegisterDataBase("test-adapt3", DBARGS.Driver, DBARGS.Source, 20, 300)
+	assert.Nil(t, err)
+	err = RegisterDataBase("test-adapt4", DBARGS.Driver, DBARGS.Source, 20, 300, 60*1000)
+	assert.Nil(t, err)
+}

--- a/pkg/common/kv.go
+++ b/pkg/common/kv.go
@@ -1,0 +1,69 @@
+// Copyright 2020 beego-dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+// KV is common structure to store key-value data.
+// when you need something like Pair, you can use this
+type KV struct {
+	Key   interface{}
+	Value interface{}
+}
+
+// KVs will store KV collection as map
+type KVs struct {
+	kvs map[interface{}]interface{}
+}
+
+// GetValueOr check whether this contains the key,
+// if the key not found, the default value will be return
+func (kvs *KVs) GetValueOr(key interface{}, defValue interface{}) interface{} {
+	v, ok := kvs.kvs[key]
+	if ok {
+		return v
+	}
+	return defValue
+}
+
+// Contains will check whether contains the key
+func (kvs *KVs) Contains(key interface{}) bool {
+	_, ok := kvs.kvs[key]
+	return ok
+}
+
+// IfContains is a functional API that if the key is in KVs, the action will be invoked
+func (kvs *KVs) IfContains(key interface{}, action func(value interface{})) *KVs {
+	v, ok := kvs.kvs[key]
+	if ok {
+		action(v)
+	}
+	return kvs
+}
+
+// Put store the value
+func (kvs *KVs) Put(key interface{}, value interface{}) *KVs {
+	kvs.kvs[key] = value
+	return kvs
+}
+
+// NewKVs will create the *KVs instance
+func NewKVs(kvs ...KV) *KVs {
+	res := &KVs{
+		kvs: make(map[interface{}]interface{}, len(kvs)),
+	}
+	for _, kv := range kvs {
+		res.kvs[kv.Key] = kv.Value
+	}
+	return res
+}

--- a/pkg/common/kv_test.go
+++ b/pkg/common/kv_test.go
@@ -1,0 +1,40 @@
+// Copyright 2020 beego-dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKVs(t *testing.T) {
+	key := "my-key"
+	kvs := NewKVs(KV{
+		Key: key,
+		Value: 12,
+	})
+
+	assert.True(t, kvs.Contains(key))
+
+	kvs.IfContains(key, func(value interface{}) {
+		kvs.Put("my-key1", "")
+	})
+
+	assert.True(t, kvs.Contains("my-key1"))
+
+	v := kvs.GetValueOr(key, 13)
+	assert.Equal(t, 12, v)
+}

--- a/pkg/orm/constant.go
+++ b/pkg/orm/constant.go
@@ -1,0 +1,21 @@
+// Copyright 2020 beego-dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orm
+
+const (
+	MaxIdleConnsKey    = "MaxIdleConns"
+	MaxOpenConnsKey    = "MaxOpenConns"
+	ConnMaxLifetimeKey = "ConnMaxLifetime"
+)

--- a/pkg/orm/db_alias_test.go
+++ b/pkg/orm/db_alias_test.go
@@ -1,0 +1,44 @@
+// Copyright 2020 beego-dev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orm
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/astaxie/beego/pkg/common"
+)
+
+func TestRegisterDataBase(t *testing.T) {
+	err := RegisterDataBase("test-params", DBARGS.Driver, DBARGS.Source, common.KV{
+		Key:   MaxIdleConnsKey,
+		Value: 20,
+	}, common.KV{
+		Key:   MaxOpenConnsKey,
+		Value: 300,
+	}, common.KV{
+		Key:   ConnMaxLifetimeKey,
+		Value: time.Minute,
+	})
+	assert.Nil(t, err)
+
+	al := getDbAlias("test-params")
+	assert.NotNil(t, al)
+	assert.Equal(t, al.MaxIdleConns, 20)
+	assert.Equal(t, al.MaxOpenConns, 300)
+	assert.Equal(t, al.ConnMaxLifetime, time.Minute)
+}

--- a/pkg/orm/models_test.go
+++ b/pkg/orm/models_test.go
@@ -27,6 +27,8 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	// As tidb can't use go get, so disable the tidb testing now
 	// _ "github.com/pingcap/tidb"
+
+	"github.com/astaxie/beego/pkg/common"
 )
 
 // A slice string field.
@@ -487,7 +489,10 @@ func init() {
 		os.Exit(2)
 	}
 
-	err := RegisterDataBase("default", DBARGS.Driver, DBARGS.Source, 20)
+	err := RegisterDataBase("default", DBARGS.Driver, DBARGS.Source, common.KV{
+		Key:MaxIdleConnsKey,
+		Value:20,
+	})
 
 	if err != nil{
 		panic(fmt.Sprintf("can not register database: %v", err))


### PR DESCRIPTION
In old API,  the `RegisterDatabase` API is:
```go
func RegisterDataBase(aliasName, driverName, dataSource string, params ...int) error {}
```
The last parameter `params` only accept `int`. But in general, we have many optional configurations, their types are different, and the `params...int` declaration is not convenient for users.

The new API is :
``` go
func RegisterDataBase(aliasName, driverName, dataSource string, params ...common.KV) error {}
```