### PR TITLE
Fix 4138

### DIFF
--- a/core/logs/slack.go
+++ b/core/logs/slack.go
@@ -1,10 +1,10 @@
 package logs
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 
 	"github.com/pkg/errors"
 )
@@ -25,8 +25,8 @@ func newSLACKWriter() Logger {
 }
 
 func (s *SLACKWriter) Format(lm *LogMsg) string {
-	text := fmt.Sprintf("{\"text\": \"%s %s\"}", lm.When.Format("2006-01-02 15:04:05"), lm.OldStyleFormat())
-	return text
+	// text := fmt.Sprintf("{\"text\": \"%s\"}", msg)
+	return lm.When.Format("2006-01-02 15:04:05") + " " + lm.OldStyleFormat()
 }
 
 func (s *SLACKWriter) SetFormatter(f LogFormatter) {
@@ -55,10 +55,12 @@ func (s *SLACKWriter) WriteMsg(lm *LogMsg) error {
 		return nil
 	}
 	msg := s.Format(lm)
-	form := url.Values{}
-	form.Add("payload", msg)
+	m := make(map[string]string, 1)
+	m["text"] = msg
 
-	resp, err := http.PostForm(s.WebhookURL, form)
+	body, _ := json.Marshal(m)
+	// resp, err := http.PostForm(s.WebhookURL, form)
+	resp, err := http.Post(s.WebhookURL, "application/json", bytes.NewReader(body))
 	if err != nil {
 		return err
 	}

--- a/core/logs/slack_test.go
+++ b/core/logs/slack_test.go
@@ -1,0 +1,44 @@
+// Copyright 2020
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logs
+
+// func TestSLACKWriter_WriteMsg(t *testing.T) {
+// 	sc := `
+// {
+//   "webhookurl":"",
+//   "level":7
+// }
+// `
+// 	l := newSLACKWriter()
+// 	err := l.Init(sc)
+// 	if err != nil {
+// 		Debug(err)
+// 	}
+//
+// 	err = l.WriteMsg(&LogMsg{
+// 		Level: 7,
+// 		Msg: `{ "abs"`,
+// 		When: time.Now(),
+// 		FilePath: "main.go",
+// 		LineNumber: 100,
+// 		enableFullFilePath: true,
+// 		enableFuncCallDepth: true,
+// 	})
+//
+// 	if err != nil {
+// 		Debug(err)
+// 	}
+//
+// }


### PR DESCRIPTION
The test was commented because the webhook can not be exposed. And if you want to test slack, just put the webhoot into test codes.