### PR TITLE
supplement datetime precision UT

### DIFF
--- a/pkg/client/orm/cmd_utils.go
+++ b/pkg/client/orm/cmd_utils.go
@@ -66,12 +66,14 @@ checkColumn:
 	case TypeDateField:
 		col = T["time.Time-date"]
 	case TypeDateTimeField:
-		if fi.timePrecision == nil {
+		// the precision of sqlite is not implemented
+		if al.Driver == 2 || fi.timePrecision == nil {
 			col = T["time.Time"]
-		} else {
+		}else {
 			s := T["time.Time-precision"]
 			col = fmt.Sprintf(s, *fi.timePrecision)
 		}
+
 	case TypeBitField:
 		col = T["int8"]
 	case TypeSmallIntegerField:

--- a/pkg/client/orm/models_test.go
+++ b/pkg/client/orm/models_test.go
@@ -241,6 +241,21 @@ type UserBig struct {
 	Name string
 }
 
+type TM struct {
+	ID            int      `orm:"column(id)"`
+	TMPrecision1 time.Time `orm:"type(datetime);precision(3)"`
+	TMPrecision2 time.Time `orm:"auto_now_add;type(datetime);precision(4)"`
+}
+
+func (t *TM) TableName() string {
+	return "tm"
+}
+
+func NewTM() *TM {
+	obj := new(TM)
+	return obj
+}
+
 type User struct {
 	ID           int    `orm:"column(id)"`
 	UserName     string `orm:"size(30);unique"`

--- a/pkg/client/orm/orm_test.go
+++ b/pkg/client/orm/orm_test.go
@@ -204,6 +204,7 @@ func TestSyncDb(t *testing.T) {
 	RegisterModel(new(PtrPk))
 	RegisterModel(new(Index))
 	RegisterModel(new(StrPk))
+	RegisterModel(new(TM))
 
 	err := RunSyncdb("default", true, Debug)
 	throwFail(t, err)
@@ -230,6 +231,7 @@ func TestRegisterModels(t *testing.T) {
 	RegisterModel(new(PtrPk))
 	RegisterModel(new(Index))
 	RegisterModel(new(StrPk))
+	RegisterModel(new(TM))
 
 	BootStrap()
 
@@ -311,6 +313,24 @@ func TestDataTypes(t *testing.T) {
 			assert.Equal(t, value, vu)
 		}
 	}
+}
+
+func TestTM(t *testing.T) {
+	// The precision of sqlite is not implemented
+	if dORM.Driver().Type() == 2 {
+		return
+	}
+	var recTM TM
+	tm := NewTM()
+	tm.TMPrecision1 = time.Unix(1596766024, 123456789)
+	tm.TMPrecision2 = time.Unix(1596766024, 123456789)
+	_, err := dORM.Insert(tm)
+	throwFail(t, err)
+
+	err = dORM.QueryTable("tm").One(&recTM)
+	throwFail(t, err)
+	throwFail(t, AssertIs(recTM.TMPrecision1.String(), "2020-08-07 02:07:04.123 +0000 UTC"))
+	throwFail(t, AssertIs(recTM.TMPrecision2.String(), "2020-08-07 02:07:04.1235 +0000 UTC"))
 }
 
 func TestNullDataTypes(t *testing.T) {


### PR DESCRIPTION
1. Supplement UT.
2. Fix hidden bug ：the precision of sqlite is not implemented.