### PR TITLE
Reset func call depth & add adapter.sh

### DIFF
--- a/pkg/adapter/logs/log.go
+++ b/pkg/adapter/logs/log.go
@@ -86,9 +86,6 @@ type Logger interface {
 	Flush()
 }
 
-var adapters = make(map[string]newLoggerFunc)
-var levelPrefix = [LevelDebug + 1]string{"[M]", "[A]", "[C]", "[E]", "[W]", "[N]", "[I]", "[D]"}
-
 // Register makes a log provide available by the provided name.
 // If Register is called twice with the same name or if driver is nil,
 // it panics.
@@ -343,4 +340,8 @@ func Debug(f interface{}, v ...interface{}) {
 // compatibility alias for Warning()
 func Trace(f interface{}, v ...interface{}) {
 	logs.Trace(f, v...)
+}
+
+func init() {
+	SetLogFuncCallDepth(4)
 }

--- a/pkg/core/logs/log.go
+++ b/pkg/core/logs/log.go
@@ -142,7 +142,7 @@ var logMsgPool *sync.Pool
 func NewLogger(channelLens ...int64) *BeeLogger {
 	bl := new(BeeLogger)
 	bl.level = LevelDebug
-	bl.loggerFuncCallDepth = 2
+	bl.loggerFuncCallDepth = 3
 	bl.msgChanLen = append(channelLens, 0)[0]
 	if bl.msgChanLen <= 0 {
 		bl.msgChanLen = defaultAsyncMsgLen

--- a/scripts/adapter.sh
+++ b/scripts/adapter.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# using pkg/adapter. Usually you want to migrate to V2 smoothly, you could running this script
+
+find ./ -name '*.go' -type f -exec sed -i '' -e 's/github.com\/astaxie\/beego/github.com\/astaxie\/beego\/pkg\/adapter/g' {} \;
+find ./ -name '*.go' -type f -exec sed -i '' -e 's/"github.com\/astaxie\/beego\/pkg\/adapter"/beego "github.com\/astaxie\/beego\/pkg\/adapter"/g' {} \;


### PR DESCRIPTION
1. Reset func call depth. 3 for core/logs and 4 for adapter/logs
2. Add `adapter.sh` used to migrate from v1 to v2 smoothly.