### PR TITLE
Custom logging format PR#3

### DIFF
--- a/pkg/logs/alils/alils.go
+++ b/pkg/logs/alils/alils.go
@@ -130,17 +130,14 @@ func (c *aliLSWriter) WriteMsg(lm *logs.LogMsg) error {
 		if len(strs) == 2 {
 			pos := strings.LastIndex(strs[0], " ")
 			topic = strs[0][pos+1 : len(strs[0])]
-			content = strs[0][0:pos] + strs[1]
 			lg = c.groupMap[topic]
 		}
 
 		// send to empty Topic
 		if lg == nil {
-			content = lm.Msg
 			lg = c.group[0]
 		}
 	} else {
-		content = lm.Msg
 		lg = c.group[0]
 	}
 

--- a/pkg/logs/conn.go
+++ b/pkg/logs/conn.go
@@ -18,20 +18,20 @@ import (
 	"encoding/json"
 	"io"
 	"net"
+
+	"github.com/astaxie/beego/pkg/common"
 )
 
 // connWriter implements LoggerInterface.
 // Writes messages in keep-live tcp connection.
 type connWriter struct {
-	lg                 *logWriter
-	innerWriter        io.WriteCloser
-	UseCustomFormatter bool
-	CustomFormatter    func(*LogMsg) string
-	ReconnectOnMsg     bool   `json:"reconnectOnMsg"`
-	Reconnect          bool   `json:"reconnect"`
-	Net                string `json:"net"`
-	Addr               string `json:"addr"`
-	Level              int    `json:"level"`
+	lg             *logWriter
+	innerWriter    io.WriteCloser
+	ReconnectOnMsg bool   `json:"reconnectOnMsg"`
+	Reconnect      bool   `json:"reconnect"`
+	Net            string `json:"net"`
+	Addr           string `json:"addr"`
+	Level          int    `json:"level"`
 }
 
 // NewConn creates new ConnWrite returning as LoggerInterface.
@@ -47,13 +47,13 @@ func (c *connWriter) Format(lm *LogMsg) string {
 
 // Init initializes a connection writer with json config.
 // json config only needs they "level" key
-func (c *connWriter) Init(jsonConfig string, LogFormatter ...func(*LogMsg) string) error {
-	for _, elem := range LogFormatter {
-		if elem != nil {
-			c.UseCustomFormatter = true
-			c.CustomFormatter = elem
-		}
-	}
+func (c *connWriter) Init(jsonConfig string, opts ...common.SimpleKV) error {
+	// for _, elem := range LogFormatter {
+	// 	if elem != nil {
+	// 		c.UseCustomFormatter = true
+	// 		c.CustomFormatter = elem
+	// 	}
+	// }
 
 	return json.Unmarshal([]byte(jsonConfig), c)
 }

--- a/pkg/logs/conn.go
+++ b/pkg/logs/conn.go
@@ -23,13 +23,15 @@ import (
 // connWriter implements LoggerInterface.
 // Writes messages in keep-live tcp connection.
 type connWriter struct {
-	lg             *logWriter
-	innerWriter    io.WriteCloser
-	ReconnectOnMsg bool   `json:"reconnectOnMsg"`
-	Reconnect      bool   `json:"reconnect"`
-	Net            string `json:"net"`
-	Addr           string `json:"addr"`
-	Level          int    `json:"level"`
+	lg                 *logWriter
+	innerWriter        io.WriteCloser
+	UseCustomFormatter bool
+	CustomFormatter    func(*LogMsg) string
+	ReconnectOnMsg     bool   `json:"reconnectOnMsg"`
+	Reconnect          bool   `json:"reconnect"`
+	Net                string `json:"net"`
+	Addr               string `json:"addr"`
+	Level              int    `json:"level"`
 }
 
 // NewConn creates new ConnWrite returning as LoggerInterface.
@@ -45,7 +47,14 @@ func (c *connWriter) Format(lm *LogMsg) string {
 
 // Init initializes a connection writer with json config.
 // json config only needs they "level" key
-func (c *connWriter) Init(jsonConfig string) error {
+func (c *connWriter) Init(jsonConfig string, LogFormatter ...func(*LogMsg) string) error {
+	for _, elem := range LogFormatter {
+		if elem != nil {
+			c.UseCustomFormatter = true
+			c.CustomFormatter = elem
+		}
+	}
+
 	return json.Unmarshal([]byte(jsonConfig), c)
 }
 

--- a/pkg/logs/console.go
+++ b/pkg/logs/console.go
@@ -81,7 +81,6 @@ func NewConsole() Logger {
 
 // Init initianlizes the console logger.
 // jsonConfig must be in the format '{"level":LevelTrace}'
-// func (c *consoleWriter) Init(jsonConfig string, LogFormatter ...func(*LogMsg) string) error {
 func (c *consoleWriter) Init(jsonConfig string, opts ...common.SimpleKV) error {
 
 	for _, elem := range opts {

--- a/pkg/logs/console.go
+++ b/pkg/logs/console.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/astaxie/beego/pkg/common"
+
 	"github.com/shiena/ansicolor"
 )
 
@@ -47,11 +49,10 @@ var colors = []brush{
 
 // consoleWriter implements LoggerInterface and writes messages to terminal.
 type consoleWriter struct {
-	lg                 *logWriter
-	UseCustomFormatter bool
-	CustomFormatter    func(*LogMsg) string
-	Level              int  `json:"level"`
-	Colorful           bool `json:"color"` //this filed is useful only when system's terminal supports color
+	lg              *logWriter
+	customFormatter func(*LogMsg) string
+	Level           int  `json:"level"`
+	Colorful        bool `json:"color"` //this filed is useful only when system's terminal supports color
 }
 
 func (c *consoleWriter) Format(lm *LogMsg) string {
@@ -80,11 +81,16 @@ func NewConsole() Logger {
 
 // Init initianlizes the console logger.
 // jsonConfig must be in the format '{"level":LevelTrace}'
-func (c *consoleWriter) Init(jsonConfig string, LogFormatter ...func(*LogMsg) string) error {
-	for _, elem := range LogFormatter {
-		if elem != nil {
-			c.UseCustomFormatter = true
-			c.CustomFormatter = elem
+// func (c *consoleWriter) Init(jsonConfig string, LogFormatter ...func(*LogMsg) string) error {
+func (c *consoleWriter) Init(jsonConfig string, opts ...common.SimpleKV) error {
+
+	for _, elem := range opts {
+		if elem.Key == "formatter" {
+			formatter, err := GetFormatter(elem)
+			if err != nil {
+				return err
+			}
+			c.customFormatter = formatter
 		}
 	}
 
@@ -107,10 +113,11 @@ func (c *consoleWriter) WriteMsg(lm *LogMsg) error {
 
 	msg := ""
 
-	if c.UseCustomFormatter {
-		msg = c.CustomFormatter(lm)
+	if c.customFormatter != nil {
+		msg = c.customFormatter(lm)
 	} else {
 		msg = c.Format(lm)
+
 	}
 
 	c.lg.writeln(msg)

--- a/pkg/logs/console.go
+++ b/pkg/logs/console.go
@@ -58,10 +58,6 @@ type consoleWriter struct {
 func (c *consoleWriter) Format(lm *LogMsg) string {
 	msg := lm.Msg
 
-	if c.Colorful {
-		msg = strings.Replace(lm.Msg, levelPrefix[lm.Level], colors[lm.Level](levelPrefix[lm.Level]), 1)
-	}
-
 	h, _, _ := formatTimeHeader(lm.When)
 	bytes := append(append(h, msg...), '\n')
 
@@ -105,12 +101,12 @@ func (c *consoleWriter) WriteMsg(lm *LogMsg) error {
 	if lm.Level > c.Level {
 		return nil
 	}
-	// fmt.Printf("Formatted: %s\n\n", c.fmtter.Format(lm))
+
+	msg := ""
+
 	if c.Colorful {
 		lm.Msg = strings.Replace(lm.Msg, levelPrefix[lm.Level], colors[lm.Level](levelPrefix[lm.Level]), 1)
 	}
-
-	msg := ""
 
 	if c.customFormatter != nil {
 		msg = c.customFormatter(lm)

--- a/pkg/logs/file.go
+++ b/pkg/logs/file.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/astaxie/beego/pkg/common"
 )
 
 // fileLogWriter implements LoggerInterface.
@@ -107,13 +109,13 @@ func (w *fileLogWriter) Format(lm *LogMsg) string {
 //  "rotate":true,
 //      "perm":"0600"
 //  }
-func (w *fileLogWriter) Init(jsonConfig string, LogFormatter ...func(*LogMsg) string) error {
-	for _, elem := range LogFormatter {
-		if elem != nil {
-			w.UseCustomFormatter = true
-			w.CustomFormatter = elem
-		}
-	}
+func (w *fileLogWriter) Init(jsonConfig string, opts ...common.SimpleKV) error {
+	// for _, elem := range LogFormatter {
+	// 	if elem != nil {
+	// 		w.UseCustomFormatter = true
+	// 		w.CustomFormatter = elem
+	// 	}
+	// }
 
 	err := json.Unmarshal([]byte(jsonConfig), w)
 	if err != nil {

--- a/pkg/logs/jianliao.go
+++ b/pkg/logs/jianliao.go
@@ -9,12 +9,14 @@ import (
 
 // JLWriter implements beego LoggerInterface and is used to send jiaoliao webhook
 type JLWriter struct {
-	AuthorName  string `json:"authorname"`
-	Title       string `json:"title"`
-	WebhookURL  string `json:"webhookurl"`
-	RedirectURL string `json:"redirecturl,omitempty"`
-	ImageURL    string `json:"imageurl,omitempty"`
-	Level       int    `json:"level"`
+	AuthorName         string `json:"authorname"`
+	Title              string `json:"title"`
+	WebhookURL         string `json:"webhookurl"`
+	RedirectURL        string `json:"redirecturl,omitempty"`
+	ImageURL           string `json:"imageurl,omitempty"`
+	Level              int    `json:"level"`
+	UseCustomFormatter bool
+	CustomFormatter    func(*LogMsg) string
 }
 
 // newJLWriter creates jiaoliao writer.
@@ -23,7 +25,14 @@ func newJLWriter() Logger {
 }
 
 // Init JLWriter with json config string
-func (s *JLWriter) Init(jsonconfig string) error {
+func (s *JLWriter) Init(jsonconfig string, LogFormatter ...func(*LogMsg) string) error {
+	for _, elem := range LogFormatter {
+		if elem != nil {
+			s.UseCustomFormatter = true
+			s.CustomFormatter = elem
+		}
+	}
+
 	return json.Unmarshal([]byte(jsonconfig), s)
 }
 

--- a/pkg/logs/jianliao.go
+++ b/pkg/logs/jianliao.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+
+	"github.com/astaxie/beego/pkg/common"
 )
 
 // JLWriter implements beego LoggerInterface and is used to send jiaoliao webhook
@@ -25,15 +27,15 @@ func newJLWriter() Logger {
 }
 
 // Init JLWriter with json config string
-func (s *JLWriter) Init(jsonconfig string, LogFormatter ...func(*LogMsg) string) error {
-	for _, elem := range LogFormatter {
-		if elem != nil {
-			s.UseCustomFormatter = true
-			s.CustomFormatter = elem
-		}
-	}
+func (s *JLWriter) Init(jsonConfig string, opts ...common.SimpleKV) error {
+	// for _, elem := range LogFormatter {
+	// 	if elem != nil {
+	// 		s.UseCustomFormatter = true
+	// 		s.CustomFormatter = elem
+	// 	}
+	// }
 
-	return json.Unmarshal([]byte(jsonconfig), s)
+	return json.Unmarshal([]byte(jsonConfig), s)
 }
 
 func (s *JLWriter) Format(lm *LogMsg) string {

--- a/pkg/logs/jianliao.go
+++ b/pkg/logs/jianliao.go
@@ -11,14 +11,13 @@ import (
 
 // JLWriter implements beego LoggerInterface and is used to send jiaoliao webhook
 type JLWriter struct {
-	AuthorName         string `json:"authorname"`
-	Title              string `json:"title"`
-	WebhookURL         string `json:"webhookurl"`
-	RedirectURL        string `json:"redirecturl,omitempty"`
-	ImageURL           string `json:"imageurl,omitempty"`
-	Level              int    `json:"level"`
-	UseCustomFormatter bool
-	CustomFormatter    func(*LogMsg) string
+	AuthorName      string `json:"authorname"`
+	Title           string `json:"title"`
+	WebhookURL      string `json:"webhookurl"`
+	RedirectURL     string `json:"redirecturl,omitempty"`
+	ImageURL        string `json:"imageurl,omitempty"`
+	Level           int    `json:"level"`
+	customFormatter func(*LogMsg) string
 }
 
 // newJLWriter creates jiaoliao writer.
@@ -28,12 +27,15 @@ func newJLWriter() Logger {
 
 // Init JLWriter with json config string
 func (s *JLWriter) Init(jsonConfig string, opts ...common.SimpleKV) error {
-	// for _, elem := range LogFormatter {
-	// 	if elem != nil {
-	// 		s.UseCustomFormatter = true
-	// 		s.CustomFormatter = elem
-	// 	}
-	// }
+	for _, elem := range opts {
+		if elem.Key == "formatter" {
+			formatter, err := GetFormatter(elem)
+			if err != nil {
+				return err
+			}
+			s.customFormatter = formatter
+		}
+	}
 
 	return json.Unmarshal([]byte(jsonConfig), s)
 }
@@ -49,7 +51,15 @@ func (s *JLWriter) WriteMsg(lm *LogMsg) error {
 		return nil
 	}
 
-	text := fmt.Sprintf("%s %s", lm.When.Format("2006-01-02 15:04:05"), s.Format(lm))
+	text := ""
+
+	if s.customFormatter != nil {
+		text = fmt.Sprintf("%s %s", lm.When.Format("2006-01-02 15:04:05"), s.customFormatter(lm))
+	} else {
+		text = fmt.Sprintf("%s %s", lm.When.Format("2006-01-02 15:04:05"), s.Format(lm))
+
+	}
+
 	form := url.Values{}
 	form.Add("authorName", s.AuthorName)
 	form.Add("title", s.Title)

--- a/pkg/logs/log.go
+++ b/pkg/logs/log.go
@@ -213,7 +213,7 @@ func (bl *BeeLogger) setLogger(adapterName string, configs ...string) error {
 	// Global formatter overrides the default set formatter
 	// but not adapter specific formatters set with logs.SetLoggerWithOpts()
 	if bl.globalFormatter != nil {
-		err = lg.Init(config)
+		err = lg.Init(config, common.SimpleKV{Key: "formatter", Value: bl.globalFormatter})
 	} else {
 		err = lg.Init(config)
 	}

--- a/pkg/logs/logformattertest/log_formatter_test.go
+++ b/pkg/logs/logformattertest/log_formatter_test.go
@@ -1,0 +1,36 @@
+package logformattertest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/astaxie/beego/pkg/common"
+	"github.com/astaxie/beego/pkg/logs"
+)
+
+func customFormatter(lm *logs.LogMsg) string {
+	return fmt.Sprintf("[CUSTOM CONSOLE LOGGING] %s", lm.Msg)
+}
+
+func globalFormatter(lm *logs.LogMsg) string {
+	return fmt.Sprintf("[GLOBAL] %s", lm.Msg)
+}
+
+func TestCustomLoggingFormatter(t *testing.T) {
+	// beego.BConfig.Log.AccessLogs = true
+
+	logs.SetLoggerWithOpts("console", []string{`{"color":true}`}, common.SimpleKV{Key: "formatter", Value: customFormatter})
+
+	// Message will be formatted by the customFormatter with colorful text set to true
+	logs.Informational("Test message")
+}
+
+func TestGlobalLoggingFormatter(t *testing.T) {
+	logs.SetGlobalFormatter(globalFormatter)
+
+	logs.SetLogger("console", `{"color":true}`)
+
+	// Message will be formatted by globalFormatter
+	logs.Informational("Test message")
+
+}

--- a/pkg/logs/multifile.go
+++ b/pkg/logs/multifile.go
@@ -16,6 +16,8 @@ package logs
 
 import (
 	"encoding/json"
+
+	"github.com/astaxie/beego/pkg/common"
 )
 
 // A filesLogWriter manages several fileLogWriter
@@ -46,16 +48,16 @@ var levelNames = [...]string{"emergency", "alert", "critical", "error", "warning
 //	"separate":["emergency", "alert", "critical", "error", "warning", "notice", "info", "debug"],
 //	}
 
-func (f *multiFileLogWriter) Init(config string, LogFormatter ...func(*LogMsg) string) error {
-	for _, elem := range LogFormatter {
-		if elem != nil {
-			f.UseCustomFormatter = true
-			f.CustomFormatter = elem
-		}
-	}
+func (f *multiFileLogWriter) Init(jsonConfig string, opts ...common.SimpleKV) error {
+	// for _, elem := range LogFormatter {
+	// 	if elem != nil {
+	// 		f.UseCustomFormatter = true
+	// 		f.CustomFormatter = elem
+	// 	}
+	// }
 
 	writer := newFileWriter().(*fileLogWriter)
-	err := writer.Init(config)
+	err := writer.Init(jsonConfig)
 	if err != nil {
 		return err
 	}
@@ -63,10 +65,10 @@ func (f *multiFileLogWriter) Init(config string, LogFormatter ...func(*LogMsg) s
 	f.writers[LevelDebug+1] = writer
 
 	//unmarshal "separate" field to f.Separate
-	json.Unmarshal([]byte(config), f)
+	json.Unmarshal([]byte(jsonConfig), f)
 
 	jsonMap := map[string]interface{}{}
-	json.Unmarshal([]byte(config), &jsonMap)
+	json.Unmarshal([]byte(jsonConfig), &jsonMap)
 
 	for i := LevelEmergency; i < LevelDebug+1; i++ {
 		for _, v := range f.Separate {

--- a/pkg/logs/multifile.go
+++ b/pkg/logs/multifile.go
@@ -26,11 +26,10 @@ import (
 // and write the error-level logs to project.error.log and write the debug-level logs to project.debug.log
 // the rotate attribute also  acts like fileLogWriter
 type multiFileLogWriter struct {
-	writers            [LevelDebug + 1 + 1]*fileLogWriter // the last one for fullLogWriter
-	fullLogWriter      *fileLogWriter
-	Separate           []string `json:"separate"`
-	UseCustomFormatter bool
-	CustomFormatter    func(*LogMsg) string
+	writers         [LevelDebug + 1 + 1]*fileLogWriter // the last one for fullLogWriter
+	fullLogWriter   *fileLogWriter
+	Separate        []string `json:"separate"`
+	customFormatter func(*LogMsg) string
 }
 
 var levelNames = [...]string{"emergency", "alert", "critical", "error", "warning", "notice", "info", "debug"}
@@ -49,12 +48,15 @@ var levelNames = [...]string{"emergency", "alert", "critical", "error", "warning
 //	}
 
 func (f *multiFileLogWriter) Init(jsonConfig string, opts ...common.SimpleKV) error {
-	// for _, elem := range LogFormatter {
-	// 	if elem != nil {
-	// 		f.UseCustomFormatter = true
-	// 		f.CustomFormatter = elem
-	// 	}
-	// }
+	for _, elem := range opts {
+		if elem.Key == "formatter" {
+			formatter, err := GetFormatter(elem)
+			if err != nil {
+				return err
+			}
+			f.customFormatter = formatter
+		}
+	}
 
 	writer := newFileWriter().(*fileLogWriter)
 	err := writer.Init(jsonConfig)

--- a/pkg/logs/slack.go
+++ b/pkg/logs/slack.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+
+	"github.com/astaxie/beego/pkg/common"
 )
 
 // SLACKWriter implements beego LoggerInterface and is used to send jiaoliao webhook
@@ -25,15 +27,14 @@ func (s *SLACKWriter) Format(lm *LogMsg) string {
 }
 
 // Init SLACKWriter with json config string
-func (s *SLACKWriter) Init(jsonconfig string, LogFormatter ...func(*LogMsg) string) error {
-	for _, elem := range LogFormatter {
-		if elem != nil {
-			s.UseCustomFormatter = true
-			s.CustomFormatter = elem
-		}
-	}
+func (s *SLACKWriter) Init(jsonConfig string, opts ...common.SimpleKV) error {
+	// 	if elem != nil {
+	// 		s.UseCustomFormatter = true
+	// 		s.CustomFormatter = elem
+	// 	}
+	// }
 
-	return json.Unmarshal([]byte(jsonconfig), s)
+	return json.Unmarshal([]byte(jsonConfig), s)
 }
 
 // WriteMsg write message in smtp writer.

--- a/pkg/logs/slack.go
+++ b/pkg/logs/slack.go
@@ -9,8 +9,10 @@ import (
 
 // SLACKWriter implements beego LoggerInterface and is used to send jiaoliao webhook
 type SLACKWriter struct {
-	WebhookURL string `json:"webhookurl"`
-	Level      int    `json:"level"`
+	WebhookURL         string `json:"webhookurl"`
+	Level              int    `json:"level"`
+	UseCustomFormatter bool
+	CustomFormatter    func(*LogMsg) string
 }
 
 // newSLACKWriter creates jiaoliao writer.
@@ -23,7 +25,14 @@ func (s *SLACKWriter) Format(lm *LogMsg) string {
 }
 
 // Init SLACKWriter with json config string
-func (s *SLACKWriter) Init(jsonconfig string) error {
+func (s *SLACKWriter) Init(jsonconfig string, LogFormatter ...func(*LogMsg) string) error {
+	for _, elem := range LogFormatter {
+		if elem != nil {
+			s.UseCustomFormatter = true
+			s.CustomFormatter = elem
+		}
+	}
+
 	return json.Unmarshal([]byte(jsonconfig), s)
 }
 

--- a/pkg/logs/smtp.go
+++ b/pkg/logs/smtp.go
@@ -32,6 +32,8 @@ type SMTPWriter struct {
 	FromAddress        string   `json:"fromAddress"`
 	RecipientAddresses []string `json:"sendTos"`
 	Level              int      `json:"level"`
+	UseCustomFormatter bool
+	CustomFormatter    func(*LogMsg) string
 }
 
 // NewSMTPWriter creates the smtp writer.
@@ -50,7 +52,14 @@ func newSMTPWriter() Logger {
 //		"sendTos":["email1","email2"],
 //		"level":LevelError
 //	}
-func (s *SMTPWriter) Init(jsonconfig string) error {
+func (s *SMTPWriter) Init(jsonconfig string, LogFormatter ...func(*LogMsg) string) error {
+	for _, elem := range LogFormatter {
+		if elem != nil {
+			s.UseCustomFormatter = true
+			s.CustomFormatter = elem
+		}
+	}
+
 	return json.Unmarshal([]byte(jsonconfig), s)
 }
 

--- a/pkg/logs/smtp.go
+++ b/pkg/logs/smtp.go
@@ -21,6 +21,8 @@ import (
 	"net"
 	"net/smtp"
 	"strings"
+
+	"github.com/astaxie/beego/pkg/common"
 )
 
 // SMTPWriter implements LoggerInterface and is used to send emails via given SMTP-server.
@@ -52,15 +54,15 @@ func newSMTPWriter() Logger {
 //		"sendTos":["email1","email2"],
 //		"level":LevelError
 //	}
-func (s *SMTPWriter) Init(jsonconfig string, LogFormatter ...func(*LogMsg) string) error {
-	for _, elem := range LogFormatter {
-		if elem != nil {
-			s.UseCustomFormatter = true
-			s.CustomFormatter = elem
-		}
-	}
+func (s *SMTPWriter) Init(jsonConfig string, opts ...common.SimpleKV) error {
+	// for _, elem := range LogFormatter {
+	// 	if elem != nil {
+	// 		s.UseCustomFormatter = true
+	// 		s.CustomFormatter = elem
+	// 	}
+	// }
 
-	return json.Unmarshal([]byte(jsonconfig), s)
+	return json.Unmarshal([]byte(jsonConfig), s)
 }
 
 func (s *SMTPWriter) getSMTPAuth(host string) smtp.Auth {

--- a/pkg/logs/smtp.go
+++ b/pkg/logs/smtp.go
@@ -34,8 +34,7 @@ type SMTPWriter struct {
 	FromAddress        string   `json:"fromAddress"`
 	RecipientAddresses []string `json:"sendTos"`
 	Level              int      `json:"level"`
-	UseCustomFormatter bool
-	CustomFormatter    func(*LogMsg) string
+	customFormatter    func(*LogMsg) string
 }
 
 // NewSMTPWriter creates the smtp writer.
@@ -55,12 +54,16 @@ func newSMTPWriter() Logger {
 //		"level":LevelError
 //	}
 func (s *SMTPWriter) Init(jsonConfig string, opts ...common.SimpleKV) error {
-	// for _, elem := range LogFormatter {
-	// 	if elem != nil {
-	// 		s.UseCustomFormatter = true
-	// 		s.CustomFormatter = elem
-	// 	}
-	// }
+
+	for _, elem := range opts {
+		if elem.Key == "formatter" {
+			formatter, err := GetFormatter(elem)
+			if err != nil {
+				return err
+			}
+			s.customFormatter = formatter
+		}
+	}
 
 	return json.Unmarshal([]byte(jsonConfig), s)
 }


### PR DESCRIPTION
## Features

Final PR for the custom log formatter

* Implements `SetLoggerWithOpt` func to allow users to define custom logging formats. Users only need to provide a function with the following signature
```go
func (lm *logs.LogMsg) string
```
* Implements `SetGlobalFormatter` to allow users to set a global formatter if they so choose. Users again use the same signature 
```go
func (lm *logs.LogMsg) string
```


The hierarchy goes like this:
### adapter specific formatter > global formatter > default formatter
i.e adapter specific can override global formatters and global formatters can override default set formatters

## Example code
```go
package main

import (
	"fmt"

	beego "github.com/astaxie/beego/pkg"
	"github.com/astaxie/beego/pkg/logs"
)

type MainController struct {
	beego.Controller
}

func customFormatter(lm *logs.LogMsg) string {
	return fmt.Sprintf("[CUSTOM CONSOLE LOGGING] %s", lm.Msg)
}

func customFormatter2(lm *logs.LogMsg) string {
	return fmt.Sprintf("[CUSTOM FILE LOGGING] %s", lm.Msg)
}

func GlobalFormatter(lm *logs.LogMsg) string {
	return fmt.Sprintf("[GLOBAL] %s", lm.Msg)
}

func main() {

	beego.BConfig.Log.AccessLogs = true

	// GlobalFormatter only overrides default log adapters. Hierarchy is like this:
	// adapter specific formatter > global formatter > default formatter
	logs.SetGlobalFormatter(GlobalFormatter)

	// logs.SetLogger("console", "")
	// logs.SetLogger("file", `{"filename":"test.json"}`)

	logs.SetLoggerWithOpts("console", []string{""}, customFormatter)
	logs.SetLoggerWithOpts("file", []string{`{"filename":"test.json"}`}, customFormatter2)

	logs.EnableFullFilePath(false)
	logs.EnableFuncCallDepth(true)
	beego.Run()
}
```