### PR TITLE
testing: fix temporary create failed on Windows

### DIFF
--- a/controller_test.go
+++ b/controller_test.go
@@ -125,8 +125,8 @@ func TestGetUint64(t *testing.T) {
 }
 
 func TestAdditionalViewPaths(t *testing.T) {
-	dir1 := "_beeTmp"
-	dir2 := "_beeTmp2"
+	dir1 := tmpDir("TestAdditionalViewPaths1")
+	dir2 := tmpDir("TestAdditionalViewPaths2")
 	defer os.RemoveAll(dir1)
 	defer os.RemoveAll(dir2)
 

--- a/template_test.go
+++ b/template_test.go
@@ -45,8 +45,12 @@ var block = `{{define "block"}}
 <h1>Hello, blocks!</h1>
 {{end}}`
 
+func tmpDir(s string) string {
+	return filepath.Join(os.TempDir(), s)
+}
+
 func TestTemplate(t *testing.T) {
-	dir := "_beeTmp"
+	dir := tmpDir("TestTemplate")
 	files := []string{
 		"header.tpl",
 		"index.tpl",
@@ -107,7 +111,7 @@ var user = `<!DOCTYPE html>
 `
 
 func TestRelativeTemplate(t *testing.T) {
-	dir := "_beeTmp"
+	dir := tmpDir("TestRelativeTemplate")
 
 	//Just add dir to known viewPaths
 	if err := AddViewPath(dir); err != nil {
@@ -218,7 +222,7 @@ var output = `<!DOCTYPE html>
 `
 
 func TestTemplateLayout(t *testing.T) {
-	dir := "_beeTmp"
+	dir := tmpDir("TestTemplateLayout")
 	files := []string{
 		"add.tpl",
 		"layout_blog.tpl",


### PR DESCRIPTION
We are creating temporary files on the root directory of beego now
This PR using system temporary directory for testing.

Fixes #4243