### PR TITLE
fix issue #3776

### DIFF
--- a/pkg/orm/models_test.go
+++ b/pkg/orm/models_test.go
@@ -54,18 +54,24 @@ func (e *SliceStringField) FieldType() int {
 }
 
 func (e *SliceStringField) SetRaw(value interface{}) error {
-	switch d := value.(type) {
-	case []string:
-		e.Set(d)
-	case string:
-		if len(d) > 0 {
-			parts := strings.Split(d, ",")
+	f := func(str string) {
+		if len(str) > 0 {
+			parts := strings.Split(str, ",")
 			v := make([]string, 0, len(parts))
 			for _, p := range parts {
 				v = append(v, strings.TrimSpace(p))
 			}
 			e.Set(v)
 		}
+	}
+
+	switch d := value.(type) {
+	case []string:
+		e.Set(d)
+	case string:
+		f(d)
+	case []byte:
+		f(string(d))
 	default:
 		return fmt.Errorf("<SliceStringField.SetRaw> unknown value `%v`", value)
 	}
@@ -97,6 +103,8 @@ func (e *JSONFieldTest) SetRaw(value interface{}) error {
 	switch d := value.(type) {
 	case string:
 		return json.Unmarshal([]byte(d), e)
+	case []byte:
+		return json.Unmarshal(d, e)
 	default:
 		return fmt.Errorf("<JSONField.SetRaw> unknown value `%v`", value)
 	}

--- a/pkg/orm/orm_raw.go
+++ b/pkg/orm/orm_raw.go
@@ -17,6 +17,7 @@ package orm
 import (
 	"database/sql"
 	"fmt"
+	"github.com/pkg/errors"
 	"reflect"
 	"time"
 )
@@ -369,7 +370,15 @@ func (o *rawSet) QueryRow(containers ...interface{}) error {
 							field.Set(mf)
 							field = mf.Elem().FieldByIndex(fi.relModelInfo.fields.pk.fieldIndex)
 						}
-						o.setFieldValue(field, value)
+						if fi.isFielder {
+							fd := field.Addr().Interface().(Fielder)
+							err := fd.SetRaw(value)
+							if err != nil {
+								return errors.Errorf("set raw error:%s", err)
+							}
+						} else {
+							o.setFieldValue(field, value)
+						}
 					}
 				}
 			} else {
@@ -510,7 +519,15 @@ func (o *rawSet) QueryRows(containers ...interface{}) (int64, error) {
 							field.Set(mf)
 							field = mf.Elem().FieldByIndex(fi.relModelInfo.fields.pk.fieldIndex)
 						}
-						o.setFieldValue(field, value)
+						if fi.isFielder {
+							fd := field.Addr().Interface().(Fielder)
+							err := fd.SetRaw(value)
+							if err != nil {
+								return 0, errors.Errorf("set raw error:%s", err)
+							}
+						} else {
+							o.setFieldValue(field, value)
+						}
 					}
 				}
 			} else {

--- a/pkg/orm/orm_test.go
+++ b/pkg/orm/orm_test.go
@@ -777,6 +777,20 @@ func TestCustomField(t *testing.T) {
 
 	throwFailNow(t, AssertIs(user.Extra.Name, "beego"))
 	throwFailNow(t, AssertIs(user.Extra.Data, "orm"))
+
+	var users []User
+	Q := dDbBaser.TableQuote()
+	n, err := dORM.Raw(fmt.Sprintf("SELECT * FROM %suser%s where id=?", Q, Q), 2).QueryRows(&users)
+	throwFailNow(t, err)
+	throwFailNow(t, AssertIs(n, 1))
+	throwFailNow(t, AssertIs(users[0].Extra.Name, "beego"))
+	throwFailNow(t, AssertIs(users[0].Extra.Data, "orm"))
+
+	user = User{}
+	err = dORM.Raw(fmt.Sprintf("SELECT * FROM %suser%s where id=?", Q, Q), 2).QueryRow(&user)
+	throwFailNow(t, err)
+	throwFailNow(t, AssertIs(user.Extra.Name, "beego"))
+	throwFailNow(t, AssertIs(user.Extra.Data, "orm"))
 }
 
 func TestExpr(t *testing.T) {
@@ -2543,4 +2557,3 @@ func TestStrPkInsert(t *testing.T) {
 	throwFailNow(t, AssertIs(err, nil))
 	throwFailNow(t, AssertIs(vForTesting.Value, value))
 }
-


### PR DESCRIPTION
fixes #3776

fix the bug that `Fielder`'s `SetRaw` is not called when calling `orm.Raw()` to query from database