### PR TITLE
decouple httplib module from web module and config module

### DIFF
--- a/pkg/client/httplib/filter/prometheus/filter.go
+++ b/pkg/client/httplib/filter/prometheus/filter.go
@@ -23,11 +23,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/astaxie/beego/pkg/client/httplib"
-	"github.com/astaxie/beego/pkg/server/web"
 )
 
 type FilterChainBuilder struct {
 	summaryVec prometheus.ObserverVec
+	AppName    string
+	ServerName string
+	RunMode    string
 }
 
 func (builder *FilterChainBuilder) FilterChain(next httplib.Filter) httplib.Filter {
@@ -36,9 +38,9 @@ func (builder *FilterChainBuilder) FilterChain(next httplib.Filter) httplib.Filt
 		Name:      "beego",
 		Subsystem: "remote_http_request",
 		ConstLabels: map[string]string{
-			"server":  web.BConfig.ServerName,
-			"env":     web.BConfig.RunMode,
-			"appname": web.BConfig.AppName,
+			"server":  builder.ServerName,
+			"env":     builder.RunMode,
+			"appname": builder.AppName,
 		},
 		Help: "The statics info for remote http requests",
 	}, []string{"proto", "scheme", "method", "host", "path", "status", "duration", "isError"})

--- a/pkg/client/httplib/testing/client.go
+++ b/pkg/client/httplib/testing/client.go
@@ -16,8 +16,6 @@ package testing
 
 import (
 	"github.com/astaxie/beego/pkg/client/httplib"
-
-	"github.com/astaxie/beego/pkg/infrastructure/config"
 )
 
 var port = ""
@@ -28,16 +26,13 @@ type TestHTTPRequest struct {
 	httplib.BeegoHTTPRequest
 }
 
+func SetTestingPort(p string) {
+	port = p
+}
+
 func getPort() string {
 	if port == "" {
-		config, err := config.NewConfig("ini", "../conf/app.conf")
-		if err != nil {
-			return "8080"
-		}
-		port, err = config.String(nil, "httpport")
-		if err != nil {
-			return "8080"
-		}
+		port = "8080"
 		return port
 	}
 	return port


### PR DESCRIPTION
httplib should be a simple and light module. It should not depend on web module.

And, we can pass `Port` when users want to use `httplib.testing`.

I think reading config in tests is not convenient.

For now, if you want to use  `httplib.testing` and you don't want to use port "8080",

please using `SetTestingPort`