### PR TITLE
Custom log formatter secondpr

### DIFF
--- a/pkg/logs/conn.go
+++ b/pkg/logs/conn.go
@@ -39,6 +39,10 @@ func NewConn() Logger {
 	return conn
 }
 
+func (c *connWriter) Format(lm *LogMsg) string {
+	return lm.Msg
+}
+
 // Init initializes a connection writer with json config.
 // json config only needs they "level" key
 func (c *connWriter) Init(jsonConfig string) error {
@@ -62,7 +66,8 @@ func (c *connWriter) WriteMsg(lm *LogMsg) error {
 		defer c.innerWriter.Close()
 	}
 
-	_, err := c.lg.writeln(lm)
+	msg := c.Format(lm)
+	_, err := c.lg.writeln(msg)
 	if err != nil {
 		return err
 	}

--- a/pkg/logs/console.go
+++ b/pkg/logs/console.go
@@ -52,6 +52,20 @@ type consoleWriter struct {
 	Colorful bool `json:"color"` //this filed is useful only when system's terminal supports color
 }
 
+func (c *consoleWriter) Format(lm *LogMsg) string {
+	msg := lm.Msg
+
+	if c.Colorful {
+		msg = strings.Replace(lm.Msg, levelPrefix[lm.Level], colors[lm.Level](levelPrefix[lm.Level]), 1)
+	}
+
+	h, _, _ := formatTimeHeader(lm.When)
+	bytes := append(append(h, msg...), '\n')
+
+	return "eee" + string(bytes)
+
+}
+
 // NewConsole creates ConsoleWriter returning as LoggerInterface.
 func NewConsole() Logger {
 	cw := &consoleWriter{
@@ -76,10 +90,12 @@ func (c *consoleWriter) WriteMsg(lm *LogMsg) error {
 	if lm.Level > c.Level {
 		return nil
 	}
+	// fmt.Printf("Formatted: %s\n\n", c.fmtter.Format(lm))
 	if c.Colorful {
 		lm.Msg = strings.Replace(lm.Msg, levelPrefix[lm.Level], colors[lm.Level](levelPrefix[lm.Level]), 1)
 	}
-	c.lg.writeln(lm)
+	msg := c.Format(lm)
+	c.lg.writeln(msg)
 	return nil
 }
 

--- a/pkg/logs/es/es.go
+++ b/pkg/logs/es/es.go
@@ -71,7 +71,7 @@ func (el *esLogger) WriteMsg(lm *logs.LogMsg) error {
 
 	idx := LogDocument{
 		Timestamp: lm.When.Format(time.RFC3339),
-		Msg:       lm.Msg,
+		Msg:       el.Format(lm),
 	}
 
 	body, err := json.Marshal(idx)

--- a/pkg/logs/es/es.go
+++ b/pkg/logs/es/es.go
@@ -35,6 +35,10 @@ type esLogger struct {
 	Level int    `json:"level"`
 }
 
+func (el *esLogger) Format(lm *logs.LogMsg) string {
+	return lm.Msg
+}
+
 // {"dsn":"http://localhost:9200/","level":1}
 func (el *esLogger) Init(jsonconfig string) error {
 	err := json.Unmarshal([]byte(jsonconfig), el)

--- a/pkg/logs/file.go
+++ b/pkg/logs/file.go
@@ -89,6 +89,10 @@ func newFileWriter() Logger {
 	return w
 }
 
+func (w *fileLogWriter) Format(lm *LogMsg) string {
+	return lm.Msg
+}
+
 // Init file logger with json config.
 // jsonConfig like:
 //  {

--- a/pkg/logs/file.go
+++ b/pkg/logs/file.go
@@ -153,7 +153,8 @@ func (w *fileLogWriter) WriteMsg(lm *LogMsg) error {
 		return nil
 	}
 	hd, d, h := formatTimeHeader(lm.When)
-	lm.Msg = string(hd) + lm.Msg + "\n"
+	msg := w.Format(lm)
+	msg = fmt.Sprintf("%s %s\n", string(hd), msg)
 	if w.Rotate {
 		w.RLock()
 		if w.needRotateHourly(len(lm.Msg), h) {
@@ -180,10 +181,10 @@ func (w *fileLogWriter) WriteMsg(lm *LogMsg) error {
 	}
 
 	w.Lock()
-	_, err := w.fileWriter.Write([]byte(lm.Msg))
+	_, err := w.fileWriter.Write([]byte(msg))
 	if err == nil {
 		w.maxLinesCurLines++
-		w.maxSizeCurSize += len(lm.Msg)
+		w.maxSizeCurSize += len(msg)
 	}
 	w.Unlock()
 	return err

--- a/pkg/logs/jianliao.go
+++ b/pkg/logs/jianliao.go
@@ -38,8 +38,7 @@ func (s *JLWriter) WriteMsg(lm *LogMsg) error {
 		return nil
 	}
 
-	text := fmt.Sprintf("%s %s", lm.When.Format("2006-01-02 15:04:05"), lm.Msg)
-
+	text := fmt.Sprintf("%s %s", lm.When.Format("2006-01-02 15:04:05"), s.Format(lm))
 	form := url.Values{}
 	form.Add("authorName", s.AuthorName)
 	form.Add("title", s.Title)

--- a/pkg/logs/jianliao.go
+++ b/pkg/logs/jianliao.go
@@ -27,6 +27,10 @@ func (s *JLWriter) Init(jsonconfig string) error {
 	return json.Unmarshal([]byte(jsonconfig), s)
 }
 
+func (s *JLWriter) Format(lm *LogMsg) string {
+	return lm.Msg
+}
+
 // WriteMsg writes message in smtp writer.
 // Sends an email with subject and only this message.
 func (s *JLWriter) WriteMsg(lm *LogMsg) error {

--- a/pkg/logs/logger.go
+++ b/pkg/logs/logger.go
@@ -30,10 +30,10 @@ func newLogWriter(wr io.Writer) *logWriter {
 	return &logWriter{writer: wr}
 }
 
-func (lg *logWriter) writeln(lm *LogMsg) (int, error) {
+func (lg *logWriter) writeln(msg string) (int, error) {
 	lg.Lock()
-	h, _, _ := formatTimeHeader(lm.When)
-	n, err := lg.writer.Write(append(append(h, lm.Msg...), '\n'))
+	msg += "\n"
+	n, err := lg.writer.Write([]byte(msg))
 	lg.Unlock()
 	return n, err
 }

--- a/pkg/logs/multifile.go
+++ b/pkg/logs/multifile.go
@@ -78,6 +78,10 @@ func (f *multiFileLogWriter) Init(config string) error {
 	return nil
 }
 
+func (f *multiFileLogWriter) Format(lm *LogMsg) string {
+	return lm.Msg
+}
+
 func (f *multiFileLogWriter) Destroy() {
 	for i := 0; i < len(f.writers); i++ {
 		if f.writers[i] != nil {

--- a/pkg/logs/slack.go
+++ b/pkg/logs/slack.go
@@ -18,6 +18,10 @@ func newSLACKWriter() Logger {
 	return &SLACKWriter{Level: LevelTrace}
 }
 
+func (s *SLACKWriter) Format(lm *LogMsg) string {
+	return lm.Msg
+}
+
 // Init SLACKWriter with json config string
 func (s *SLACKWriter) Init(jsonconfig string) error {
 	return json.Unmarshal([]byte(jsonconfig), s)

--- a/pkg/logs/slack.go
+++ b/pkg/logs/slack.go
@@ -33,8 +33,8 @@ func (s *SLACKWriter) WriteMsg(lm *LogMsg) error {
 	if lm.Level > s.Level {
 		return nil
 	}
-
-	text := fmt.Sprintf("{\"text\": \"%s %s\"}", lm.When.Format("2006-01-02 15:04:05"), lm.Msg)
+	msg := s.Format(lm)
+	text := fmt.Sprintf("{\"text\": \"%s %s\"}", lm.When.Format("2006-01-02 15:04:05"), msg)
 
 	form := url.Values{}
 	form.Add("payload", text)

--- a/pkg/logs/smtp.go
+++ b/pkg/logs/smtp.go
@@ -114,6 +114,10 @@ func (s *SMTPWriter) sendMail(hostAddressWithPort string, auth smtp.Auth, fromAd
 	return client.Quit()
 }
 
+func (s *SMTPWriter) Format(lm *LogMsg) string {
+	return lm.Msg
+}
+
 // WriteMsg writes message in smtp writer.
 // Sends an email with subject and only this message.
 func (s *SMTPWriter) WriteMsg(lm *LogMsg) error {

--- a/pkg/logs/smtp.go
+++ b/pkg/logs/smtp.go
@@ -130,11 +130,13 @@ func (s *SMTPWriter) WriteMsg(lm *LogMsg) error {
 	// Set up authentication information.
 	auth := s.getSMTPAuth(hp[0])
 
+	msg := s.Format(lm)
+
 	// Connect to the server, authenticate, set the sender and recipient,
 	// and send the email all in one step.
 	contentType := "Content-Type: text/plain" + "; charset=UTF-8"
 	mailmsg := []byte("To: " + strings.Join(s.RecipientAddresses, ";") + "\r\nFrom: " + s.FromAddress + "<" + s.FromAddress +
-		">\r\nSubject: " + s.Subject + "\r\n" + contentType + "\r\n\r\n" + fmt.Sprintf(".%s", lm.When.Format("2006-01-02 15:04:05")) + lm.Msg)
+		">\r\nSubject: " + s.Subject + "\r\n" + contentType + "\r\n\r\n" + fmt.Sprintf(".%s", lm.When.Format("2006-01-02 15:04:05")) + msg)
 
 	return s.sendMail(s.Host, auth, s.FromAddress, s.RecipientAddresses, mailmsg)
 }


### PR DESCRIPTION
Second PR of the custom log formatter. I found this one to be very closely coupled to the third part so I found it quite hard. `LogFormatter` is implemented but no custom formatting is implemented yet which will come in the third PR. 

Most of the work will come in the third actually so this pr isn't very important at all

Works fully with 
```go
package main

import (
	beego "github.com/astaxie/beego/pkg"
	"github.com/astaxie/beego/pkg/logs"
)

type MainController struct {
	beego.Controller
}

func main() {
	// ctrl := &MainController{}
	// beego.Router("/yuppa", ctrl, "get:Yuppa")
	beego.BConfig.Log.AccessLogs = true
	beego.BConfig.Log.AccessLogsFormat = "JSON_FORMAT"
	logs.SetLogger("console", "")
	logs.SetLogger("file", `{"filename":"test.json"}`)

	logs.EnableFullFilePath(true)
	logs.EnableFuncCallDepth(true)
	beego.Run()
}
```