### PR TITLE
fix CI fail for connection log test

### DIFF
--- a/logs/conn_test.go
+++ b/logs/conn_test.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"os"
 	"testing"
+	"time"
 )
 
 // ConnTCPListener takes a TCP listener and accepts n TCP connections
@@ -73,7 +74,7 @@ func TestReconnect(t *testing.T) {
 	select {
 	case second := <-newConns:
 		second.Close()
-	default:
+	case <-time.After(5 * time.Second):
 		t.Error("Did not reconnect")
 	}
 }


### PR DESCRIPTION
I notice that the CI fail sometimes because of log module's `TestReconnect` test case. This pr fix it.