### PR TITLE
Add more methods to Configer

### DIFF
--- a/pkg/config.go
+++ b/pkg/config.go
@@ -411,6 +411,7 @@ func LoadAppConfig(adapterName, configPath string) error {
 }
 
 type beegoAppConfig struct {
+	config.BaseConfiger
 	innerConfig config.Configer
 }
 
@@ -419,7 +420,7 @@ func newAppConfig(appConfigProvider, appConfigPath string) (*beegoAppConfig, err
 	if err != nil {
 		return nil, err
 	}
-	return &beegoAppConfig{ac}, nil
+	return &beegoAppConfig{innerConfig: ac}, nil
 }
 
 func (b *beegoAppConfig) Set(key, val string) error {

--- a/pkg/config/base_config_test.go
+++ b/pkg/config/base_config_test.go
@@ -1,0 +1,71 @@
+// Copyright 2020
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBaseConfiger_DefaultBool(t *testing.T) {
+	bc := newBaseConfier("true")
+	assert.True(t, bc.DefaultBool("key1", false))
+	assert.True(t, bc.DefaultBool("key2", true))
+}
+
+func TestBaseConfiger_DefaultFloat(t *testing.T) {
+	bc := newBaseConfier("12.3")
+	assert.Equal(t, 12.3, bc.DefaultFloat("key1", 0.1))
+	assert.Equal(t, 0.1, bc.DefaultFloat("key2", 0.1))
+}
+
+func TestBaseConfiger_DefaultInt(t *testing.T) {
+	bc := newBaseConfier("10")
+	assert.Equal(t, 10, bc.DefaultInt("key1", 8))
+	assert.Equal(t, 8, bc.DefaultInt("key2", 8))
+}
+
+func TestBaseConfiger_DefaultInt64(t *testing.T) {
+	bc := newBaseConfier("64")
+	assert.Equal(t, int64(64), bc.DefaultInt64("key1", int64(8)))
+	assert.Equal(t, int64(8), bc.DefaultInt64("key2", int64(8)))
+}
+
+func TestBaseConfiger_DefaultString(t *testing.T) {
+	bc := newBaseConfier("Hello")
+	assert.Equal(t, "Hello", bc.DefaultString("key1", "world"))
+	assert.Equal(t, "world", bc.DefaultString("key2", "world"))
+}
+
+func TestBaseConfiger_DefaultStrings(t *testing.T) {
+	bc := newBaseConfier("Hello;world")
+	assert.Equal(t, []string{"Hello", "world"}, bc.DefaultStrings("key1", []string{"world"}))
+	assert.Equal(t, []string{"world"}, bc.DefaultStrings("key2", []string{"world"}))
+}
+
+func newBaseConfier(str1 string) *BaseConfiger {
+	return &BaseConfiger{
+		reader: func(key string) (string, error) {
+			if key == "key1" {
+				return str1, nil
+			} else {
+				return "", errors.New("mock error")
+			}
+
+		},
+	}
+}

--- a/pkg/config/fake.go
+++ b/pkg/config/fake.go
@@ -21,6 +21,7 @@ import (
 )
 
 type fakeConfigContainer struct {
+	BaseConfiger
 	data map[string]string
 }
 

--- a/pkg/config/ini.go
+++ b/pkg/config/ini.go
@@ -225,6 +225,7 @@ func (ini *IniConfig) ParseData(data []byte) (Configer, error) {
 // IniConfigContainer is a config which represents the ini configuration.
 // When set and get value, support key as section:name type.
 type IniConfigContainer struct {
+	BaseConfiger
 	data           map[string]map[string]string // section=> key:val
 	sectionComment map[string]string            // section : comment
 	keyComment     map[string]string            // id: []{comment, key...}; id 1 is for main comment.

--- a/pkg/config/json/json.go
+++ b/pkg/config/json/json.go
@@ -69,6 +69,7 @@ func (js *JSONConfig) ParseData(data []byte) (config.Configer, error) {
 // JSONConfigContainer is a config which represents the json configuration.
 // Only when get value, support key as section:name type.
 type JSONConfigContainer struct {
+	config.BaseConfiger
 	data map[string]interface{}
 	sync.RWMutex
 }

--- a/pkg/config/xml/xml.go
+++ b/pkg/config/xml/xml.go
@@ -74,6 +74,7 @@ func (xc *Config) ParseData(data []byte) (config.Configer, error) {
 
 // ConfigContainer is a Config which represents the xml configuration.
 type ConfigContainer struct {
+	config.BaseConfiger
 	data map[string]interface{}
 	sync.Mutex
 }

--- a/pkg/config/yaml/yaml.go
+++ b/pkg/config/yaml/yaml.go
@@ -118,6 +118,7 @@ func parseYML(buf []byte) (cnf map[string]interface{}, err error) {
 
 // ConfigContainer is a config which represents the yaml configuration.
 type ConfigContainer struct {
+	config.BaseConfiger
 	data map[string]interface{}
 	sync.RWMutex
 }

--- a/pkg/orm/filter_orm_decorator_test.go
+++ b/pkg/orm/filter_orm_decorator_test.go
@@ -115,7 +115,7 @@ func TestFilterOrmDecorator_Delete(t *testing.T) {
 	register()
 	o := &filterMockOrm{}
 	od := NewFilterOrmDecorator(o, func(next Filter) Filter {
-		return func(ctx context.Context, inv *Invocation) []interface{}  {
+		return func(ctx context.Context, inv *Invocation) []interface{} {
 			assert.Equal(t, "DeleteWithCtx", inv.Method)
 			assert.Equal(t, 2, len(inv.Args))
 			assert.Equal(t, "FILTER_TEST", inv.GetTableName())
@@ -311,7 +311,7 @@ func TestFilterOrmDecorator_Raw(t *testing.T) {
 	assert.Nil(t, res)
 }
 
-func TestFilterOrmDecorator_ReadForUpdate(t *testing.T)  {
+func TestFilterOrmDecorator_ReadForUpdate(t *testing.T) {
 	register()
 	o := &filterMockOrm{}
 	od := NewFilterOrmDecorator(o, func(next Filter) Filter {


### PR DESCRIPTION
I add three more methods into Configer:
```go
	Unmarshaler(obj interface{}) error
	Sub(key string) (Configer, error)
	OnChange(fn func(cfg Configer))
```

And then I define a `BaseConfiger`. 

But all implementations need to be changed. I will create issues to trace them.