### PR TITLE
Add MaxFileSize configuration

### DIFF
--- a/config.go
+++ b/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	CopyRequestBody     bool
 	EnableGzip          bool
 	MaxMemory           int64
+	MaxFileSize         int64
 	EnableErrorsShow    bool
 	EnableErrorsRender  bool
 	Listen              Listen
@@ -216,6 +217,7 @@ func newBConfig() *Config {
 		CopyRequestBody:     false,
 		EnableGzip:          false,
 		MaxMemory:           1 << 26, //64MB
+		MaxFileSize:         1 << 27, //128MB
 		EnableErrorsShow:    true,
 		EnableErrorsRender:  true,
 		Listen: Listen{

--- a/config_test.go
+++ b/config_test.go
@@ -68,6 +68,7 @@ func TestAssignConfig_02(t *testing.T) {
 		}
 	}
 	configMap["MaxMemory"] = 1024
+	configMap["MaxFileSize"] = 1025
 	configMap["Graceful"] = true
 	configMap["XSRFExpire"] = 32
 	configMap["SessionProviderConfig"] = "file"
@@ -83,6 +84,11 @@ func TestAssignConfig_02(t *testing.T) {
 
 	if _BConfig.MaxMemory != 1024 {
 		t.Log(_BConfig.MaxMemory)
+		t.FailNow()
+	}
+
+	if _BConfig.MaxFileSize != 1025 {
+		t.Log(_BConfig.MaxFileSize)
 		t.FailNow()
 	}
 

--- a/router.go
+++ b/router.go
@@ -750,6 +750,12 @@ func (p *ControllerRegister) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 			}
 			context.Input.CopyBody(BConfig.MaxMemory)
 		}
+
+		if r.ContentLength > BConfig.MaxFileSize {
+			logs.Error(errors.New("payload too large"))
+			exception("413", context)
+			goto Admin
+		}
 		context.Input.ParseFormOrMulitForm(BConfig.MaxMemory)
 	}
 


### PR DESCRIPTION
The Go stdlib multipart has no limitation while parsing multipart file.

Fix #4224