### PR TITLE
Optimize orm by using BDOption rather than hints

### DIFF
--- a/pkg/adapter/orm/db_alias.go
+++ b/pkg/adapter/orm/db_alias.go
@@ -20,8 +20,6 @@ import (
 	"time"
 
 	"github.com/astaxie/beego/pkg/client/orm"
-	"github.com/astaxie/beego/pkg/client/orm/hints"
-	"github.com/astaxie/beego/pkg/infrastructure/utils"
 )
 
 // DriverType database driver constant int.
@@ -86,13 +84,13 @@ func AddAliasWthDB(aliasName, driverName string, db *sql.DB) error {
 
 // RegisterDataBase Setting the database connect params. Use the database driver self dataSource args.
 func RegisterDataBase(aliasName, driverName, dataSource string, params ...int) error {
-	opts := make([]utils.KV, 0, 2)
+	opts := make([]orm.DBOption, 0, 2)
 	if len(params) > 0 {
-		opts = append(opts, hints.MaxIdleConnections(params[0]))
+		opts = append(opts, orm.MaxIdleConnections(params[0]))
 	}
 
 	if len(params) > 1 {
-		opts = append(opts, hints.MaxOpenConnections(params[1]))
+		opts = append(opts, orm.MaxOpenConnections(params[1]))
 	}
 	return orm.RegisterDataBase(aliasName, driverName, dataSource, opts...)
 }

--- a/pkg/client/orm/db_alias_test.go
+++ b/pkg/client/orm/db_alias_test.go
@@ -18,16 +18,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/astaxie/beego/pkg/client/orm/hints"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRegisterDataBase(t *testing.T) {
 	err := RegisterDataBase("test-params", DBARGS.Driver, DBARGS.Source,
-		hints.MaxIdleConnections(20),
-		hints.MaxOpenConnections(300),
-		hints.ConnMaxLifetime(time.Minute))
+		MaxIdleConnections(20),
+		MaxOpenConnections(300),
+		ConnMaxLifetime(time.Minute))
 	assert.Nil(t, err)
 
 	al := getDbAlias("test-params")
@@ -39,7 +37,7 @@ func TestRegisterDataBase(t *testing.T) {
 
 func TestRegisterDataBase_MaxStmtCacheSizeNegative1(t *testing.T) {
 	aliasName := "TestRegisterDataBase_MaxStmtCacheSizeNegative1"
-	err := RegisterDataBase(aliasName, DBARGS.Driver, DBARGS.Source, hints.MaxStmtCacheSize(-1))
+	err := RegisterDataBase(aliasName, DBARGS.Driver, DBARGS.Source, MaxStmtCacheSize(-1))
 	assert.Nil(t, err)
 
 	al := getDbAlias(aliasName)
@@ -49,7 +47,7 @@ func TestRegisterDataBase_MaxStmtCacheSizeNegative1(t *testing.T) {
 
 func TestRegisterDataBase_MaxStmtCacheSize0(t *testing.T) {
 	aliasName := "TestRegisterDataBase_MaxStmtCacheSize0"
-	err := RegisterDataBase(aliasName, DBARGS.Driver, DBARGS.Source, hints.MaxStmtCacheSize(0))
+	err := RegisterDataBase(aliasName, DBARGS.Driver, DBARGS.Source, MaxStmtCacheSize(0))
 	assert.Nil(t, err)
 
 	al := getDbAlias(aliasName)
@@ -59,7 +57,7 @@ func TestRegisterDataBase_MaxStmtCacheSize0(t *testing.T) {
 
 func TestRegisterDataBase_MaxStmtCacheSize1(t *testing.T) {
 	aliasName := "TestRegisterDataBase_MaxStmtCacheSize1"
-	err := RegisterDataBase(aliasName, DBARGS.Driver, DBARGS.Source, hints.MaxStmtCacheSize(1))
+	err := RegisterDataBase(aliasName, DBARGS.Driver, DBARGS.Source, MaxStmtCacheSize(1))
 	assert.Nil(t, err)
 
 	al := getDbAlias(aliasName)
@@ -69,7 +67,7 @@ func TestRegisterDataBase_MaxStmtCacheSize1(t *testing.T) {
 
 func TestRegisterDataBase_MaxStmtCacheSize841(t *testing.T) {
 	aliasName := "TestRegisterDataBase_MaxStmtCacheSize841"
-	err := RegisterDataBase(aliasName, DBARGS.Driver, DBARGS.Source, hints.MaxStmtCacheSize(841))
+	err := RegisterDataBase(aliasName, DBARGS.Driver, DBARGS.Source, MaxStmtCacheSize(841))
 	assert.Nil(t, err)
 
 	al := getDbAlias(aliasName)

--- a/pkg/client/orm/hints/db_hints.go
+++ b/pkg/client/orm/hints/db_hints.go
@@ -15,20 +15,12 @@
 package hints
 
 import (
-	"time"
-
 	"github.com/astaxie/beego/pkg/infrastructure/utils"
 )
 
 const (
-	//db level
-	KeyMaxIdleConnections = iota
-	KeyMaxOpenConnections
-	KeyConnMaxLifetime
-	KeyMaxStmtCacheSize
-
 	//query level
-	KeyForceIndex
+	KeyForceIndex = iota
 	KeyUseIndex
 	KeyIgnoreIndex
 	KeyForUpdate
@@ -56,26 +48,6 @@ func (s *Hint) GetValue() interface{} {
 }
 
 var _ utils.KV = new(Hint)
-
-// MaxIdleConnections return a hint about MaxIdleConnections
-func MaxIdleConnections(v int) *Hint {
-	return NewHint(KeyMaxIdleConnections, v)
-}
-
-// MaxOpenConnections return a hint about MaxOpenConnections
-func MaxOpenConnections(v int) *Hint {
-	return NewHint(KeyMaxOpenConnections, v)
-}
-
-// ConnMaxLifetime return a hint about ConnMaxLifetime
-func ConnMaxLifetime(v time.Duration) *Hint {
-	return NewHint(KeyConnMaxLifetime, v)
-}
-
-// MaxStmtCacheSize return a hint about MaxStmtCacheSize
-func MaxStmtCacheSize(v int) *Hint {
-	return NewHint(KeyMaxStmtCacheSize, v)
-}
 
 // ForceIndex return a hint about ForceIndex
 func ForceIndex(indexes ...string) *Hint {

--- a/pkg/client/orm/hints/db_hints_test.go
+++ b/pkg/client/orm/hints/db_hints_test.go
@@ -48,34 +48,6 @@ func TestNewHint_float(t *testing.T) {
 	assert.Equal(t, hint.GetValue(), value)
 }
 
-func TestMaxOpenConnections(t *testing.T) {
-	i := 887423
-	hint := MaxOpenConnections(i)
-	assert.Equal(t, hint.GetValue(), i)
-	assert.Equal(t, hint.GetKey(), KeyMaxOpenConnections)
-}
-
-func TestConnMaxLifetime(t *testing.T) {
-	i := time.Hour
-	hint := ConnMaxLifetime(i)
-	assert.Equal(t, hint.GetValue(), i)
-	assert.Equal(t, hint.GetKey(), KeyConnMaxLifetime)
-}
-
-func TestMaxIdleConnections(t *testing.T) {
-	i := 42316
-	hint := MaxIdleConnections(i)
-	assert.Equal(t, hint.GetValue(), i)
-	assert.Equal(t, hint.GetKey(), KeyMaxIdleConnections)
-}
-
-func TestMaxStmtCacheSize(t *testing.T) {
-	i := 94157
-	hint := MaxStmtCacheSize(i)
-	assert.Equal(t, hint.GetValue(), i)
-	assert.Equal(t, hint.GetKey(), KeyMaxStmtCacheSize)
-}
-
 func TestForceIndex(t *testing.T) {
 	s := []string{`f_index1`, `f_index2`, `f_index3`}
 	hint := ForceIndex(s...)

--- a/pkg/client/orm/models_test.go
+++ b/pkg/client/orm/models_test.go
@@ -22,8 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/astaxie/beego/pkg/client/orm/hints"
-
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
@@ -529,7 +527,7 @@ func init() {
 		os.Exit(2)
 	}
 
-	err := RegisterDataBase("default", DBARGS.Driver, DBARGS.Source, hints.MaxIdleConnections(20))
+	err := RegisterDataBase("default", DBARGS.Driver, DBARGS.Source, MaxIdleConnections(20))
 
 	if err != nil {
 		panic(fmt.Sprintf("can not register database: %v", err))

--- a/pkg/client/orm/orm.go
+++ b/pkg/client/orm/orm.go
@@ -601,7 +601,7 @@ func NewOrmUsingDB(aliasName string) Ormer {
 }
 
 // NewOrmWithDB create a new ormer object with specify *sql.DB for query
-func NewOrmWithDB(driverName, aliasName string, db *sql.DB, params ...utils.KV) (Ormer, error) {
+func NewOrmWithDB(driverName, aliasName string, db *sql.DB, params ...DBOption) (Ormer, error) {
 	al, err := newAliasWithDb(aliasName, driverName, db, params...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In my original design, `hints` were used to pass some information when we query DB. It's not a good practice to use it as the parameter to create DB. So I add `DBOption` to replace `hints`. I will keep `hints` because I think we should support pass `hints` by using `context.Context`.

For example, if I want to invoke `orm.Read` method and I want to use `xxxIndex`, I can pass `ForceIndex` hint.