### PR TITLE
Refactor orm filter

### DIFF
--- a/githook/pre-commit
+++ b/githook/pre-commit
@@ -1,6 +1,6 @@
 
-goimports -l pkg
-goimports -l examples
+goimports -w -format-only pkg
+goimports -w -format-only examples
 
 ineffassign .
 

--- a/pkg/bean/context.go
+++ b/pkg/bean/context.go
@@ -1,4 +1,4 @@
-// Copyright 2020 
+// Copyright 2020
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,5 +17,4 @@ package bean
 // ApplicationContext define for future
 // when we decide to support DI, IoC, this will be core API
 type ApplicationContext interface {
-
 }

--- a/pkg/bean/doc.go
+++ b/pkg/bean/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 
+// Copyright 2020
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/bean/factory.go
+++ b/pkg/bean/factory.go
@@ -1,4 +1,4 @@
-// Copyright 2020 
+// Copyright 2020
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/bean/metadata.go
+++ b/pkg/bean/metadata.go
@@ -1,4 +1,4 @@
-// Copyright 2020 
+// Copyright 2020
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/bean/tag_auto_wire_bean_factory.go
+++ b/pkg/bean/tag_auto_wire_bean_factory.go
@@ -1,4 +1,4 @@
-// Copyright 2020 
+// Copyright 2020
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/bean/tag_auto_wire_bean_factory_test.go
+++ b/pkg/bean/tag_auto_wire_bean_factory_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 
+// Copyright 2020
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/bean/time_type_adapter.go
+++ b/pkg/bean/time_type_adapter.go
@@ -1,4 +1,4 @@
-// Copyright 2020 
+// Copyright 2020
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package bean
 import (
 	"context"
 	"time"
-
 )
 
 // TimeTypeAdapter process the time.Time
@@ -29,7 +28,7 @@ type TimeTypeAdapter struct {
 // and if the DftValue == now
 // time.Now() is returned
 func (t *TimeTypeAdapter) DefaultValue(ctx context.Context, dftValue string) (interface{}, error) {
-	if dftValue == "now"{
+	if dftValue == "now" {
 		return time.Now(), nil
 	}
 	return time.Parse(t.Layout, dftValue)

--- a/pkg/bean/time_type_adapter_test.go
+++ b/pkg/bean/time_type_adapter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 
+// Copyright 2020
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/bean/type_adapter.go
+++ b/pkg/bean/type_adapter.go
@@ -1,4 +1,4 @@
-// Copyright 2020 
+// Copyright 2020
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/context/param/parsers_test.go
+++ b/pkg/context/param/parsers_test.go
@@ -1,8 +1,10 @@
 package param
 
-import "testing"
-import "reflect"
-import "time"
+import (
+	"reflect"
+	"testing"
+	"time"
+)
 
 type testDefinition struct {
 	strValue       string

--- a/pkg/controller_test.go
+++ b/pkg/controller_test.go
@@ -21,9 +21,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/astaxie/beego/pkg/context"
 	"os"
 	"path/filepath"
+
+	"github.com/astaxie/beego/pkg/context"
 )
 
 func TestGetInt(t *testing.T) {

--- a/pkg/orm/db.go
+++ b/pkg/orm/db.go
@@ -18,10 +18,11 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/astaxie/beego/pkg/orm/hints"
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/astaxie/beego/pkg/orm/hints"
 )
 
 const (
@@ -490,7 +491,7 @@ func (d *dbBase) InsertValue(q dbQuerier, mi *modelInfo, isMulti bool, names []s
 			if err != nil {
 				DebugLog.Println(ErrLastInsertIdUnavailable, ':', err)
 				return lastInsertId, ErrLastInsertIdUnavailable
-			}else{
+			} else {
 				return lastInsertId, nil
 			}
 		}
@@ -598,7 +599,7 @@ func (d *dbBase) InsertOrUpdate(q dbQuerier, mi *modelInfo, ind reflect.Value, a
 			if err != nil {
 				DebugLog.Println(ErrLastInsertIdUnavailable, ':', err)
 				return lastInsertId, ErrLastInsertIdUnavailable
-			}else{
+			} else {
 				return lastInsertId, nil
 			}
 		}
@@ -1954,5 +1955,3 @@ func (d *dbBase) GenerateSpecifyIndex(tableName string, useIndex int, indexes []
 
 	return fmt.Sprintf(` %s INDEX(%s) `, useWay, strings.Join(s, `,`))
 }
-
-

--- a/pkg/orm/db_alias.go
+++ b/pkg/orm/db_alias.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/astaxie/beego/pkg/orm/hints"
 	"sync"
 	"time"
+
+	"github.com/astaxie/beego/pkg/orm/hints"
 
 	lru "github.com/hashicorp/golang-lru"
 

--- a/pkg/orm/db_alias_test.go
+++ b/pkg/orm/db_alias_test.go
@@ -15,9 +15,10 @@
 package orm
 
 import (
-	"github.com/astaxie/beego/pkg/orm/hints"
 	"testing"
 	"time"
+
+	"github.com/astaxie/beego/pkg/orm/hints"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/orm/db_mysql.go
+++ b/pkg/orm/db_mysql.go
@@ -169,7 +169,7 @@ func (d *dbBaseMysql) InsertOrUpdate(q dbQuerier, mi *modelInfo, ind reflect.Val
 			if err != nil {
 				DebugLog.Println(ErrLastInsertIdUnavailable, ':', err)
 				return lastInsertId, ErrLastInsertIdUnavailable
-			}else{
+			} else {
 				return lastInsertId, nil
 			}
 		}

--- a/pkg/orm/db_oracle.go
+++ b/pkg/orm/db_oracle.go
@@ -16,8 +16,9 @@ package orm
 
 import (
 	"fmt"
-	"github.com/astaxie/beego/pkg/orm/hints"
 	"strings"
+
+	"github.com/astaxie/beego/pkg/orm/hints"
 )
 
 // oracle operators.
@@ -155,7 +156,7 @@ func (d *dbBaseOracle) InsertValue(q dbQuerier, mi *modelInfo, isMulti bool, nam
 			if err != nil {
 				DebugLog.Println(ErrLastInsertIdUnavailable, ':', err)
 				return lastInsertId, ErrLastInsertIdUnavailable
-			}else{
+			} else {
 				return lastInsertId, nil
 			}
 		}

--- a/pkg/orm/db_postgres.go
+++ b/pkg/orm/db_postgres.go
@@ -92,7 +92,6 @@ func (d *dbBasePostgres) MaxLimit() uint64 {
 	return 0
 }
 
-
 // postgresql quote is ".
 func (d *dbBasePostgres) TableQuote() string {
 	return `"`

--- a/pkg/orm/db_sqlite.go
+++ b/pkg/orm/db_sqlite.go
@@ -17,10 +17,11 @@ package orm
 import (
 	"database/sql"
 	"fmt"
-	"github.com/astaxie/beego/pkg/orm/hints"
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/astaxie/beego/pkg/orm/hints"
 )
 
 // sqlite operators.
@@ -172,7 +173,6 @@ func (d *dbBaseSqlite) GenerateSpecifyIndex(tableName string, useIndex int, inde
 		return ``
 	}
 }
-
 
 // create new sqlite dbBaser.
 func newdbBaseSqlite() dbBaser {

--- a/pkg/orm/db_tables.go
+++ b/pkg/orm/db_tables.go
@@ -473,7 +473,7 @@ func (t *dbTables) getLimitSQL(mi *modelInfo, offset int64, limit int64) (limits
 }
 
 // getIndexSql generate index sql.
-func (t *dbTables) getIndexSql(tableName string,useIndex int, indexes []string) (clause string) {
+func (t *dbTables) getIndexSql(tableName string, useIndex int, indexes []string) (clause string) {
 	if len(indexes) == 0 {
 		return
 	}

--- a/pkg/orm/do_nothing_orm.go
+++ b/pkg/orm/do_nothing_orm.go
@@ -17,6 +17,7 @@ package orm
 import (
 	"context"
 	"database/sql"
+
 	"github.com/astaxie/beego/pkg/common"
 )
 
@@ -27,7 +28,6 @@ import (
 var _ Ormer = new(DoNothingOrm)
 
 type DoNothingOrm struct {
-
 }
 
 func (d *DoNothingOrm) Read(md interface{}, cols ...string) error {
@@ -54,11 +54,11 @@ func (d *DoNothingOrm) ReadOrCreateWithCtx(ctx context.Context, md interface{}, 
 	return false, 0, nil
 }
 
-func (d *DoNothingOrm) LoadRelated(md interface{}, name string,  args ...common.KV) (int64, error) {
+func (d *DoNothingOrm) LoadRelated(md interface{}, name string, args ...common.KV) (int64, error) {
 	return 0, nil
 }
 
-func (d *DoNothingOrm) LoadRelatedWithCtx(ctx context.Context, md interface{}, name string,  args ...common.KV) (int64, error) {
+func (d *DoNothingOrm) LoadRelatedWithCtx(ctx context.Context, md interface{}, name string, args ...common.KV) (int64, error) {
 	return 0, nil
 }
 

--- a/pkg/orm/filter.go
+++ b/pkg/orm/filter.go
@@ -24,7 +24,11 @@ type FilterChain func(next Filter) Filter
 
 // Filter's behavior is a little big strange.
 // it's only be called when users call methods of Ormer
-type Filter func(ctx context.Context, inv *Invocation)
+// return value is an array. it's a little bit hard to understand,
+// for example, the Ormer's Read method only return error
+// so the filter processing this method should return an array whose first element is error
+// and, Ormer's ReadOrCreateWithCtx return three values, so the Filter's result should contains three values
+type Filter func(ctx context.Context, inv *Invocation) []interface{}
 
 var globalFilterChains = make([]FilterChain, 0, 4)
 

--- a/pkg/orm/filter/bean/default_value_filter.go
+++ b/pkg/orm/filter/bean/default_value_filter.go
@@ -1,4 +1,4 @@
-// Copyright 2020 
+// Copyright 2020
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ func NewDefaultValueFilterChainBuilder(typeAdapters map[string]bean.TypeAdapter,
 }
 
 func (d *DefaultValueFilterChainBuilder) FilterChain(next orm.Filter) orm.Filter {
-	return func(ctx context.Context, inv *orm.Invocation) {
+	return func(ctx context.Context, inv *orm.Invocation) []interface{} {
 		switch inv.Method {
 		case "Insert", "InsertWithCtx":
 			d.handleInsert(ctx, inv)
@@ -88,7 +88,7 @@ func (d *DefaultValueFilterChainBuilder) FilterChain(next orm.Filter) orm.Filter
 			d.handleInsertMulti(ctx, inv)
 			break
 		}
-		next(ctx, inv)
+		return next(ctx, inv)
 	}
 }
 

--- a/pkg/orm/filter/bean/default_value_filter_test.go
+++ b/pkg/orm/filter/bean/default_value_filter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 
+// Copyright 2020
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/orm/filter/opentracing/filter_test.go
+++ b/pkg/orm/filter/opentracing/filter_test.go
@@ -25,8 +25,9 @@ import (
 )
 
 func TestFilterChainBuilder_FilterChain(t *testing.T) {
-	next := func(ctx context.Context, inv *orm.Invocation) {
+	next := func(ctx context.Context, inv *orm.Invocation) []interface{} {
 		inv.TxName = "Hello"
+		return []interface{}{}
 	}
 
 	builder := &FilterChainBuilder{

--- a/pkg/orm/filter/prometheus/filter.go
+++ b/pkg/orm/filter/prometheus/filter.go
@@ -56,15 +56,16 @@ func NewFilterChainBuilder() *FilterChainBuilder {
 }
 
 func (builder *FilterChainBuilder) FilterChain(next orm.Filter) orm.Filter {
-	return func(ctx context.Context, inv *orm.Invocation) {
+	return func(ctx context.Context, inv *orm.Invocation) []interface{} {
 		startTime := time.Now()
-		next(ctx, inv)
+		res := next(ctx, inv)
 		endTime := time.Now()
 		dur := (endTime.Sub(startTime)) / time.Millisecond
 
 		// if the TPS is too large, here may be some problem
 		// thinking about using goroutine pool
 		go builder.report(ctx, inv, dur)
+		return res
 	}
 }
 

--- a/pkg/orm/filter/prometheus/filter_test.go
+++ b/pkg/orm/filter/prometheus/filter_test.go
@@ -28,8 +28,9 @@ func TestFilterChainBuilder_FilterChain(t *testing.T) {
 	builder := NewFilterChainBuilder()
 	assert.NotNil(t, builder.summaryVec)
 
-	filter := builder.FilterChain(func(ctx context.Context, inv *orm.Invocation) {
+	filter := builder.FilterChain(func(ctx context.Context, inv *orm.Invocation) []interface{} {
 		inv.Method = "coming"
+		return []interface{}{}
 	})
 	assert.NotNil(t, filter)
 

--- a/pkg/orm/filter_orm_decorator_test.go
+++ b/pkg/orm/filter_orm_decorator_test.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"github.com/astaxie/beego/pkg/common"
 	"sync"
 	"testing"
+
+	"github.com/astaxie/beego/pkg/common"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -31,11 +32,11 @@ func TestFilterOrmDecorator_Read(t *testing.T) {
 
 	o := &filterMockOrm{}
 	od := NewFilterOrmDecorator(o, func(next Filter) Filter {
-		return func(ctx context.Context, inv *Invocation) {
+		return func(ctx context.Context, inv *Invocation) []interface{} {
 			assert.Equal(t, "ReadWithCtx", inv.Method)
 			assert.Equal(t, 2, len(inv.Args))
 			assert.Equal(t, "FILTER_TEST", inv.GetTableName())
-			next(ctx, inv)
+			return next(ctx, inv)
 		}
 	})
 
@@ -50,7 +51,7 @@ func TestFilterOrmDecorator_BeginTx(t *testing.T) {
 
 	o := &filterMockOrm{}
 	od := NewFilterOrmDecorator(o, func(next Filter) Filter {
-		return func(ctx context.Context, inv *Invocation) {
+		return func(ctx context.Context, inv *Invocation) []interface{} {
 			if inv.Method == "BeginWithCtxAndOpts" {
 				assert.Equal(t, 1, len(inv.Args))
 				assert.Equal(t, "", inv.GetTableName())
@@ -69,7 +70,7 @@ func TestFilterOrmDecorator_BeginTx(t *testing.T) {
 				t.Fail()
 			}
 
-			next(ctx, inv)
+			return next(ctx, inv)
 		}
 	})
 	to, err := od.Begin()
@@ -98,11 +99,11 @@ func TestFilterOrmDecorator_BeginTx(t *testing.T) {
 func TestFilterOrmDecorator_DBStats(t *testing.T) {
 	o := &filterMockOrm{}
 	od := NewFilterOrmDecorator(o, func(next Filter) Filter {
-		return func(ctx context.Context, inv *Invocation) {
+		return func(ctx context.Context, inv *Invocation) []interface{} {
 			assert.Equal(t, "DBStats", inv.Method)
 			assert.Equal(t, 0, len(inv.Args))
 			assert.Equal(t, "", inv.GetTableName())
-			next(ctx, inv)
+			return next(ctx, inv)
 		}
 	})
 	res := od.DBStats()
@@ -114,11 +115,11 @@ func TestFilterOrmDecorator_Delete(t *testing.T) {
 	register()
 	o := &filterMockOrm{}
 	od := NewFilterOrmDecorator(o, func(next Filter) Filter {
-		return func(ctx context.Context, inv *Invocation) {
+		return func(ctx context.Context, inv *Invocation) []interface{}  {
 			assert.Equal(t, "DeleteWithCtx", inv.Method)
 			assert.Equal(t, 2, len(inv.Args))
 			assert.Equal(t, "FILTER_TEST", inv.GetTableName())
-			next(ctx, inv)
+			return next(ctx, inv)
 		}
 	})
 	res, err := od.Delete(&FilterTestEntity{})
@@ -130,14 +131,13 @@ func TestFilterOrmDecorator_Delete(t *testing.T) {
 func TestFilterOrmDecorator_DoTx(t *testing.T) {
 	o := &filterMockOrm{}
 	od := NewFilterOrmDecorator(o, func(next Filter) Filter {
-		return func(ctx context.Context, inv *Invocation) {
+		return func(ctx context.Context, inv *Invocation) []interface{} {
 			if inv.Method == "DoTxWithCtxAndOpts" {
 				assert.Equal(t, 2, len(inv.Args))
 				assert.Equal(t, "", inv.GetTableName())
 				assert.False(t, inv.InsideTx)
 			}
-
-			next(ctx, inv)
+			return next(ctx, inv)
 		}
 	})
 
@@ -156,16 +156,15 @@ func TestFilterOrmDecorator_DoTx(t *testing.T) {
 	})
 	assert.NotNil(t, err)
 
-
 	od = NewFilterOrmDecorator(o, func(next Filter) Filter {
-		return func(ctx context.Context, inv *Invocation) {
+		return func(ctx context.Context, inv *Invocation) []interface{} {
 			if inv.Method == "DoTxWithCtxAndOpts" {
 				assert.Equal(t, 2, len(inv.Args))
 				assert.Equal(t, "", inv.GetTableName())
 				assert.Equal(t, "do tx name", inv.TxName)
 				assert.False(t, inv.InsideTx)
 			}
-			next(ctx, inv)
+			return next(ctx, inv)
 		}
 	})
 
@@ -179,12 +178,12 @@ func TestFilterOrmDecorator_DoTx(t *testing.T) {
 func TestFilterOrmDecorator_Driver(t *testing.T) {
 	o := &filterMockOrm{}
 	od := NewFilterOrmDecorator(o, func(next Filter) Filter {
-		return func(ctx context.Context, inv *Invocation) {
+		return func(ctx context.Context, inv *Invocation) []interface{} {
 			assert.Equal(t, "Driver", inv.Method)
 			assert.Equal(t, 0, len(inv.Args))
 			assert.Equal(t, "", inv.GetTableName())
 			assert.False(t, inv.InsideTx)
-			next(ctx, inv)
+			return next(ctx, inv)
 		}
 	})
 	res := od.Driver()
@@ -195,12 +194,12 @@ func TestFilterOrmDecorator_Insert(t *testing.T) {
 	register()
 	o := &filterMockOrm{}
 	od := NewFilterOrmDecorator(o, func(next Filter) Filter {
-		return func(ctx context.Context, inv *Invocation) {
+		return func(ctx context.Context, inv *Invocation) []interface{} {
 			assert.Equal(t, "InsertWithCtx", inv.Method)
 			assert.Equal(t, 1, len(inv.Args))
 			assert.Equal(t, "FILTER_TEST", inv.GetTableName())
 			assert.False(t, inv.InsideTx)
-			next(ctx, inv)
+			return next(ctx, inv)
 		}
 	})
 
@@ -214,12 +213,12 @@ func TestFilterOrmDecorator_InsertMulti(t *testing.T) {
 	register()
 	o := &filterMockOrm{}
 	od := NewFilterOrmDecorator(o, func(next Filter) Filter {
-		return func(ctx context.Context, inv *Invocation) {
+		return func(ctx context.Context, inv *Invocation) []interface{} {
 			assert.Equal(t, "InsertMultiWithCtx", inv.Method)
 			assert.Equal(t, 2, len(inv.Args))
 			assert.Equal(t, "FILTER_TEST", inv.GetTableName())
 			assert.False(t, inv.InsideTx)
-			next(ctx, inv)
+			return next(ctx, inv)
 		}
 	})
 
@@ -234,12 +233,12 @@ func TestFilterOrmDecorator_InsertOrUpdate(t *testing.T) {
 	register()
 	o := &filterMockOrm{}
 	od := NewFilterOrmDecorator(o, func(next Filter) Filter {
-		return func(ctx context.Context, inv *Invocation) {
+		return func(ctx context.Context, inv *Invocation) []interface{} {
 			assert.Equal(t, "InsertOrUpdateWithCtx", inv.Method)
 			assert.Equal(t, 2, len(inv.Args))
 			assert.Equal(t, "FILTER_TEST", inv.GetTableName())
 			assert.False(t, inv.InsideTx)
-			next(ctx, inv)
+			return next(ctx, inv)
 		}
 	})
 	i, err := od.InsertOrUpdate(&FilterTestEntity{})
@@ -251,12 +250,12 @@ func TestFilterOrmDecorator_InsertOrUpdate(t *testing.T) {
 func TestFilterOrmDecorator_LoadRelated(t *testing.T) {
 	o := &filterMockOrm{}
 	od := NewFilterOrmDecorator(o, func(next Filter) Filter {
-		return func(ctx context.Context, inv *Invocation) {
+		return func(ctx context.Context, inv *Invocation) []interface{} {
 			assert.Equal(t, "LoadRelatedWithCtx", inv.Method)
 			assert.Equal(t, 3, len(inv.Args))
 			assert.Equal(t, "FILTER_TEST", inv.GetTableName())
 			assert.False(t, inv.InsideTx)
-			next(ctx, inv)
+			return next(ctx, inv)
 		}
 	})
 	i, err := od.LoadRelated(&FilterTestEntity{}, "hello")
@@ -268,12 +267,12 @@ func TestFilterOrmDecorator_LoadRelated(t *testing.T) {
 func TestFilterOrmDecorator_QueryM2M(t *testing.T) {
 	o := &filterMockOrm{}
 	od := NewFilterOrmDecorator(o, func(next Filter) Filter {
-		return func(ctx context.Context, inv *Invocation) {
+		return func(ctx context.Context, inv *Invocation) []interface{} {
 			assert.Equal(t, "QueryM2MWithCtx", inv.Method)
 			assert.Equal(t, 2, len(inv.Args))
 			assert.Equal(t, "FILTER_TEST", inv.GetTableName())
 			assert.False(t, inv.InsideTx)
-			next(ctx, inv)
+			return next(ctx, inv)
 		}
 	})
 	res := od.QueryM2M(&FilterTestEntity{}, "hello")
@@ -284,12 +283,12 @@ func TestFilterOrmDecorator_QueryTable(t *testing.T) {
 	register()
 	o := &filterMockOrm{}
 	od := NewFilterOrmDecorator(o, func(next Filter) Filter {
-		return func(ctx context.Context, inv *Invocation) {
+		return func(ctx context.Context, inv *Invocation) []interface{} {
 			assert.Equal(t, "QueryTableWithCtx", inv.Method)
 			assert.Equal(t, 1, len(inv.Args))
 			assert.Equal(t, "FILTER_TEST", inv.GetTableName())
 			assert.False(t, inv.InsideTx)
-			next(ctx, inv)
+			return next(ctx, inv)
 		}
 	})
 	res := od.QueryTable(&FilterTestEntity{})
@@ -300,28 +299,28 @@ func TestFilterOrmDecorator_Raw(t *testing.T) {
 	register()
 	o := &filterMockOrm{}
 	od := NewFilterOrmDecorator(o, func(next Filter) Filter {
-		return func(ctx context.Context, inv *Invocation) {
+		return func(ctx context.Context, inv *Invocation) []interface{} {
 			assert.Equal(t, "RawWithCtx", inv.Method)
 			assert.Equal(t, 2, len(inv.Args))
 			assert.Equal(t, "", inv.GetTableName())
 			assert.False(t, inv.InsideTx)
-			next(ctx, inv)
+			return next(ctx, inv)
 		}
 	})
 	res := od.Raw("hh")
 	assert.Nil(t, res)
 }
 
-func TestFilterOrmDecorator_ReadForUpdate(t *testing.T) {
+func TestFilterOrmDecorator_ReadForUpdate(t *testing.T)  {
 	register()
 	o := &filterMockOrm{}
 	od := NewFilterOrmDecorator(o, func(next Filter) Filter {
-		return func(ctx context.Context, inv *Invocation) {
+		return func(ctx context.Context, inv *Invocation) []interface{} {
 			assert.Equal(t, "ReadForUpdateWithCtx", inv.Method)
 			assert.Equal(t, 2, len(inv.Args))
 			assert.Equal(t, "FILTER_TEST", inv.GetTableName())
 			assert.False(t, inv.InsideTx)
-			next(ctx, inv)
+			return next(ctx, inv)
 		}
 	})
 	err := od.ReadForUpdate(&FilterTestEntity{})
@@ -333,12 +332,12 @@ func TestFilterOrmDecorator_ReadOrCreate(t *testing.T) {
 	register()
 	o := &filterMockOrm{}
 	od := NewFilterOrmDecorator(o, func(next Filter) Filter {
-		return func(ctx context.Context, inv *Invocation) {
+		return func(ctx context.Context, inv *Invocation) []interface{} {
 			assert.Equal(t, "ReadOrCreateWithCtx", inv.Method)
 			assert.Equal(t, 3, len(inv.Args))
 			assert.Equal(t, "FILTER_TEST", inv.GetTableName())
 			assert.False(t, inv.InsideTx)
-			next(ctx, inv)
+			return next(ctx, inv)
 		}
 	})
 	ok, i, err := od.ReadOrCreate(&FilterTestEntity{}, "name")

--- a/pkg/orm/filter_test.go
+++ b/pkg/orm/filter_test.go
@@ -23,8 +23,8 @@ import (
 
 func TestAddGlobalFilterChain(t *testing.T) {
 	AddGlobalFilterChain(func(next Filter) Filter {
-		return func(ctx context.Context, inv *Invocation) {
-
+		return func(ctx context.Context, inv *Invocation) []interface{} {
+			return next(ctx, inv)
 		}
 	})
 	assert.Equal(t, 1, len(globalFilterChains))

--- a/pkg/orm/hints/db_hints.go
+++ b/pkg/orm/hints/db_hints.go
@@ -15,8 +15,9 @@
 package hints
 
 import (
-	"github.com/astaxie/beego/pkg/common"
 	"time"
+
+	"github.com/astaxie/beego/pkg/common"
 )
 
 const (

--- a/pkg/orm/hints/db_hints_test.go
+++ b/pkg/orm/hints/db_hints_test.go
@@ -15,9 +15,10 @@
 package hints
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewHint_time(t *testing.T) {

--- a/pkg/orm/invocation.go
+++ b/pkg/orm/invocation.go
@@ -29,7 +29,7 @@ type Invocation struct {
 
 	mi *modelInfo
 	// f is the Orm operation
-	f func(ctx context.Context)
+	f func(ctx context.Context) []interface{}
 
 	// insideTx indicates whether this is inside a transaction
 	InsideTx    bool
@@ -44,8 +44,8 @@ func (inv *Invocation) GetTableName() string {
 	return ""
 }
 
-func (inv *Invocation) execute(ctx context.Context) {
-	inv.f(ctx)
+func (inv *Invocation) execute(ctx context.Context) []interface{} {
+	return inv.f(ctx)
 }
 
 // GetPkFieldName return the primary key of this table

--- a/pkg/orm/models_test.go
+++ b/pkg/orm/models_test.go
@@ -18,10 +18,11 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"github.com/astaxie/beego/pkg/orm/hints"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/astaxie/beego/pkg/orm/hints"
 
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
@@ -430,7 +431,7 @@ type PtrPk struct {
 }
 
 type StrPk struct {
-	Id    string  `orm:"column(id);size(64);pk"`
+	Id    string `orm:"column(id);size(64);pk"`
 	Value string
 }
 

--- a/pkg/orm/orm.go
+++ b/pkg/orm/orm.go
@@ -58,11 +58,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/astaxie/beego/pkg/common"
-	"github.com/astaxie/beego/pkg/orm/hints"
 	"os"
 	"reflect"
 	"time"
+
+	"github.com/astaxie/beego/pkg/common"
+	"github.com/astaxie/beego/pkg/orm/hints"
 
 	"github.com/astaxie/beego/pkg/logs"
 )

--- a/pkg/orm/orm_queryset.go
+++ b/pkg/orm/orm_queryset.go
@@ -17,6 +17,7 @@ package orm
 import (
 	"context"
 	"fmt"
+
 	"github.com/astaxie/beego/pkg/orm/hints"
 )
 

--- a/pkg/orm/orm_raw.go
+++ b/pkg/orm/orm_raw.go
@@ -17,9 +17,10 @@ package orm
 import (
 	"database/sql"
 	"fmt"
-	"github.com/pkg/errors"
 	"reflect"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 // raw sql string prepared statement

--- a/pkg/orm/orm_test.go
+++ b/pkg/orm/orm_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/astaxie/beego/pkg/orm/hints"
 	"io/ioutil"
 	"math"
 	"os"
@@ -31,6 +30,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/astaxie/beego/pkg/orm/hints"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -2565,7 +2566,7 @@ func TestStrPkInsert(t *testing.T) {
 		Id:    pk,
 		Value: value2,
 	}
-	
+
 	_, err = dORM.InsertOrUpdate(strPkForUpsert, `id`)
 	if err != nil {
 		fmt.Println(err)

--- a/pkg/orm/types.go
+++ b/pkg/orm/types.go
@@ -17,9 +17,10 @@ package orm
 import (
 	"context"
 	"database/sql"
-	"github.com/astaxie/beego/pkg/common"
 	"reflect"
 	"time"
+
+	"github.com/astaxie/beego/pkg/common"
 )
 
 // TableNaming is usually used by model
@@ -579,5 +580,5 @@ type dbBaser interface {
 	collectFieldValue(*modelInfo, *fieldInfo, reflect.Value, bool, *time.Location) (interface{}, error)
 	setval(dbQuerier, *modelInfo, []string) error
 
-	GenerateSpecifyIndex(tableName string,useIndex int ,indexes []string) string
+	GenerateSpecifyIndex(tableName string, useIndex int, indexes []string) string
 }

--- a/pkg/parser.go
+++ b/pkg/parser.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"go/ast"
-	"golang.org/x/tools/go/packages"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -28,6 +27,8 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+
+	"golang.org/x/tools/go/packages"
 
 	"github.com/astaxie/beego/pkg/context/param"
 	"github.com/astaxie/beego/pkg/logs"

--- a/pkg/plugins/auth/basic.go
+++ b/pkg/plugins/auth/basic.go
@@ -40,7 +40,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/astaxie/beego/pkg"
+	beego "github.com/astaxie/beego/pkg"
 	"github.com/astaxie/beego/pkg/context"
 )
 

--- a/pkg/plugins/authz/authz.go
+++ b/pkg/plugins/authz/authz.go
@@ -40,10 +40,11 @@
 package authz
 
 import (
-	"github.com/astaxie/beego/pkg"
+	"net/http"
+
+	beego "github.com/astaxie/beego/pkg"
 	"github.com/astaxie/beego/pkg/context"
 	"github.com/casbin/casbin"
-	"net/http"
 )
 
 // NewAuthorizer returns the authorizer.

--- a/pkg/plugins/authz/authz_test.go
+++ b/pkg/plugins/authz/authz_test.go
@@ -15,13 +15,14 @@
 package authz
 
 import (
-	"github.com/astaxie/beego/pkg"
-	"github.com/astaxie/beego/pkg/context"
-	"github.com/astaxie/beego/pkg/plugins/auth"
-	"github.com/casbin/casbin"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	beego "github.com/astaxie/beego/pkg"
+	"github.com/astaxie/beego/pkg/context"
+	"github.com/astaxie/beego/pkg/plugins/auth"
+	"github.com/casbin/casbin"
 )
 
 func testRequest(t *testing.T, handler *beego.ControllerRegister, user string, path string, method string, code int) {

--- a/pkg/plugins/cors/cors.go
+++ b/pkg/plugins/cors/cors.go
@@ -42,7 +42,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/astaxie/beego/pkg"
+	beego "github.com/astaxie/beego/pkg"
 	"github.com/astaxie/beego/pkg/context"
 )
 

--- a/pkg/plugins/cors/cors_test.go
+++ b/pkg/plugins/cors/cors_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/astaxie/beego/pkg"
+	beego "github.com/astaxie/beego/pkg"
 	"github.com/astaxie/beego/pkg/context"
 )
 

--- a/pkg/session/redis/sess_redis.go
+++ b/pkg/session/redis/sess_redis.go
@@ -224,7 +224,7 @@ func (rp *Provider) SessionRegenerate(oldsid, sid string) (session.Store, error)
 		c.Do(c.Context(), "SET", sid, "", "EX", rp.maxlifetime)
 	} else {
 		c.Rename(oldsid, sid)
-		c.Expire(sid, time.Duration(rp.maxlifetime) * time.Second)
+		c.Expire(sid, time.Duration(rp.maxlifetime)*time.Second)
 	}
 	return rp.SessionRead(sid)
 }

--- a/pkg/session/redis_cluster/redis_cluster.go
+++ b/pkg/session/redis_cluster/redis_cluster.go
@@ -33,13 +33,14 @@
 package redis_cluster
 
 import (
-	"github.com/astaxie/beego/pkg/session"
-	rediss "github.com/go-redis/redis/v7"
 	"net/http"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/astaxie/beego/pkg/session"
+	rediss "github.com/go-redis/redis/v7"
 )
 
 var redispder = &Provider{}

--- a/pkg/session/redis_sentinel/sess_redis_sentinel.go
+++ b/pkg/session/redis_sentinel/sess_redis_sentinel.go
@@ -33,13 +33,14 @@
 package redis_sentinel
 
 import (
-	"github.com/astaxie/beego/pkg/session"
-	"github.com/go-redis/redis/v7"
 	"net/http"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/astaxie/beego/pkg/session"
+	"github.com/go-redis/redis/v7"
 )
 
 var redispder = &Provider{}

--- a/pkg/staticfile.go
+++ b/pkg/staticfile.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/astaxie/beego/pkg/context"
 	"github.com/astaxie/beego/pkg/logs"
-	"github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru"
 )
 
 var errNotStaticRequest = errors.New("request not a static file request")

--- a/pkg/template_test.go
+++ b/pkg/template_test.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/elazarl/go-bindata-assetfs"
+	assetfs "github.com/elazarl/go-bindata-assetfs"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/astaxie/beego/test"

--- a/pkg/utils/captcha/captcha.go
+++ b/pkg/utils/captcha/captcha.go
@@ -66,7 +66,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/astaxie/beego/pkg"
+	beego "github.com/astaxie/beego/pkg"
 	"github.com/astaxie/beego/pkg/cache"
 	"github.com/astaxie/beego/pkg/context"
 	"github.com/astaxie/beego/pkg/logs"

--- a/pkg/validation/validators.go
+++ b/pkg/validation/validators.go
@@ -16,13 +16,14 @@ package validation
 
 import (
 	"fmt"
-	"github.com/astaxie/beego/pkg/logs"
 	"reflect"
 	"regexp"
 	"strings"
 	"sync"
 	"time"
 	"unicode/utf8"
+
+	"github.com/astaxie/beego/pkg/logs"
 )
 
 // CanSkipFuncs will skip valid if RequiredFirst is true and the struct field's value is empty

--- a/test/bindata.go
+++ b/test/bindata.go
@@ -11,13 +11,14 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
-	"github.com/elazarl/go-bindata-assetfs"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	assetfs "github.com/elazarl/go-bindata-assetfs"
 )
 
 func bindataRead(data []byte, name string) ([]byte, error) {


### PR DESCRIPTION
Last time when I develop default_value_filter, I found that I can not break the filter chain. So I add return value to Filter interface.

Thus, when we implement some custom filter, we could return result directly rather than invoke next Filter.