### PR TITLE
add comment router path configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/wendal/errors v0.0.0-20130201093226-f66c77a7882b // indirect
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
+	golang.org/x/tools v0.0.0-20200117065230-39095c1d176c
 	google.golang.org/grpc v1.31.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8
 )

--- a/pkg/beego.go
+++ b/pkg/beego.go
@@ -97,6 +97,7 @@ func initBeforeHTTPRun() {
 		registerTemplate,
 		registerAdmin,
 		registerGzip,
+		registerCommentRouter,
 	)
 
 	for _, hk := range hooks {

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -86,6 +86,7 @@ type WebConfig struct {
 	TemplateLeft           string
 	TemplateRight          string
 	ViewsPath              string
+	CommentRouterPath      string
 	EnableXSRF             bool
 	XSRFKey                string
 	XSRFExpire             int
@@ -245,6 +246,7 @@ func newBConfig() *Config {
 			TemplateLeft:           "{{",
 			TemplateRight:          "}}",
 			ViewsPath:              "views",
+			CommentRouterPath:      "controllers",
 			EnableXSRF:             false,
 			XSRFKey:                "beegoxsrf",
 			XSRFExpire:             0,

--- a/pkg/hooks.go
+++ b/pkg/hooks.go
@@ -102,3 +102,13 @@ func registerGzip() error {
 	}
 	return nil
 }
+
+func registerCommentRouter() error {
+	if BConfig.RunMode == DEV {
+		if err := parserPkg(filepath.Join(WorkPath, BConfig.WebConfig.CommentRouterPath)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/router.go
+++ b/pkg/router.go
@@ -18,9 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"path"
-	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -257,45 +255,6 @@ func (p *ControllerRegister) addToRouter(method, pattern string, r *ControllerIn
 // Include only when the Runmode is dev will generate router file in the router/auto.go from the controller
 // Include(&BankAccount{}, &OrderController{},&RefundController{},&ReceiptController{})
 func (p *ControllerRegister) Include(cList ...ControllerInterface) {
-	if BConfig.RunMode == DEV {
-		skip := make(map[string]bool, 10)
-		wgopath := utils.GetGOPATHs()
-		go111module := os.Getenv(`GO111MODULE`)
-		for _, c := range cList {
-			reflectVal := reflect.ValueOf(c)
-			t := reflect.Indirect(reflectVal).Type()
-			// for go modules
-			if go111module == `on` {
-				pkgpath := filepath.Join(WorkPath, "..", t.PkgPath())
-				if utils.FileExists(pkgpath) {
-					if pkgpath != "" {
-						if _, ok := skip[pkgpath]; !ok {
-							skip[pkgpath] = true
-							parserPkg(pkgpath, t.PkgPath())
-						}
-					}
-				}
-			} else {
-				if len(wgopath) == 0 {
-					panic("you are in dev mode. So please set gopath")
-				}
-				pkgpath := ""
-				for _, wg := range wgopath {
-					wg, _ = filepath.EvalSymlinks(filepath.Join(wg, "src", t.PkgPath()))
-					if utils.FileExists(wg) {
-						pkgpath = wg
-						break
-					}
-				}
-				if pkgpath != "" {
-					if _, ok := skip[pkgpath]; !ok {
-						skip[pkgpath] = true
-						parserPkg(pkgpath, t.PkgPath())
-					}
-				}
-			}
-		}
-	}
 	for _, c := range cList {
 		reflectVal := reflect.ValueOf(c)
 		t := reflect.Indirect(reflectVal).Type()


### PR DESCRIPTION
Add an option to config the comment router directory to solve the probelm with comment router generation when using go module. See the discussion in #4093 