### PR TITLE
Enhancement/Add a new MySQL operator for strict case sensitive query

### DIFF
--- a/orm/db.go
+++ b/orm/db.go
@@ -36,10 +36,11 @@ var (
 
 var (
 	operators = map[string]bool{
-		"exact":     true,
-		"iexact":    true,
-		"contains":  true,
-		"icontains": true,
+		"exact":       true,
+		"iexact":      true,
+		"strictexact": true,
+		"contains":    true,
+		"icontains":   true,
 		// "regex":       true,
 		// "iregex":      true,
 		"gt":          true,
@@ -1202,7 +1203,7 @@ func (d *dbBase) GenerateOperatorSQL(mi *modelInfo, fi *fieldInfo, operator stri
 		}
 		sql = d.ins.OperatorSQL(operator)
 		switch operator {
-		case "exact":
+		case "exact", "strictexact":
 			if arg == nil {
 				params[0] = "IS NULL"
 			}

--- a/orm/db_mysql.go
+++ b/orm/db_mysql.go
@@ -22,10 +22,11 @@ import (
 
 // mysql operators.
 var mysqlOperators = map[string]string{
-	"exact":     "= BINARY ?",
-	"iexact":    "LIKE ?",
-	"contains":  "LIKE BINARY ?",
-	"icontains": "LIKE ?",
+	"exact":       "= ?",
+	"iexact":      "LIKE ?",
+	"strictexact": "= BINARY ?",
+	"contains":    "LIKE BINARY ?",
+	"icontains":   "LIKE ?",
 	// "regex":       "REGEXP BINARY ?",
 	// "iregex":      "REGEXP ?",
 	"gt":          "> ?",

--- a/orm/db_mysql.go
+++ b/orm/db_mysql.go
@@ -22,7 +22,7 @@ import (
 
 // mysql operators.
 var mysqlOperators = map[string]string{
-	"exact":     "= ?",
+	"exact":     "= BINARY ?",
 	"iexact":    "LIKE ?",
 	"contains":  "LIKE BINARY ?",
 	"icontains": "LIKE ?",

--- a/orm/orm_test.go
+++ b/orm/orm_test.go
@@ -822,13 +822,16 @@ func TestOperators(t *testing.T) {
 	throwFail(t, err)
 	throwFail(t, AssertIs(num, 1))
 
-	num, err = qs.Filter("user_name__strictexact", "Slene").Count()
-	throwFail(t, err)
-	throwFail(t, AssertIs(num, 0))
+	if dORM.Driver().Name() == "mysql" {
+		// Now only mysql support `strictexact`
+		num, err = qs.Filter("user_name__strictexact", "Slene").Count()
+		throwFail(t, err)
+		throwFail(t, AssertIs(num, 0))
 
-	num, err = qs.Filter("user_name__strictexact", "slene").Count()
-	throwFail(t, err)
-	throwFail(t, AssertIs(num, 1))
+		num, err = qs.Filter("user_name__strictexact", "slene").Count()
+		throwFail(t, err)
+		throwFail(t, AssertIs(num, 1))
+	}
 
 	num, err = qs.Filter("user_name__contains", "e").Count()
 	throwFail(t, err)

--- a/orm/orm_test.go
+++ b/orm/orm_test.go
@@ -822,7 +822,7 @@ func TestOperators(t *testing.T) {
 	throwFail(t, err)
 	throwFail(t, AssertIs(num, 1))
 
-	if dORM.Driver().Name() == "mysql" {
+	if IsMysql {
 		// Now only mysql support `strictexact`
 		num, err = qs.Filter("user_name__strictexact", "Slene").Count()
 		throwFail(t, err)

--- a/orm/orm_test.go
+++ b/orm/orm_test.go
@@ -822,6 +822,14 @@ func TestOperators(t *testing.T) {
 	throwFail(t, err)
 	throwFail(t, AssertIs(num, 1))
 
+	num, err = qs.Filter("user_name__strictexact", "Slene").Count()
+	throwFail(t, err)
+	throwFail(t, AssertIs(num, 0))
+
+	num, err = qs.Filter("user_name__strictexact", "slene").Count()
+	throwFail(t, err)
+	throwFail(t, AssertIs(num, 1))
+
 	num, err = qs.Filter("user_name__contains", "e").Count()
 	throwFail(t, err)
 	throwFail(t, AssertIs(num, 2))


### PR DESCRIPTION
Using `BINARY` key for `exact` operator in MySQL query.<br/>
Since the default collation shipped from MySQL is case insensitive and accent insensitive, making `exact` always case sensitive could avoid confusions.<br/>
Besides, adding a `BINARY` to `exact` operator makes it align with other operators, like [contains](https://github.com/astaxie/beego/blob/f946a35acd6fa002da765cfbdcda9c393b2f30ee/orm/db_mysql.go#L27) operator.