### PR TITLE
Add Content-length field for logging

### DIFF
--- a/router.go
+++ b/router.go
@@ -1046,7 +1046,7 @@ func LogAccess(ctx *beecontext.Context, startTime *time.Time, statusCode int) {
 		HTTPReferrer:   r.Header.Get("Referer"),
 		HTTPUserAgent:  r.Header.Get("User-Agent"),
 		RemoteUser:     r.Header.Get("Remote-User"),
-		BodyBytesSent:  0, // @todo this one is missing!
+		BodyBytesSent:  r.ContentLength,
 	}
 	logs.AccessLog(record, BConfig.Log.AccessLogsFormat)
 }


### PR DESCRIPTION
https://github.com/astaxie/beego/blob/7a48fbb69846515d9dc3627096590f2b7b2a1bca/router.go#L1049

Saw the todo message and thought including the field wouldn't be too hard. The [request type](https://golang.org/pkg/net/http/#Request) has a `ContentLength` field for this. Not sure if this is right as the fix was quite easy but I assume that whoever wrote the todo didn't know about this field.

Run this code and you'll see in the logging that the correct content length (body_bytes_sent) is being sent

```
curl -X GET "http://localhost:8080/download" -d "hello=world"                    
```


```go
package main

import (
	"github.com/astaxie/beego"
)

func main() {
	ctrl := &MainController{}
	beego.Router("/yuppa", ctrl, "get:Yuppa")
	beego.BConfig.Log.AccessLogs = true
	beego.BConfig.Log.AccessLogsFormat = "JSON_FORMAT"
	beego.Run()
}

type MainController struct {
	beego.Controller
}

func (ctrl *MainController) Yuppa() {
	output := ctrl.Ctx.Output
	output.Header("Content-Type", "application/json")
	ctrl.Ctx.WriteString("Golang is a great language")
}

```

```
cathal@gomei: $ go run main.go
2020/07/20 21:21:39.492 [I]  http server Running on http://:8080
2020/07/20 21:21:40.581  {"remote_addr":"127.0.0.1","request_time":"0001-01-01T00:00:00Z","request_method":"GET","request":"GET /download HTTP/1.1","server_protocol":"HTTP/1.1","host":"localhost:8080","status":404,"body_bytes_sent":11,"elapsed_time":0,"http_referrer":"","http_user_agent":"curl/7.58.0","remote_user":""}
```