### PR TITLE
session: adds CookieSameSite to ManagerConfig

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,13 +15,14 @@
 package beego
 
 import (
+	"crypto/tls"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
 	"strings"
-	"crypto/tls"
 
 	"github.com/astaxie/beego/config"
 	"github.com/astaxie/beego/context"
@@ -108,6 +109,7 @@ type SessionConfig struct {
 	SessionEnableSidInHTTPHeader bool // enable store/get the sessionId into/from http headers
 	SessionNameInHTTPHeader      string
 	SessionEnableSidInURLQuery   bool // enable get the sessionId from Url Query params
+	SessionCookieSameSite        http.SameSite
 }
 
 // LogConfig holds Log related config
@@ -153,7 +155,7 @@ func init() {
 	}
 	appConfigPath = filepath.Join(WorkPath, "conf", filename)
 	if configPath := os.Getenv("BEEGO_CONFIG_PATH"); configPath != "" {
-		appConfigPath =  configPath
+		appConfigPath = configPath
 	}
 	if !utils.FileExists(appConfigPath) {
 		appConfigPath = filepath.Join(AppPath, "conf", filename)
@@ -267,6 +269,7 @@ func newBConfig() *Config {
 				SessionEnableSidInHTTPHeader: false, // enable store/get the sessionId into/from http headers
 				SessionNameInHTTPHeader:      "Beegosessionid",
 				SessionEnableSidInURLQuery:   false, // enable get the sessionId from Url Query params
+				SessionCookieSameSite:        http.SameSiteDefaultMode,
 			},
 		},
 		Log: LogConfig{

--- a/hooks.go
+++ b/hooks.go
@@ -61,6 +61,7 @@ func registerSession() error {
 			conf.EnableSidInHTTPHeader = BConfig.WebConfig.Session.SessionEnableSidInHTTPHeader
 			conf.SessionNameInHTTPHeader = BConfig.WebConfig.Session.SessionNameInHTTPHeader
 			conf.EnableSidInURLQuery = BConfig.WebConfig.Session.SessionEnableSidInURLQuery
+			conf.CookieSameSite = BConfig.WebConfig.Session.SessionCookieSameSite
 		} else {
 			if err = json.Unmarshal([]byte(sessionConfig), conf); err != nil {
 				return err

--- a/session/session.go
+++ b/session/session.go
@@ -92,20 +92,21 @@ func GetProvider(name string) (Provider, error) {
 
 // ManagerConfig define the session config
 type ManagerConfig struct {
-	CookieName              string `json:"cookieName"`
-	EnableSetCookie         bool   `json:"enableSetCookie,omitempty"`
-	Gclifetime              int64  `json:"gclifetime"`
-	Maxlifetime             int64  `json:"maxLifetime"`
-	DisableHTTPOnly         bool   `json:"disableHTTPOnly"`
-	Secure                  bool   `json:"secure"`
-	CookieLifeTime          int    `json:"cookieLifeTime"`
-	ProviderConfig          string `json:"providerConfig"`
-	Domain                  string `json:"domain"`
-	SessionIDLength         int64  `json:"sessionIDLength"`
-	EnableSidInHTTPHeader   bool   `json:"EnableSidInHTTPHeader"`
-	SessionNameInHTTPHeader string `json:"SessionNameInHTTPHeader"`
-	EnableSidInURLQuery     bool   `json:"EnableSidInURLQuery"`
-	SessionIDPrefix         string `json:"sessionIDPrefix"`
+	CookieName              string        `json:"cookieName"`
+	EnableSetCookie         bool          `json:"enableSetCookie,omitempty"`
+	Gclifetime              int64         `json:"gclifetime"`
+	Maxlifetime             int64         `json:"maxLifetime"`
+	DisableHTTPOnly         bool          `json:"disableHTTPOnly"`
+	Secure                  bool          `json:"secure"`
+	CookieLifeTime          int           `json:"cookieLifeTime"`
+	ProviderConfig          string        `json:"providerConfig"`
+	Domain                  string        `json:"domain"`
+	SessionIDLength         int64         `json:"sessionIDLength"`
+	EnableSidInHTTPHeader   bool          `json:"EnableSidInHTTPHeader"`
+	SessionNameInHTTPHeader string        `json:"SessionNameInHTTPHeader"`
+	EnableSidInURLQuery     bool          `json:"EnableSidInURLQuery"`
+	SessionIDPrefix         string        `json:"sessionIDPrefix"`
+	CookieSameSite          http.SameSite `json:"cookieSameSite"`
 }
 
 // Manager contains Provider and its configuration.
@@ -232,6 +233,7 @@ func (manager *Manager) SessionStart(w http.ResponseWriter, r *http.Request) (se
 		HttpOnly: !manager.config.DisableHTTPOnly,
 		Secure:   manager.isSecure(r),
 		Domain:   manager.config.Domain,
+		SameSite: manager.config.CookieSameSite,
 	}
 	if manager.config.CookieLifeTime > 0 {
 		cookie.MaxAge = manager.config.CookieLifeTime
@@ -271,7 +273,9 @@ func (manager *Manager) SessionDestroy(w http.ResponseWriter, r *http.Request) {
 			HttpOnly: !manager.config.DisableHTTPOnly,
 			Expires:  expiration,
 			MaxAge:   -1,
-			Domain:   manager.config.Domain}
+			Domain:   manager.config.Domain,
+			SameSite: manager.config.CookieSameSite,
+		}
 
 		http.SetCookie(w, cookie)
 	}
@@ -306,6 +310,7 @@ func (manager *Manager) SessionRegenerateID(w http.ResponseWriter, r *http.Reque
 			HttpOnly: !manager.config.DisableHTTPOnly,
 			Secure:   manager.isSecure(r),
 			Domain:   manager.config.Domain,
+			SameSite: manager.config.CookieSameSite,
 		}
 	} else {
 		oldsid, _ := url.QueryUnescape(cookie.Value)


### PR DESCRIPTION
Cookie SameSite attribute has become an important part to secure user information. Browsers are requiring SameSite to include cookies in more complex calls. For example, we have issues to receive the session ID cookie for requests coming from OAuth POST callbacks.

Close #3578 

Reference:
https://web.dev/samesite-cookies-explained/
https://www.chromium.org/updates/same-site