### PR TITLE
添加 BConfig.Listen.ClientAuth 字段及处理逻辑

### DIFF
--- a/app.go
+++ b/app.go
@@ -195,10 +195,15 @@ func (app *App) Run(mws ...MiddleWare) {
 					return
 				}
 				pool.AppendCertsFromPEM(data)
-				app.Server.TLSConfig = &tls.Config{
+				tlsConfig := tls.Config{
 					ClientCAs:  pool,
-					ClientAuth: tls.RequireAndVerifyClientCert,
 				}
+				if string(BConfig.Listen.ClientAuth) != "" {
+					tslConfig.ClientAuth = BConfig.Listen.ClientAuth
+				} else {
+					tslConfig.ClientAuth = tls.RequireAndVerifyClientCert
+				}
+				app.Server.TLSConfig = &tslConfig
 			}
 			if err := app.Server.ListenAndServeTLS(BConfig.Listen.HTTPSCertFile, BConfig.Listen.HTTPSKeyFile); err != nil {
 				logs.Critical("ListenAndServeTLS: ", err)

--- a/app.go
+++ b/app.go
@@ -202,7 +202,7 @@ func (app *App) Run(mws ...MiddleWare) {
 				if string(BConfig.Listen.ClientAuth) != "" {
 					tlsConfig.ClientAuth = BConfig.Listen.ClientAuth
 				}
-				app.Server.TLSConfig = &tslConfig
+				app.Server.TLSConfig = &tlsConfig
 			}
 			if err := app.Server.ListenAndServeTLS(BConfig.Listen.HTTPSCertFile, BConfig.Listen.HTTPSKeyFile); err != nil {
 				logs.Critical("ListenAndServeTLS: ", err)

--- a/app.go
+++ b/app.go
@@ -197,11 +197,10 @@ func (app *App) Run(mws ...MiddleWare) {
 				pool.AppendCertsFromPEM(data)
 				tlsConfig := tls.Config{
 					ClientCAs:  pool,
+					ClientAuth: tls.RequireAndVerifyClientCert,
 				}
 				if string(BConfig.Listen.ClientAuth) != "" {
 					tslConfig.ClientAuth = BConfig.Listen.ClientAuth
-				} else {
-					tslConfig.ClientAuth = tls.RequireAndVerifyClientCert
 				}
 				app.Server.TLSConfig = &tslConfig
 			}

--- a/app.go
+++ b/app.go
@@ -195,14 +195,10 @@ func (app *App) Run(mws ...MiddleWare) {
 					return
 				}
 				pool.AppendCertsFromPEM(data)
-				tlsConfig := tls.Config{
+				app.Server.TLSConfig = &tls.Config{
 					ClientCAs:  pool,
-					ClientAuth: tls.RequireAndVerifyClientCert,
+					ClientAuth: BConfig.Listen.ClientAuth,
 				}
-				if string(BConfig.Listen.ClientAuth) != "" {
-					tlsConfig.ClientAuth = BConfig.Listen.ClientAuth
-				}
-				app.Server.TLSConfig = &tlsConfig
 			}
 			if err := app.Server.ListenAndServeTLS(BConfig.Listen.HTTPSCertFile, BConfig.Listen.HTTPSKeyFile); err != nil {
 				logs.Critical("ListenAndServeTLS: ", err)

--- a/app.go
+++ b/app.go
@@ -200,7 +200,7 @@ func (app *App) Run(mws ...MiddleWare) {
 					ClientAuth: tls.RequireAndVerifyClientCert,
 				}
 				if string(BConfig.Listen.ClientAuth) != "" {
-					tslConfig.ClientAuth = BConfig.Listen.ClientAuth
+					tlsConfig.ClientAuth = BConfig.Listen.ClientAuth
 				}
 				app.Server.TLSConfig = &tslConfig
 			}

--- a/config.go
+++ b/config.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"crypto/tls"
 
 	"github.com/astaxie/beego/config"
 	"github.com/astaxie/beego/context"
@@ -65,6 +66,7 @@ type Listen struct {
 	HTTPSCertFile     string
 	HTTPSKeyFile      string
 	TrustCaFile       string
+	ClientAuth        tls.ClientAuthType
 	EnableAdmin       bool
 	AdminAddr         string
 	AdminPort         int
@@ -234,6 +236,7 @@ func newBConfig() *Config {
 			AdminPort:     8088,
 			EnableFcgi:    false,
 			EnableStdIo:   false,
+			ClientAuth:    tls.VerifyClientCertIfGiven,
 		},
 		WebConfig: WebConfig{
 			AutoRender:             true,

--- a/config.go
+++ b/config.go
@@ -236,7 +236,7 @@ func newBConfig() *Config {
 			AdminPort:     8088,
 			EnableFcgi:    false,
 			EnableStdIo:   false,
-			ClientAuth:    tls.VerifyClientCertIfGiven,
+			ClientAuth:    tls.RequireAndVerifyClientCert,
 		},
 		WebConfig: WebConfig{
 			AutoRender:             true,


### PR DESCRIPTION
添加 BConfig.Listen.ClientAuth 字段及处理逻辑，提供对外可配置的客户端证书认证策略，避免写死在源码中。具体情况可看#4110