### PR TITLE
allow users to ignore some table when run orm commands

### DIFF
--- a/pkg/client/orm/cmd.go
+++ b/pkg/client/orm/cmd.go
@@ -142,6 +142,12 @@ func (d *commandSyncDb) Run() error {
 	}
 
 	for i, mi := range modelCache.allOrdered() {
+
+		if !isApplicableTableForDB(mi.addrField, d.al.Name) {
+			fmt.Printf("table `%s` is not applicable to database '%s'\n", mi.table, d.al.Name)
+			continue
+		}
+
 		if tables[mi.table] {
 			if !d.noInfo {
 				fmt.Printf("table `%s` already exists, skip\n", mi.table)

--- a/pkg/client/orm/models.go
+++ b/pkg/client/orm/models.go
@@ -414,7 +414,7 @@ func (mc *_modelCache) getDbDropSQL(al *alias) (queries []string, err error) {
 	for _, mi := range modelCache.allOrdered() {
 		queries = append(queries, fmt.Sprintf(`DROP TABLE IF EXISTS %s%s%s`, Q, mi.table, Q))
 	}
-	return queries,nil
+	return queries, nil
 }
 
 //getDbCreateSQL get database scheme creation sql queries

--- a/pkg/client/orm/models_utils.go
+++ b/pkg/client/orm/models_utils.go
@@ -107,6 +107,18 @@ func getTableUnique(val reflect.Value) [][]string {
 	return nil
 }
 
+// get whether the table needs to be created for the database alias
+func isApplicableTableForDB(val reflect.Value, db string) bool {
+	fun := val.MethodByName("IsApplicableTableForDB")
+	if fun.IsValid() {
+		vals := fun.Call([]reflect.Value{reflect.ValueOf(db)})
+		if len(vals) > 0 && vals[0].Kind() == reflect.Bool {
+			return vals[0].Bool()
+		}
+	}
+	return true
+}
+
 // get snaked column name
 func getColumnName(ft int, addrField reflect.Value, sf reflect.StructField, col string) string {
 	column := col

--- a/pkg/client/orm/models_utils_test.go
+++ b/pkg/client/orm/models_utils_test.go
@@ -1,0 +1,35 @@
+// Copyright 2020
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orm
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type NotApplicableModel struct {
+	Id int
+}
+
+func (n *NotApplicableModel) IsApplicableTableForDB(db string) bool {
+	return db == "default"
+}
+
+func Test_IsApplicableTableForDB(t *testing.T) {
+	assert.False(t, isApplicableTableForDB(reflect.ValueOf(&NotApplicableModel{}), "defa"))
+	assert.True(t, isApplicableTableForDB(reflect.ValueOf(&NotApplicableModel{}), "default"))
+}

--- a/pkg/client/orm/types.go
+++ b/pkg/client/orm/types.go
@@ -75,6 +75,11 @@ type TableUniqueI interface {
 	TableUnique() [][]string
 }
 
+// IsApplicableTableForDB if return false, we won't create table to this db
+type IsApplicableTableForDB interface {
+	IsApplicableTableForDB(db string) bool
+}
+
 // Driver define database driver
 type Driver interface {
 	Name() string


### PR DESCRIPTION
As @asif-fndr mentioned in #3495, this is a common use case for to-B applications  that sometimes we register model but we don't want beego to create tables for specific DBs.

So I move that pr here.
