### PR TITLE
fix issue #3430: reverse sequence of generating leaves of router prefix tree

### DIFF
--- a/server/web/tree.go
+++ b/server/web/tree.go
@@ -210,9 +210,9 @@ func (t *Tree) AddRouter(pattern string, runObject interface{}) {
 func (t *Tree) addseg(segments []string, route interface{}, wildcards []string, reg string) {
 	if len(segments) == 0 {
 		if reg != "" {
-			t.leaves = append(t.leaves, &leafInfo{runObject: route, wildcards: wildcards, regexps: regexp.MustCompile("^" + reg + "$")})
+			t.leaves = append([]*leafInfo{{runObject: route, wildcards: wildcards, regexps: regexp.MustCompile("^" + reg + "$")}}, t.leaves...)
 		} else {
-			t.leaves = append(t.leaves, &leafInfo{runObject: route, wildcards: wildcards})
+			t.leaves = append([]*leafInfo{{runObject: route, wildcards: wildcards}}, t.leaves...)
 		}
 	} else {
 		seg := segments[0]

--- a/server/web/tree_test.go
+++ b/server/web/tree_test.go
@@ -74,6 +74,17 @@ func init() {
 	routers = append(routers, testinfo{"/v1/:v(.+)_cms/ttt_:id(.+)_:page(.+).html", "/v1/2_cms/ttt_123_1.html", map[string]string{":v": "2", ":id": "123", ":page": "1"}})
 	routers = append(routers, testinfo{"/api/projects/:pid/members/?:mid", "/api/projects/1/members", map[string]string{":pid": "1"}})
 	routers = append(routers, testinfo{"/api/projects/:pid/members/?:mid", "/api/projects/1/members/2", map[string]string{":pid": "1", ":mid": "2"}})
+	routers = append(routers, testinfo{"/?:year/?:month/?:day", "/2020/11/10", map[string]string{":year": "2020", ":month": "11", ":day": "10"}})
+	routers = append(routers, testinfo{"/?:year/?:month/?:day", "/2020/11", map[string]string{":year": "2020", ":month": "11"}})
+	routers = append(routers, testinfo{"/?:year", "/2020", map[string]string{":year": "2020"}})
+	routers = append(routers, testinfo{"/?:year([0-9]+)/?:month([0-9]+)/mid/?:day([0-9]+)/?:hour([0-9]+)", "/2020/11/mid/10/24", map[string]string{":year": "2020", ":month": "11", ":day": "10", ":hour": "24"}})
+	routers = append(routers, testinfo{"/?:year/?:month/mid/?:day/?:hour", "/2020/mid/10", map[string]string{":year": "2020", ":day": "10"}})
+	routers = append(routers, testinfo{"/?:year/?:month/mid/?:day/?:hour", "/2020/11/mid", map[string]string{":year": "2020", ":month": "11"}})
+	routers = append(routers, testinfo{"/?:year/?:month/mid/?:day/?:hour", "/mid/10/24", map[string]string{":day": "10", ":hour": "24"}})
+	routers = append(routers, testinfo{"/?:year([0-9]+)/:month([0-9]+)/mid/:day([0-9]+)/?:hour([0-9]+)", "/2020/11/mid/10/24", map[string]string{":year": "2020", ":month": "11", ":day": "10", ":hour": "24"}})
+	routers = append(routers, testinfo{"/?:year/:month/mid/:day/?:hour", "/11/mid/10/24", map[string]string{":month": "11", ":day": "10"}})
+	routers = append(routers, testinfo{"/?:year/:month/mid/:day/?:hour", "/2020/11/mid/10", map[string]string{":year": "2020", ":month": "11", ":day": "10"}})
+	routers = append(routers, testinfo{"/?:year/:month/mid/:day/?:hour", "/11/mid/10", map[string]string{":month": "11", ":day": "10"}})
 }
 
 func TestTreeRouters(t *testing.T) {

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -50,6 +50,7 @@ func TestModifyTaskListAfterRunning(t *testing.T) {
 		return nil
 	})
 	err := tk.Run(nil)
+
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
fix issue #3430 

```go
// tree.go
// ...
		if len(params) > 0 && params[0] == ":" {
			t.addseg(segments[1:], route, wildcards, reg)
			params = params[1:]
		}
// ...
```
The recursive call of addseg here make the `t.leaves` is rightmost match when append slice `t.leaves` sequentially.
To make the `t.leaves` is leftmost match, this PR modify the append sequence of `t.leaves`.

In addition, test cases for verifying the leftmost matching of regular routes are provided in this PR.